### PR TITLE
autofix: run-2026-02-25-102537 (Codebase Audit and Critical Issue Remediation)

### DIFF
--- a/src/state/conversation/core.rs
+++ b/src/state/conversation/core.rs
@@ -250,6 +250,12 @@ impl ConversationManager {
                                 );
                             }
                         }
+                        StreamEvent::Error(message) => {
+                            emit_text_update(
+                                stream_delta_tx,
+                                format!("\n* Event: parser_error={message}\n"),
+                            );
+                        }
                         StreamEvent::Unknown => {
                             if !use_structured_blocks && stream_server_events {
                                 emit_text_update(

--- a/src/types/api_types.rs
+++ b/src/types/api_types.rs
@@ -58,6 +58,8 @@ pub enum StreamEvent {
         delta: MessageDelta,
     },
     MessageStop,
+    // CRIT-01: Add an Error variant to surface SSE parsing failures to the UI.
+    Error(String),
     #[serde(other)]
     Unknown,
 }


### PR DESCRIPTION
## Motivation

**Repo:** `aistar-au/vexcoder`

This PR applies the parser-error surfacing repair from the ADR-021 audit follow-up. It adds 8 lines and removes 0 lines across 2 files to carry `StreamEvent::Error` through the API types and into the conversation streaming path.

### Why

Why: parser failures need to surface through both the provider-facing event type and the conversation streaming path so the user-visible stream state matches the underlying parse result.

### Files changed

- `src/state/conversation/core.rs` (+6 -0)
- `src/types/api_types.rs` (+2 -0)

### References

- [ADR-021 Codebase audit: dead weight, duplication, and shared-code opportunities](https://github.com/aistar-au/vexcoder/blob/main/docs/adr/ADR-021-codebase-audit-dead-weight-duplication-shared-code-opportunities.md)