### PR TITLE
REF-04: wire RuntimeContext::start_turn to dispatch with owned context

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -108,8 +108,7 @@ impl RuntimeMode for TuiMode {
         }
 
         self.turn_in_progress = true;
-        let _ = input;
-        let _ = ctx;
+        ctx.start_turn(input);
     }
 
     fn on_model_update(&mut self, update: UiUpdate, _ctx: &mut RuntimeContext) {
@@ -3468,8 +3467,13 @@ mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    fn dummy_ctx<'a>(conversation: &'a mut ConversationManager) -> RuntimeContext<'a> {
-        RuntimeContext { conversation }
+    fn dummy_ctx(conversation: ConversationManager) -> RuntimeContext {
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        RuntimeContext::new(
+            conversation,
+            tx,
+            tokio_util::sync::CancellationToken::new(),
+        )
     }
 
     #[tokio::test]
@@ -4022,16 +4026,16 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_ref_03_tui_mode_overlay_blocks_input() {
+    #[tokio::test]
+    async fn test_ref_03_tui_mode_overlay_blocks_input() {
         use crate::api::{mock_client::MockApiClient, ApiClient};
         use crate::runtime::mode::RuntimeMode;
         use std::collections::HashMap;
         use std::sync::Arc;
 
         let mock_api_client = ApiClient::new_mock(Arc::new(MockApiClient::new(vec![])));
-        let mut conversation = ConversationManager::new_mock(mock_api_client, HashMap::new());
-        let mut ctx = dummy_ctx(&mut conversation);
+        let conversation = ConversationManager::new_mock(mock_api_client, HashMap::new());
+        let mut ctx = dummy_ctx(conversation);
 
         let mut mode = TuiMode::new();
         assert!(!mode.is_turn_in_progress());

--- a/src/runtime/loop.rs
+++ b/src/runtime/loop.rs
@@ -13,7 +13,7 @@ impl<M: RuntimeMode> Runtime<M> {
     pub fn new(mode: M, update_rx: mpsc::UnboundedReceiver<UiUpdate>) -> Self {
         Self { mode, update_rx }
     }
-    pub fn run<F>(&mut self, frontend: &mut F, ctx: &mut RuntimeContext<'_>)
+    pub fn run<F>(&mut self, frontend: &mut F, ctx: &mut RuntimeContext)
     where
         F: FrontendAdapter,
     {
@@ -73,16 +73,19 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_ref_05_headless_loop_terminates() {
+    #[tokio::test]
+    async fn test_ref_05_headless_loop_terminates() {
         let mock = Arc::new(MockApiClient::new(vec![]));
         let client = ApiClient::new_mock(mock);
-        let mut conversation = ConversationManager::new_mock(client, HashMap::new());
-        let mut ctx = RuntimeContext {
-            conversation: &mut conversation,
-        };
+        let conversation = ConversationManager::new_mock(client, HashMap::new());
+        let (tx, _rx) = mpsc::unbounded_channel::<UiUpdate>();
+        let mut ctx = RuntimeContext::new(
+            conversation,
+            tx,
+            tokio_util::sync::CancellationToken::new(),
+        );
 
-        let (_tx, update_rx) = mpsc::unbounded_channel::<UiUpdate>();
+        let (_update_tx, update_rx) = mpsc::unbounded_channel::<UiUpdate>();
         let mode = crate::app::TuiMode::new();
         let mut runtime = Runtime::new(mode, update_rx);
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -78,7 +78,7 @@ mod tests {
         }
 
         let _ = std::mem::size_of::<RuntimeEvent>();
-        let _ = std::mem::size_of::<Option<RuntimeContext<'static>>>();
+        let _ = std::mem::size_of::<Option<RuntimeContext>>();
         let _ = _uses_runtime_mode_trait::<DummyMode>;
         let _ = _uses_frontend_adapter_trait::<DummyFrontend>;
     }


### PR DESCRIPTION
## Motivation

**Repo:** `aistar-au/vexcoder`

This PR wires `RuntimeContext::start_turn` to the API dispatch path on top of the owned-context refactor. It adds 125 lines and removes 82 lines across 4 files to connect user input, API streaming, and the runtime loop through the same dispatch seam.

### Why

Why: the runtime, app, and supporting tests on this branch need to move together so the runtime contract stays consistent across the code paths touched here.

### Files changed

- `src/app/mod.rs` (+12 -8)
- `src/runtime/context.rs` (+101 -65)
- `src/runtime/loop.rs` (+11 -8)
- `src/runtime/mod.rs` (+1 -1)

### References

- [ADR-006 Runtime mode contracts](https://github.com/aistar-au/vexcoder/blob/main/docs/adr/completed/ADR-006-runtime-mode-contracts.md)
- [ADR-007 Runtime-core canonical dispatch - no alternate routing](https://github.com/aistar-au/vexcoder/blob/main/docs/adr/completed/ADR-007-runtime-canonical-dispatch-no-alt-routing.md)