### PR TITLE
REF-02: convert runtime to module and add runtime contract stubs (align to spec)

### DIFF
--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -1,0 +1,17 @@
+use crate::state::ConversationManager;
+
+pub struct RuntimeContext<'a> {
+    pub conversation: &'a mut ConversationManager,
+}
+
+impl<'a> RuntimeContext<'a> {
+    /// Begin a new conversation turn. Wired in REF-04; currently a no-op stub.
+    pub fn start_turn(&mut self, _input: String) {
+        // wired in REF-04
+    }
+
+    /// Cancel the active turn. Wired in REF-04; currently a no-op stub.
+    pub fn cancel_turn(&mut self) {
+        // wired in REF-04
+    }
+}

--- a/src/runtime/event.rs
+++ b/src/runtime/event.rs
@@ -1,0 +1,13 @@
+use crate::state::ToolApprovalRequest;
+
+/// Internal routing events for the runtime loop.
+///
+/// Distinct from `UiUpdate` which flows to modes.
+/// Reserved for future multi-mode dispatch (REF-06+); stub for now.
+pub enum RuntimeEvent {
+    TurnStarted { id: u64 },
+    StreamDelta { text: String },
+    ToolApprovalRequest(ToolApprovalRequest),
+    TurnComplete,
+    Error(String),
+}

--- a/src/runtime/frontend.rs
+++ b/src/runtime/frontend.rs
@@ -1,0 +1,7 @@
+use super::mode::RuntimeMode;
+
+pub trait FrontendAdapter {
+    fn poll_user_input(&mut self) -> Option<String>;
+    fn render<M: RuntimeMode>(&mut self, mode: &M);
+    fn should_quit(&self) -> bool;
+}

--- a/src/runtime/loop.rs
+++ b/src/runtime/loop.rs
@@ -1,0 +1,16 @@
+use crate::runtime::UiUpdate;
+use tokio::sync::mpsc;
+
+use super::{context::RuntimeContext, frontend::FrontendAdapter, mode::RuntimeMode};
+
+pub struct Runtime<M: RuntimeMode> {
+    pub mode: M,
+    update_rx: mpsc::UnboundedReceiver<UiUpdate>,
+}
+
+impl<M: RuntimeMode> Runtime<M> {
+    pub fn new(mode: M, update_rx: mpsc::UnboundedReceiver<UiUpdate>) -> Self {
+        Self { mode, update_rx }
+    }
+    // run() wired in REF-05
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,3 +1,12 @@
+pub mod context;
+pub mod event;
+pub mod frontend;
+pub mod r#loop;
+pub mod mode;
+pub mod update;
+
+pub use update::UiUpdate;
+
 pub fn parse_bool_flag(value: String) -> Option<bool> {
     parse_bool_str(value.as_str())
 }
@@ -31,6 +40,20 @@ mod tests {
         assert_eq!(parse_bool_flag("YES".to_string()), Some(true));
         assert_eq!(parse_bool_flag("off".to_string()), Some(false));
         assert_eq!(parse_bool_str("maybe"), None);
+    }
+
+    #[test]
+    fn test_ref_02_runtime_types_compile() {
+        use crate::runtime::{
+            context::RuntimeContext,
+            event::RuntimeEvent,
+            frontend::FrontendAdapter,
+            mode::RuntimeMode,
+            UiUpdate,
+        };
+        // Zero-cost existence check — if the module tree compiles, this passes.
+        let _ = std::mem::size_of::<RuntimeEvent>();
+        let _ = std::mem::size_of::<UiUpdate>();
     }
 
     #[test]

--- a/src/runtime/mode.rs
+++ b/src/runtime/mode.rs
@@ -1,0 +1,9 @@
+use crate::runtime::UiUpdate;
+
+use super::context::RuntimeContext;
+
+pub trait RuntimeMode {
+    fn on_user_input(&mut self, input: String, ctx: &mut RuntimeContext);
+    fn on_model_update(&mut self, update: UiUpdate, ctx: &mut RuntimeContext);
+    fn is_turn_in_progress(&self) -> bool;
+}

--- a/src/runtime/update.rs
+++ b/src/runtime/update.rs
@@ -1,0 +1,16 @@
+use crate::state::{StreamBlock, ToolApprovalRequest};
+
+/// Events flowing from the model/tool layer up to the UI layer.
+///
+/// Defined in `runtime` (not `app`) so runtime types can reference it
+/// without depending on the UI layer. `src/app/mod.rs` imports this as
+/// `use crate::runtime::UiUpdate`.
+pub enum UiUpdate {
+    StreamDelta(String),
+    StreamBlockStart { index: usize, block: StreamBlock },
+    StreamBlockDelta { index: usize, delta: String },
+    StreamBlockComplete { index: usize },
+    ToolApprovalRequest(ToolApprovalRequest),
+    TurnComplete,
+    Error(String),
+}


### PR DESCRIPTION
## Motivation

**Repo:** `aistar-au/vexcoder`

This PR converts the flat runtime file into a module tree and adds the first compile-time runtime contract stubs. It adds 101 lines and removes 0 lines across 7 files to define the runtime module boundaries before implementation work begins.

### Why

Why: the runtime, app, and supporting tests on this branch need to move together so the runtime contract stays consistent across the code paths touched here.

### Files changed

- `src/runtime/context.rs` (+17 -0)
- `src/runtime/event.rs` (+13 -0)
- `src/runtime/frontend.rs` (+7 -0)
- `src/runtime/loop.rs` (+16 -0)
- `src/runtime/mod.rs` (+23 -0)
- `src/runtime/mode.rs` (+9 -0)
- `src/runtime/update.rs` (+16 -0)

### References

- [ADR-004 Runtime seam refactor - headless-first architecture](https://github.com/aistar-au/vexcoder/blob/main/docs/adr/completed/ADR-004-runtime-seam-headless-first.md)
- [ADR-006 Runtime mode contracts](https://github.com/aistar-au/vexcoder/blob/main/docs/adr/completed/ADR-006-runtime-mode-contracts.md)