### PR TITLE
chore: MCP permission probe — close and delete branch

### DIFF
--- a/.mcp-probe
+++ b/.mcp-probe
@@ -1,0 +1,3 @@
+# MCP permission probe
+
+This file was created to test PR creation via the GitHub MCP server. Safe to delete with the branch.


### PR DESCRIPTION
## Motivation

**Repo:** `aistar-au/vexcoder`

This PR records the MCP permission probe against the ADR-024 MCP surface. It adds 3 lines and removes 0 lines across 1 file to leave a small probe artifact showing the permission path that was exercised before the branch was closed.

### Why

Why: the probe artifact makes the historical MCP permission check explicit without pretending it was product code or a feature branch.

### Files changed

- `.mcp-probe` (+3 -0)

### References

- [ADR-024 Zero-licensing-cost agent parity gaps](https://github.com/aistar-au/vexcoder/blob/main/docs/adr/ADR-024-zero-licensing-cost-agent-parity-gaps.md)