### PR TITLE
REF-05: implement generic Runtime<M>::run loop and headless anchor test

### DIFF
--- a/src/runtime/loop.rs
+++ b/src/runtime/loop.rs
@@ -1,7 +1,7 @@
-use crate::runtime::UiUpdate;
+use crate::runtime::{frontend::FrontendAdapter, mode::RuntimeMode, UiUpdate};
 use tokio::sync::mpsc;
 
-use super::mode::RuntimeMode;
+use super::context::RuntimeContext;
 
 pub struct Runtime<M: RuntimeMode> {
     pub mode: M,
@@ -12,5 +12,85 @@ impl<M: RuntimeMode> Runtime<M> {
     pub fn new(mode: M, update_rx: mpsc::UnboundedReceiver<UiUpdate>) -> Self {
         Self { mode, update_rx }
     }
-    // run() wired in REF-05
+    pub fn run<F>(&mut self, frontend: &mut F, ctx: &mut RuntimeContext<'_>)
+    where
+        F: FrontendAdapter,
+    {
+        loop {
+            if frontend.should_quit() {
+                break;
+            }
+
+            if let Some(input) = frontend.poll_user_input() {
+                self.mode.on_user_input(input, ctx);
+            }
+
+            while let Ok(update) = self.update_rx.try_recv() {
+                self.mode.on_model_update(update, ctx);
+            }
+
+            frontend.render(&self.mode);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::{mock_client::MockApiClient, ApiClient};
+    use crate::state::ConversationManager;
+    use std::collections::{HashMap, VecDeque};
+    use std::sync::Arc;
+
+    struct HeadlessFrontend {
+        inputs: VecDeque<String>,
+        render_count: usize,
+        quit_after: usize,
+    }
+
+    impl HeadlessFrontend {
+        fn new(inputs: Vec<&str>, quit_after: usize) -> Self {
+            Self {
+                inputs: inputs.into_iter().map(|s| s.to_string()).collect(),
+                render_count: 0,
+                quit_after,
+            }
+        }
+    }
+
+    impl FrontendAdapter for HeadlessFrontend {
+        fn poll_user_input(&mut self) -> Option<String> {
+            self.inputs.pop_front()
+        }
+
+        fn render<N: RuntimeMode>(&mut self, _mode: &N) {
+            self.render_count += 1;
+        }
+
+        fn should_quit(&self) -> bool {
+            self.render_count >= self.quit_after
+        }
+    }
+
+    #[test]
+    fn test_ref_05_headless_loop_terminates() {
+        let mock = Arc::new(MockApiClient::new(vec![]));
+        let client = ApiClient::new_mock(mock);
+        let mut conversation = ConversationManager::new_mock(client, HashMap::new());
+        let mut ctx = RuntimeContext {
+            conversation: &mut conversation,
+        };
+
+        let (_tx, update_rx) = mpsc::unbounded_channel::<UiUpdate>();
+        let mode = crate::app::TuiMode::new();
+        let mut runtime = Runtime::new(mode, update_rx);
+
+        let mut frontend = HeadlessFrontend::new(vec!["hello", "world"], 3);
+        runtime.run(&mut frontend, &mut ctx);
+
+        assert_eq!(
+            frontend.render_count, 3,
+            "loop must render exactly quit_after times before exiting"
+        );
+    }
 }


### PR DESCRIPTION
## Motivation

**Repo:** `aistar-au/vexcoder`

This PR implements the generic `Runtime<M>::run` loop and the headless anchor test required by the REF track. It adds 83 lines and removes 3 lines across 1 file to replace the run stub with a frontend-agnostic event loop.

### Why

Why: the runtime, app, and supporting tests on this branch need to move together so the runtime contract stays consistent across the code paths touched here.

### Files changed

- `src/runtime/loop.rs` (+83 -3)

### References

- [ADR-004 Runtime seam refactor - headless-first architecture](https://github.com/aistar-au/vexcoder/blob/main/docs/adr/completed/ADR-004-runtime-seam-headless-first.md)
- [ADR-006 Runtime mode contracts](https://github.com/aistar-au/vexcoder/blob/main/docs/adr/completed/ADR-006-runtime-mode-contracts.md)