### PR TITLE
autofix: run-2026-02-24-145950 (Full Codebase Initial Review - Critical Issues)

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -39,6 +39,13 @@ mod tests {
                 _ctx: &mut RuntimeContext,
             ) {
             }
+            fn on_frontend_event(&mut self, event: UserInputEvent, ctx: &mut RuntimeContext) {
+                match event {
+                    UserInputEvent::Text(input) => self.on_user_input(input, ctx),
+                    UserInputEvent::Interrupt => self.on_interrupt(ctx),
+                    UserInputEvent::Scroll { .. } => {}
+                }
+            }
             fn is_turn_in_progress(&self) -> bool {
                 false
             }

--- a/src/runtime/loop.rs
+++ b/src/runtime/loop.rs
@@ -111,6 +111,14 @@ mod tests {
             self.interrupt_calls += 1;
         }
 
+        fn on_frontend_event(&mut self, event: UserInputEvent, ctx: &mut RuntimeContext) {
+            match event {
+                UserInputEvent::Text(input) => self.on_user_input(input, ctx),
+                UserInputEvent::Interrupt => self.on_interrupt(ctx),
+                UserInputEvent::Scroll { .. } => {}
+            }
+        }
+
         fn is_turn_in_progress(&self) -> bool {
             false
         }

--- a/src/runtime/mode.rs
+++ b/src/runtime/mode.rs
@@ -7,12 +7,6 @@ pub trait RuntimeMode {
     fn on_user_input(&mut self, input: String, ctx: &mut RuntimeContext);
     fn on_model_update(&mut self, update: UiUpdate, ctx: &mut RuntimeContext);
     fn on_interrupt(&mut self, _ctx: &mut RuntimeContext) {}
-    fn on_frontend_event(&mut self, event: UserInputEvent, ctx: &mut RuntimeContext) {
-        match event {
-            UserInputEvent::Text(input) => self.on_user_input(input, ctx),
-            UserInputEvent::Interrupt => self.on_interrupt(ctx),
-            UserInputEvent::Scroll { .. } => {}
-        }
-    }
+    fn on_frontend_event(&mut self, event: UserInputEvent, ctx: &mut RuntimeContext);
     fn is_turn_in_progress(&self) -> bool;
 }


### PR DESCRIPTION
## Motivation

**Repo:** `aistar-au/vexcoder`

This PR applies the runtime frontend-event repair against the managed TUI follow-up tracked in ADR-019. It adds 16 lines and removes 7 lines across 3 files to make `on_frontend_event` an explicit `RuntimeMode` requirement instead of a silently inherited default that dropped scroll events.

### Why

Why: the runtime and TUI boundaries only stay predictable when scroll/control events are handled through an explicit contract instead of falling through a default method that can be silently inherited.

### Files changed

- `src/runtime.rs` (+7 -0)
- `src/runtime/loop.rs` (+8 -0)
- `src/runtime/mode.rs` (+1 -7)

### References

- [ADR-018 Managed TUI scrollback, streaming cell, overlays](https://github.com/aistar-au/vexcoder/blob/main/docs/adr/ADR-018-managed-tui-scrollback-streaming-cell-overlays.md)
- [ADR-019 ADR-018 follow-up sequencing for correctness, cutover, and cleanup](https://github.com/aistar-au/vexcoder/blob/main/docs/adr/completed/ADR-019-adr-018-follow-up-correctness-cutover-cleanup.md)