### PR TITLE
fix: restore remote read_file content for model context

### DIFF
--- a/src/state/conversation/history.rs
+++ b/src/state/conversation/history.rs
@@ -129,14 +129,6 @@ impl ConversationManager {
         output: &str,
         summary: ReadFileSnapshotSummary,
     ) -> String {
-        if !self.client.is_local_endpoint() {
-            return format_read_file_snapshot_message(
-                path,
-                summary,
-                ReadFileSummaryMessageStyle::History,
-            );
-        }
-
         match summary {
             ReadFileSnapshotSummary::Unchanged { .. } => format_read_file_snapshot_message(
                 path,


### PR DESCRIPTION
## Motivation

**Repo:** `aistar-au/vexcoder`

This PR fixes the remote `read_file` context-visibility surface captured by ADR-020. It adds 0 lines and removes 8 lines across 1 file to remove the remote-only suppression path that stripped file content from model context.

### Why

Why: tool-result formatting only serves remote analysis if the first read and changed snapshot paths preserve the same file content the model needs for reasoning.

### Files changed

- `src/state/conversation/history.rs` (+0 -8)

### References

- [ADR-020 Looping architecture and enriched tool response correctness](https://github.com/aistar-au/vexcoder/blob/main/docs/adr/completed/ADR-020-looping-architecture-enriched-response-correctness.md)