### PR TITLE
Fix REF-02/03: move UiUpdate into runtime module and fix runtime wiring

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3,6 +3,7 @@ use crate::edit_diff::{format_edit_hunks, DEFAULT_EDIT_DIFF_CONTEXT_LINES};
 use crate::runtime::context::RuntimeContext;
 use crate::runtime::mode::RuntimeMode;
 use crate::runtime::parse_bool_flag;
+use crate::runtime::UiUpdate;
 use crate::state::{
     ConversationManager, ConversationStreamUpdate, StreamBlock, ToolApprovalRequest, ToolStatus,
 };
@@ -41,16 +42,6 @@ const TUI_TICK_INTERVAL: Duration = Duration::from_millis(120);
 const REPO_WIDGET_REFRESH_INTERVAL: Duration = Duration::from_millis(1500);
 const MULTILINE_PROMPT_START: &str = "/paste";
 const MULTILINE_PROMPT_END: &str = "/send";
-
-pub enum UiUpdate {
-    StreamDelta(String),
-    StreamBlockStart { index: usize, block: StreamBlock },
-    StreamBlockDelta { index: usize, delta: String },
-    StreamBlockComplete { index: usize },
-    ToolApprovalRequest(ToolApprovalRequest),
-    TurnComplete,
-    Error(String),
-}
 
 struct HistoryState {
     messages: Vec<String>,

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -1,13 +1,11 @@
-use crate::app::UiUpdate;
 use crate::state::ConversationManager;
-use tokio::sync::mpsc;
 
 pub struct RuntimeContext<'a> {
     pub conversation: &'a mut ConversationManager,
 }
 
 impl<'a> RuntimeContext<'a> {
-    pub fn start_turn(&mut self, _input: String, _tx: mpsc::UnboundedSender<UiUpdate>) {
+    pub fn start_turn(&mut self, _input: String) {
         // wired in REF-04
     }
 

--- a/src/runtime/loop.rs
+++ b/src/runtime/loop.rs
@@ -1,4 +1,4 @@
-use crate::app::UiUpdate;
+use crate::runtime::UiUpdate;
 use tokio::sync::mpsc;
 
 use super::mode::RuntimeMode;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -3,6 +3,9 @@ pub mod event;
 pub mod frontend;
 pub mod r#loop;
 pub mod mode;
+pub mod update;
+
+pub use update::UiUpdate;
 
 pub fn parse_bool_flag(value: String) -> Option<bool> {
     parse_bool_str(value.as_str())
@@ -54,7 +57,7 @@ mod tests {
             fn on_user_input(&mut self, _input: String, _ctx: &mut RuntimeContext) {}
             fn on_model_update(
                 &mut self,
-                _update: crate::app::UiUpdate,
+                _update: crate::runtime::UiUpdate,
                 _ctx: &mut RuntimeContext,
             ) {
             }

--- a/src/runtime/mode.rs
+++ b/src/runtime/mode.rs
@@ -1,4 +1,4 @@
-use crate::app::UiUpdate;
+use crate::runtime::UiUpdate;
 
 use super::context::RuntimeContext;
 

--- a/src/runtime/update.rs
+++ b/src/runtime/update.rs
@@ -1,0 +1,11 @@
+use crate::state::{StreamBlock, ToolApprovalRequest};
+
+pub enum UiUpdate {
+    StreamDelta(String),
+    StreamBlockStart { index: usize, block: StreamBlock },
+    StreamBlockDelta { index: usize, delta: String },
+    StreamBlockComplete { index: usize },
+    ToolApprovalRequest(ToolApprovalRequest),
+    TurnComplete,
+    Error(String),
+}


### PR DESCRIPTION
## Motivation

**Repo:** `aistar-au/vexcoder`

This PR moves `UiUpdate` into the runtime layer and removes the duplicate app-owned definition. It adds 19 lines and removes 16 lines across 6 files to keep the runtime contract surface in one module before later dispatch work lands.

### Why

Why: the runtime, app, and supporting tests on this branch need to move together so the runtime contract stays consistent across the code paths touched here.

### Files changed

- `src/app/mod.rs` (+1 -10)
- `src/runtime/context.rs` (+1 -3)
- `src/runtime/loop.rs` (+1 -1)
- `src/runtime/mod.rs` (+4 -1)
- `src/runtime/mode.rs` (+1 -1)
- `src/runtime/update.rs` (+11 -0)

### References

- [ADR-006 Runtime mode contracts](https://github.com/aistar-au/vexcoder/blob/main/docs/adr/completed/ADR-006-runtime-mode-contracts.md)