### PR TITLE
Wire RuntimeContext::start_turn to API dispatch and own ConversationManager

### DIFF
--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -1,84 +1,138 @@
+use crate::api::stream::StreamParser;
+use crate::runtime::UiUpdate;
 use crate::state::ConversationManager;
+use crate::types::StreamEvent;
+use futures::StreamExt;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
 
-/// Borrowed per-tick context passed into every `RuntimeMode` callback.
+/// Capability surface passed to `RuntimeMode` methods.
 ///
-/// The lifetime `'a` is the borrow of `ConversationManager` for one event loop
-/// tick. A future task (REF-04 Track A) will evaluate whether this should
-/// become an owned shape; for now the borrowed form is correct and sufficient.
-///
-/// `start_turn` is still a no-op stub while REF-04 Track A wiring is pending.
-/// The prerequisite dispatch surface from
-/// `TASKS/REF-04-pre-conversation-dispatch-surface.md` is already merged.
-pub struct RuntimeContext<'a> {
-    pub conversation: &'a mut ConversationManager,
+/// Owns `ConversationManager` (not a borrow) so that REF-05's runtime loop
+/// can hold it without a lifetime parameter. See ADR-006 §2.
+pub struct RuntimeContext {
+    pub(crate) conversation: ConversationManager,
+    pub(crate) update_tx: mpsc::UnboundedSender<UiUpdate>,
+    pub(crate) cancel: CancellationToken,
 }
 
