### PR TITLE
REF-03 follow-up: align TurnComplete contract and reuse test stubs

### DIFF
--- a/src/state/conversation.rs
+++ b/src/state/conversation.rs
@@ -33,6 +33,18 @@ pub struct ToolApprovalRequest {
     pub response_tx: oneshot::Sender<bool>,
 }
 
+#[cfg(test)]
+impl ToolApprovalRequest {
+    pub fn test_stub() -> Self {
+        let (response_tx, _response_rx) = oneshot::channel::<bool>();
+        Self {
+            tool_name: "read_file".to_string(),
+            input_preview: "{}".to_string(),
+            response_tx,
+        }
+    }
+}
+
 const LOCAL_DEFAULT_MAX_ASSISTANT_HISTORY_CHARS: usize = 1_200;
 const LOCAL_DEFAULT_MAX_TOOL_RESULT_HISTORY_CHARS: usize = 2_500;
 const LOCAL_DEFAULT_MAX_API_MESSAGES: usize = 14;


### PR DESCRIPTION
## Motivation

**Repo:** `aistar-au/vexcoder`

This PR aligns `TurnComplete` with the REF-03 unit-event contract and consolidates runtime-seam test helpers. It adds 142 lines and removes 24 lines across 2 files to keep the turn-complete event shape and test scaffolding consistent.

### Why

Why: the runtime, app, and supporting tests on this branch need to move together so the runtime contract stays consistent across the code paths touched here.

### Files changed

- `src/app/mod.rs` (+130 -24)
- `src/state/conversation.rs` (+12 -0)

### References

- [ADR-006 Runtime mode contracts](https://github.com/aistar-au/vexcoder/blob/main/docs/adr/completed/ADR-006-runtime-mode-contracts.md)