### PR TITLE
REF-04-pre: finalize dispatch prep surface updates

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -93,6 +93,7 @@ impl ApiClient {
         messages: &[ApiMessage],
         token: tokio_util::sync::CancellationToken,
     ) -> Result<ByteStream> {
+        // TODO(REF-04): wire cancellation into stream request lifecycle.
         let _ = token;
         self.create_stream(messages).await
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -92,6 +92,12 @@ impl TuiMode {
     }
 }
 
+impl Default for TuiMode {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl RuntimeMode for TuiMode {
     fn on_user_input(&mut self, input: String, ctx: &mut RuntimeContext) {
         if self.overlay.is_some() {

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -61,7 +61,9 @@ mod tests {
     #[ignore = "REF-04 Track A pending: start_turn dispatch not wired yet"]
     fn test_ref_04_start_turn_dispatches() {
         let mut conversation = make_conversation();
-        let mut ctx = RuntimeContext { conversation: &mut conversation };
+        let mut ctx = RuntimeContext {
+            conversation: &mut conversation,
+        };
         ctx.start_turn("hello".to_string());
         // Replace with real assertions once wired:
         //   assert!(matches!(update_rx.try_recv().unwrap(), UiUpdate::TurnComplete));
@@ -73,7 +75,9 @@ mod tests {
     #[test]
     fn test_ref_04_runtime_context_constructs() {
         let mut conversation = make_conversation();
-        let mut ctx = RuntimeContext { conversation: &mut conversation };
+        let mut ctx = RuntimeContext {
+            conversation: &mut conversation,
+        };
         // start_turn is a no-op stub (REF-04 gap). Calling it must not panic.
         ctx.start_turn("probe".to_string());
     }

--- a/src/tool_preview.rs
+++ b/src/tool_preview.rs
@@ -348,10 +348,7 @@ mod tests {
         let after_change_repeat = cache.summarize("a.rs", "abcd");
         assert_eq!(
             after_change_repeat,
-            ReadFileSnapshotSummary::Unchanged {
-                chars: 4,
-                lines: 1
-            }
+            ReadFileSnapshotSummary::Unchanged { chars: 4, lines: 1 }
         );
     }
 


### PR DESCRIPTION
## Motivation

**Repo:** `aistar-au/vexcoder`

This PR finalizes the REF-04-pre dispatch-preparation surface without changing runtime behavior. It adds 14 lines and removes 6 lines across 4 files to stabilize the cancellation-aware stream signature and related constructor cleanup before the real dispatch wiring lands.

### Why

Why: the runtime, app, and supporting tests on this branch need to move together so the runtime contract stays consistent across the code paths touched here.

### Files changed

- `src/api/client.rs` (+1 -0)
- `src/app/mod.rs` (+6 -0)
- `src/runtime/context.rs` (+6 -2)
- `src/tool_preview.rs` (+1 -4)

### References

- [ADR-006 Runtime mode contracts](https://github.com/aistar-au/vexcoder/blob/main/docs/adr/completed/ADR-006-runtime-mode-contracts.md)