-impl<'a> RuntimeContext<'a> {
-    /// Initiate a user turn.
-    ///
-    /// # REF-04 Track A pending — currently a no-op
-    ///
-    /// Full implementation is pending REF-04 Track A follow-up wiring.
-    /// The prerequisite surface from `TASKS/REF-04-pre-conversation-dispatch-surface.md`
-    /// is now available:
-    ///
-    /// - `ConversationManager::push_user_message(&mut self, input: String)`
-    /// - `ConversationManager::messages_for_api(&self) -> Vec<ApiMessage>`
-    /// - `ConversationManager::client(&self) -> Arc<ApiClient>` (provided by REF-04-pre)
-    /// - `ApiClient::create_stream_with_cancel(&self, msgs, token: CancellationToken)`
-    ///
-    /// The anchor test `test_ref_04_start_turn_dispatches` remains `#[ignore]`
-    /// until Track A dispatch wiring is implemented.
-    pub fn start_turn(&mut self, _input: String) {
-        // REF-04 Track A TODO: wire dispatch using the exposed conversation/api surface.
+impl RuntimeContext {
+    pub fn new(
+        conversation: ConversationManager,
+        update_tx: mpsc::UnboundedSender<UiUpdate>,
+        cancel: CancellationToken,
+    ) -> Self {
+        Self {
+            conversation,
+            update_tx,
+            cancel,
+        }
+    }
+
+    pub fn start_turn(&mut self, input: String) {
+        self.conversation.push_user_message(input);
+
+        let turn_cancel = self.cancel.child_token();
+        let tx = self.update_tx.clone();
+        let messages = self.conversation.messages_for_api();
+        let client = self.conversation.client();
+
+        tokio::spawn(async move {
+            let result = client.create_stream_with_cancel(&messages, turn_cancel.clone()).await;
+
+            match result {
+                Ok(mut stream) => {
+                    let mut parser = StreamParser::new();
+                    while let Some(chunk_result) = stream.next().await {
+                        if turn_cancel.is_cancelled() {
+                            break;
+                        }
+
+                        let chunk = match chunk_result {
+                            Ok(chunk) => chunk,
+                            Err(e) => {
+                                let _ = tx.send(UiUpdate::Error(e.to_string()));
+                                return;
+                            }
+                        };
+
+                        let events = match parser.process(&chunk) {
+                            Ok(events) => events,
+                            Err(e) => {
+                                let _ = tx.send(UiUpdate::Error(e.to_string()));
+                                return;
+                            }
+                        };
+
+                        for event in events {
+                            if turn_cancel.is_cancelled() {
+                                break;
+                            }
+                            if let StreamEvent::ContentBlockDelta {
+                                delta: crate::types::Delta { text: Some(text), .. },
+                                ..
+                            } = event
+                            {
+                                let _ = tx.send(UiUpdate::StreamDelta(text));
+                            }
+                        }
+                    }
+                    let _ = tx.send(UiUpdate::TurnComplete);
+                }
+                Err(e) => {
+                    let _ = tx.send(UiUpdate::Error(e.to_string()));
+                }
+            }
+        });
+    }
+
+    pub fn cancel_turn(&mut self) {
+        self.cancel.cancel();
+        self.cancel = CancellationToken::new();
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::RuntimeContext;
     use crate::api::{mock_client::MockApiClient, ApiClient};
+    use crate::runtime::UiUpdate;
     use crate::state::ConversationManager;
     use std::collections::HashMap;
     use std::sync::Arc;
+    use tokio::sync::mpsc;
+    use tokio_util::sync::CancellationToken;
 
-    fn make_conversation() -> ConversationManager {
-        let mock = Arc::new(MockApiClient::new(vec![]));
-        let client = ApiClient::new_mock(mock);
-        ConversationManager::new_mock(client, HashMap::new())
-    }
+    #[tokio::test]
+    async fn test_ref_04_start_turn_dispatches_message() {
+        let (tx, mut rx) = mpsc::unbounded_channel::<UiUpdate>();
 
-    /// REF-04 anchor — start_turn dispatches a real turn.
-    ///
-    /// IGNORED: pending REF-04 Track A dispatch wiring in `start_turn`.
-    ///
-    /// Required before un-ignoring:
-    ///   - ConversationManager::push_user_message
-    ///   - ConversationManager::messages_for_api
-    ///   - ConversationManager::client() -> Arc<ApiClient>
-    ///   - ApiClient::create_stream_with_cancel (CancellationToken variant)
-    #[test]
-    #[ignore = "REF-04 Track A pending: start_turn dispatch not wired yet"]
-    fn test_ref_04_start_turn_dispatches() {
-        let mut conversation = make_conversation();
-        let mut ctx = RuntimeContext {
-            conversation: &mut conversation,
-        };
-        ctx.start_turn("hello".to_string());
-        // Replace with real assertions once wired:
-        //   assert!(matches!(update_rx.try_recv().unwrap(), UiUpdate::TurnComplete));
-        todo!("wire assertions when REF-04 Track A dispatch wiring lands")
-    }
+        let client = ApiClient::new_mock(Arc::new(MockApiClient::new(vec![vec![
+            "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\n".to_string(),
+            "data: {\"choices\":[{\"delta\":{\"content\":\" world\"},\"finish_reason\":\"stop\"}]}\n\n".to_string(),
+        ]])));
+        let conversation = ConversationManager::new_mock(client, HashMap::new());
 
-    /// Smoke test — RuntimeContext constructs and start_turn is callable without panicking.
-    /// Must stay green at all times.
-    #[test]
-    fn test_ref_04_runtime_context_constructs() {
-        let mut conversation = make_conversation();
-        let mut ctx = RuntimeContext {
-            conversation: &mut conversation,
-        };
-        // start_turn is a no-op stub (REF-04 gap). Calling it must not panic.
-        ctx.start_turn("probe".to_string());
+        let mut ctx = RuntimeContext::new(conversation, tx, CancellationToken::new());
+
+        ctx.start_turn("test input".to_string());
+
+        let mut saw_delta = false;
+        let mut saw_complete = false;
+        loop {
+            match tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv()).await {
+                Ok(Some(UiUpdate::StreamDelta(_))) => saw_delta = true,
+                Ok(Some(UiUpdate::TurnComplete)) => {
+                    saw_complete = true;
+                    break;
+                }
+                Ok(Some(UiUpdate::Error(e))) => panic!("unexpected error: {e}"),
+                Ok(None) | Err(_) => break,
+                _ => {}
+            }
+        }
+
+        assert!(saw_delta, "expected at least one StreamDelta");
+        assert!(saw_complete, "expected TurnComplete");
     }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -78,7 +78,7 @@ mod tests {
         }
 
         let _ = std::mem::size_of::<RuntimeEvent>();
-        let _ = std::mem::size_of::<Option<RuntimeContext<'static>>>();
+        let _ = std::mem::size_of::<Option<RuntimeContext>>();
         let _ = _uses_runtime_mode_trait::<DummyMode>;
         let _ = _uses_frontend_adapter_trait::<DummyFrontend>;
     }


### PR DESCRIPTION
## Motivation

**Repo:** `aistar-au/vexcoder`

This PR wires `RuntimeContext::start_turn` to the API dispatch path and moves the runtime context to an owned shape. It adds 146 lines and removes 86 lines across 4 files to align dispatch, cancellation, and test setup around one runtime contract.

### Why

Why: the runtime, app, and supporting tests on this branch need to move together so the runtime contract stays consistent across the code paths touched here.

### Files changed

- `src/app/mod.rs` (+16 -12)
- `src/runtime/context.rs` (+119 -65)
- `src/runtime/loop.rs` (+10 -8)
- `src/runtime/mod.rs` (+1 -1)

### References

- [ADR-006 Runtime mode contracts](https://github.com/aistar-au/vexcoder/blob/main/docs/adr/completed/ADR-006-runtime-mode-contracts.md)
- [ADR-007 Runtime-core canonical dispatch - no alternate routing](https://github.com/aistar-au/vexcoder/blob/main/docs/adr/completed/ADR-007-runtime-canonical-dispatch-no-alt-routing.md)