### PR TITLE
docs: add mdbook structure and simplify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,114 +1,28 @@
 # VexCoder
 
-Terminal-first coding assistant with streaming responses, tool execution, and ratatui UI.
-
-## Installation
-
-### From Source
-
-macOS/Linux:
-
-```bash
-git clone https://github.com/aistar-au/vexcoder.git
-cd vexcoder
-make gate-fast
-cargo build --release
-./target/release/vex
-```
-
-Windows PowerShell 7:
-
-```powershell
-git clone https://github.com/aistar-au/vexcoder.git
-cd vexcoder
-$env:PATH = "$env:USERPROFILE\.cargo\bin;$env:PATH"
-cargo build --release --bin vex
-.\target\release\vex.exe
-```
-
-To package a Windows archive locally, install Visual Studio Build Tools with the C++ workload and run:
-
-```powershell
-.\scripts\release.ps1 -Version v0.1.0-alpha.1 -Target x86_64-pc-windows-msvc -RunGate
-```
-
-### From GitHub Releases
-
-Download the archive for your platform from the GitHub Releases page, unpack it, and run `vex`.
-
-macOS/Linux:
-
-```bash
-curl -L -o vex.tar.gz https://github.com/aistar-au/vexcoder/releases/download/v0.1.0-alpha.1/vex-0.1.0-alpha.1-x86_64-unknown-linux-musl.tar.gz
-tar -xzf vex.tar.gz
-./vex-0.1.0-alpha.1-x86_64-unknown-linux-musl/vex
-```
-
-Windows PowerShell 7:
-
-```powershell
-Invoke-WebRequest -Uri "https://github.com/aistar-au/vexcoder/releases/download/v0.1.0-alpha.1/vex-0.1.0-alpha.1-x86_64-pc-windows-msvc.zip" -OutFile vex.zip
-Expand-Archive vex.zip -DestinationPath .
-.\vex-0.1.0-alpha.1-x86_64-pc-windows-msvc\vex.exe
-```
-
-Windows alpha archives are unsigned today. SmartScreen will show an "Unknown Publisher" warning until Authenticode signing is added. SignPath.io is the planned first signing path for open-source release automation.
-
-## Quick Start
-
-```bash
-cargo run
-```
-
-## Configuration
-
-`vexcoder` is configured via environment variables. `VEX_MODEL_URL` is the only required variable.
-
-| Variable | Required | Description |
-|---|---|---|
-| `VEX_MODEL_URL` | Yes | API endpoint URL |
-| `VEX_MODEL_TOKEN` | Remote only | Bearer token for non-local endpoints |
-| `VEX_MODEL_NAME` | No | Model identifier (default: `local/default`) |
-| `VEX_MODEL_PROTOCOL` | No | `messages-v1` or `chat-compat` (inferred from URL if omitted) |
-| `VEX_TOOL_CALL_MODE` | No | `structured` (remote default) or `tagged-fallback` (local default) |
-| `VEX_MODEL_BACKEND` | No | `api-server` or `local-runtime` (inferred from URL if omitted) |
-| `VEX_WORKDIR` | No | Working directory override (defaults to current directory) |
-
-`VEX_MODEL_PROTOCOL` is inferred from the URL: endpoints containing `/chat/completions` or ending in `/v1` default to `chat-compat`; all others default to `messages-v1`.
-
-Local endpoint example:
-
-```bash
-VEX_MODEL_URL=http://localhost:8000/v1/messages \
-VEX_MODEL_NAME=local/default \
-cargo run
-```
-
-Remote endpoint example:
-
-```bash
-VEX_MODEL_URL=https://your-inference-server/v1/messages \
-VEX_MODEL_TOKEN=your-token \
-VEX_MODEL_NAME=your-model-name \
-cargo run
-```
-
-For operators migrating from a pre-ADR-022 deployment, see [ADR-022](docs/adr/ADR-022-free-open-coding-agent-roadmap.md) and its [amendment](docs/adr/ADR-022-amendment-2026-03-03.md).
-
-## Built-in TUI Commands
-
-- `/commands` or `/help`
-- `/clear`
-- `/history`
-- `/repo`
-- `/ps`
-- `/quit`
+Terminal-first coding assistant with streaming responses, tool execution, and a terminal UI.
 
 ## Documentation
 
-Architecture Decision Records are in [`docs/adr/`](docs/adr/ADR-README.md).
+Full documentation is in [`docs/src/`](docs/src/SUMMARY.md). To read it locally:
 
-Source maps:
+```bash
+cargo install mdbook
+mdbook serve docs
+```
 
-- App/raw links for the Rust application code: `CONTRIBUTING.md`
-- Sponsor VexCoder: SegWit bc1qrv27qmjvleyrllr3ed7pxstxgvrjesxxj0dzwa, Eth 0xe5D746f089D155f0E1C6dD6C663E3F5D853BAe6a
+- [Introduction](docs/src/introduction.md)
+- [Quick Start](docs/src/quick-start.md)
+- [Installation — macOS, Linux, Windows](docs/src/installation/index.md)
+- [Configuration](docs/src/configuration.md)
+- [TUI Commands](docs/src/commands.md)
+- [Architecture Overview](docs/src/architecture.md)
+- [Architecture Decision Records](docs/adr/ADR-README.md)
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) and [AGENTS.md](AGENTS.md).
+
+---
+
+Sponsor: SegWit `bc1qrv27qmjvleyrllr3ed7pxstxgvrjesxxj0dzwa` · Eth `0xe5D746f089D155f0E1C6dD6C663E3F5D853BAe6a`

--- a/book.toml
+++ b/book.toml
@@ -1,0 +1,11 @@
+[book]
+title = "VexCoder"
+description = "Terminal-first coding assistant with streaming responses, tool execution, and a terminal UI."
+authors = ["aistar-au"]
+language = "en"
+multilingual = false
+src = "docs/src"
+
+[output.html]
+git-repository-url = "https://github.com/aistar-au/vexcoder"
+edit-url-template = "https://github.com/aistar-au/vexcoder/edit/main/{path}"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,0 +1,21 @@
+# Summary
+
+[Introduction](introduction.md)
+
+---
+
+# User Guide
+
+- [Quick Start](quick-start.md)
+- [Installation](installation/index.md)
+  - [macOS](installation/macos.md)
+  - [Linux](installation/linux.md)
+  - [Windows](installation/windows.md)
+- [Configuration](configuration.md)
+- [TUI Commands](commands.md)
+
+# Reference
+
+- [Architecture Overview](architecture.md)
+- [Contributing](contributing.md)
+- [Architecture Decision Records](adr/index.md)

--- a/docs/src/adr/index.md
+++ b/docs/src/adr/index.md
@@ -1,0 +1,15 @@
+# Architecture Decision Records
+
+Architecture decisions are recorded incrementally in `docs/adr/`. See [ADR-README.md](../../adr/ADR-README.md) for the index and status of each record.
+
+## Active ADRs
+
+- [ADR-021 — Codebase audit: dead weight, duplication, shared code opportunities](../../adr/ADR-021-codebase-audit-dead-weight-duplication-shared-code-opportunities.md)
+- [ADR-022 — Free open coding agent roadmap](../../adr/ADR-022-free-open-coding-agent-roadmap.md)
+- [ADR-022 amendment (2026-03-03)](../../adr/ADR-022-amendment-2026-03-03.md)
+- [ADR-023 — Deterministic edit loop](../../adr/ADR-023-deterministic-edit-loop.md)
+- [ADR-024 — Zero licensing cost, agent parity gaps](../../adr/ADR-024-zero-licensing-cost-agent-parity-gaps.md)
+
+## Completed ADRs
+
+Earlier records in `docs/adr/completed/` cover runtime mode contracts, TUI lifecycle, protocol detection, policy enforcement, and append-terminal session design.

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -1,0 +1,54 @@
+# Architecture Overview
+
+This page describes VexCoder's runtime structure at a level sufficient to orient contributors. Detailed decisions and rationale are in the [Architecture Decision Records](adr/index.md).
+
+## Runtime boundary
+
+The runtime boundary separates orchestration from presentation. Everything inside `src/runtime/` owns orchestration and policy wiring. UI code in `src/ui/` and the application surface in `src/app.rs` do not reach through this boundary.
+
+The canonical dispatch path from user input to tool execution is:
+
+```
+user input
+  → app command handling (src/app.rs)
+    → runtime loop (src/runtime/loop.rs)
+      → edit loop (src/runtime/edit_loop.rs)
+        → API client (src/api/client.rs)
+          → tool operator (src/tools/operator.rs)
+            → approval gate (src/runtime/approval.rs)
+              → filesystem / shell tool execution
+```
+
+There is one path. There are no alternate routing shortcuts.
+
+## Protocol detection
+
+VexCoder supports two wire protocols. The protocol is detected automatically from the endpoint URL:
+
+- `messages-v1` — native protocol, used when the path does not match `chat-compat` patterns.
+- `chat-compat` — OpenAI-compatible chat completions protocol, used when the path contains `/chat/completions` or ends in `/v1`.
+
+The backend mode (`api-server` vs `local-runtime`) is inferred by the same mechanism and can be overridden via `VEX_MODEL_BACKEND`.
+
+## Edit loop
+
+The edit loop (`src/runtime/edit_loop.rs`) is the bounded execution context for a single agentic turn. It enforces a turn ceiling (`DEFAULT_MAX_TURNS = 6`, `HARD_MAX_TURNS = 12`), supports cancellation via a `CancellationToken`, and tracks workspace dirty state. The last validation result is accessible after the loop completes.
+
+## Tool confinement
+
+All file operations from the tool operator (`src/tools/operator.rs`) are confined to the workspace root. Paths are normalised lexically before any filesystem access to prevent traversal outside the root.
+
+## Headless and TUI modes
+
+VexCoder supports both a terminal UI session and a headless mode for scripting. The mode boundary is enforced at the runtime seam. The same core runtime runs in both modes.
+
+## State
+
+Conversation and task state (`src/state/`) are managed separately. Conversation history, streaming state, and tool call tracking live in `src/state/conversation/`. Task state is tracked in `src/runtime/task_state.rs`.
+
+## Further reading
+
+- [ADR-004 — Runtime seam and headless-first design](../adr/completed/ADR-004-runtime-seam-headless-first.md)
+- [ADR-006 — Runtime mode contracts](../adr/completed/ADR-006-runtime-mode-contracts.md)
+- [ADR-023 — Deterministic edit loop](../adr/ADR-023-deterministic-edit-loop.md)
+- [Full ADR index](adr/index.md)

--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -1,0 +1,33 @@
+# TUI Commands
+
+Commands are entered at the VexCoder prompt inside the terminal UI. All commands begin with `/`.
+
+## Reference
+
+### `/commands` or `/help`
+
+Prints the list of available commands.
+
+### `/clear`
+
+Clears the current conversation and resets the context window. Any active edit loop is cancelled before the conversation is cleared.
+
+### `/history`
+
+Displays the conversation history for the current session.
+
+### `/repo`
+
+Prints the current working directory root that VexCoder is treating as the repository root. This is the boundary enforced for all tool file operations.
+
+### `/ps`
+
+Prints the status of any currently running background processes or pending tool operations.
+
+### `/quit`
+
+Exits VexCoder cleanly. Pending tool operations are cancelled before exit.
+
+## Keyboard shortcuts
+
+Inside the editor, standard readline-compatible shortcuts apply. The editor is a single-line input; multi-line content is pasted as a block.

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -1,0 +1,60 @@
+# Configuration
+
+VexCoder is configured entirely through environment variables. There are no configuration files. The only required variable is `VEX_MODEL_URL`.
+
+## Required
+
+### `VEX_MODEL_URL`
+
+The full URL of the inference API endpoint. VexCoder infers the protocol from this value.
+
+- A path containing `/chat/completions` or ending in `/v1` defaults to `chat-compat` (OpenAI-compatible).
+- All other paths default to `messages-v1`.
+
+Local example:
+
+```bash
+VEX_MODEL_URL=http://localhost:8000/v1/messages
+```
+
+Remote example:
+
+```bash
+VEX_MODEL_URL=https://your-inference-server/v1/messages
+```
+
+## Authentication
+
+### `VEX_MODEL_TOKEN`
+
+Bearer token sent in the `Authorization` header. Required for remote endpoints that enforce authentication. Not needed for unauthenticated local endpoints.
+
+## Model selection
+
+### `VEX_MODEL_NAME`
+
+The model identifier passed to the API. Defaults to `local/default` when not set. For remote endpoints this typically needs to match the model name the server recognises.
+
+## Protocol and transport
+
+### `VEX_MODEL_PROTOCOL`
+
+Overrides the protocol inferred from the URL. Accepted values: `messages-v1`, `chat-compat`. Useful when your endpoint path does not follow the inference convention.
+
+### `VEX_MODEL_BACKEND`
+
+Overrides the backend mode inferred from the URL. Accepted values: `api-server`, `local-runtime`. VexCoder infers this from the URL; set it only if the inference is wrong for your setup.
+
+### `VEX_TOOL_CALL_MODE`
+
+Controls how tool calls are encoded in requests. Accepted values: `structured` (default for remote endpoints), `tagged-fallback` (default for local endpoints). The `tagged-fallback` mode embeds tool use in the message text for models that do not support structured tool call APIs.
+
+## Working directory
+
+### `VEX_WORKDIR`
+
+Overrides the working directory used for tool execution. Defaults to the current directory at launch. VexCoder confines all file access to this root.
+
+## Migration note
+
+If you are migrating from a deployment predating the current protocol architecture, see [ADR-022](../adr/ADR-022-free-open-coding-agent-roadmap.md) and its [amendment](../adr/ADR-022-amendment-2026-03-03.md) for the changes to endpoint inference and protocol selection.

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -1,0 +1,14 @@
+# Contributing
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) at the repository root for the full contributor guide, including the source map, verification protocol, and hard rules.
+
+For agent and automated contributor bootstrap, see [AGENTS.md](../../AGENTS.md).
+
+## Short checklist
+
+Before opening a pull request:
+
+- Run `make gate-fast` and confirm it is green (`cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `cargo test --all-targets`).
+- If you added files, update `REPO-RAW-URL-MAP.md` in the companion dispatcher repository.
+- For changes to `src/` or `tests/`, run the pre-push debugger described in `AGENTS.md` before pushing.
+- Merge to `main` via merge commit only. No squash, no rebase.

--- a/docs/src/installation/index.md
+++ b/docs/src/installation/index.md
@@ -1,0 +1,43 @@
+# Installation
+
+VexCoder is distributed as a single statically-linked binary. You can build it from source or download a pre-built archive from GitHub Releases.
+
+## Choose your path
+
+- [Build from source on macOS](macos.md)
+- [Build from source on Linux](linux.md)
+- [Build from source on Windows](windows.md)
+
+## Download a pre-built release
+
+Pre-built archives are attached to each [GitHub Release](https://github.com/aistar-au/vexcoder/releases).
+
+**macOS / Linux:**
+
+```bash
+curl -L -o vex.tar.gz \
+  https://github.com/aistar-au/vexcoder/releases/download/v0.1.0-alpha.1/vex-0.1.0-alpha.1-x86_64-unknown-linux-musl.tar.gz
+tar -xzf vex.tar.gz
+./vex-0.1.0-alpha.1-x86_64-unknown-linux-musl/vex
+```
+
+**Windows PowerShell 7:**
+
+```powershell
+Invoke-WebRequest `
+  -Uri "https://github.com/aistar-au/vexcoder/releases/download/v0.1.0-alpha.1/vex-0.1.0-alpha.1-x86_64-pc-windows-msvc.zip" `
+  -OutFile vex.zip
+Expand-Archive vex.zip -DestinationPath .
+.\vex-0.1.0-alpha.1-x86_64-pc-windows-msvc\vex.exe
+```
+
+Windows archives are currently unsigned. SmartScreen will display an "Unknown Publisher" warning. Authenticode signing via SignPath.io is planned for a future release.
+
+## Supported targets
+
+| Target | Notes |
+|---|---|
+| `x86_64-unknown-linux-musl` | Fully static, runs on any glibc-free Linux |
+| `x86_64-pc-windows-msvc` | Requires Visual C++ Redistributable |
+| `x86_64-apple-darwin` | macOS 11+ |
+| `aarch64-apple-darwin` | Apple Silicon, macOS 11+ |

--- a/docs/src/installation/linux.md
+++ b/docs/src/installation/linux.md
@@ -1,0 +1,140 @@
+# Build from Source — Linux
+
+Tested on Ubuntu 22.04 LTS, Fedora 39, and Arch Linux. The instructions use Debian/Ubuntu package names; substitute your package manager where noted.
+
+## Step 1 — Install system build dependencies
+
+VexCoder's direct Rust dependencies do not require native system libraries beyond a C linker. Install the minimal set:
+
+**Debian / Ubuntu:**
+
+```bash
+sudo apt-get update
+sudo apt-get install -y build-essential curl git pkg-config
+```
+
+**Fedora / RHEL:**
+
+```bash
+sudo dnf install -y gcc make curl git pkg-config
+```
+
+**Arch Linux:**
+
+```bash
+sudo pacman -Sy --needed base-devel curl git
+```
+
+Verify the C compiler is available:
+
+```bash
+cc --version
+```
+
+## Step 2 — Install Rust via rustup
+
+Do not use your distribution's Rust package. System-packaged Rust is often multiple releases behind and does not support toolchain components reliably.
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+Choose option 1 (default installation). Reload your shell:
+
+```bash
+source "$HOME/.cargo/env"
+```
+
+Update to the latest stable toolchain:
+
+```bash
+rustup update stable
+rustup show
+cargo --version
+```
+
+## Step 3 — (Optional) Add the musl target for static builds
+
+The GitHub Releases Linux binary is compiled against musl for maximum portability. If you want to produce the same fully static binary:
+
+```bash
+# Install musl toolchain (Debian/Ubuntu)
+sudo apt-get install -y musl-tools
+
+# Add the Rust target
+rustup target add x86_64-unknown-linux-musl
+```
+
+## Step 4 — Install taplo (TOML formatter and validator)
+
+```bash
+cargo install taplo-cli --locked
+```
+
+Add `$HOME/.cargo/bin` to your `PATH` if it is not already present:
+
+```bash
+echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> ~/.bashrc
+source ~/.bashrc
+taplo --version
+```
+
+## Step 5 — Clone and build
+
+```bash
+git clone https://github.com/aistar-au/vexcoder.git
+cd vexcoder
+```
+
+Run the gate:
+
+```bash
+make gate-fast
+```
+
+Build the standard dynamically-linked release binary:
+
+```bash
+cargo build --release
+```
+
+Or build the fully static musl binary:
+
+```bash
+cargo build --release --target x86_64-unknown-linux-musl
+```
+
+Binary paths:
+
+- Dynamic: `target/release/vex`
+- Static musl: `target/x86_64-unknown-linux-musl/release/vex`
+
+## Step 6 — Run
+
+```bash
+VEX_MODEL_URL=http://localhost:8000/v1/messages \
+./target/release/vex
+```
+
+Install to your Cargo bin path:
+
+```bash
+cargo install --path .
+vex
+```
+
+## Step 7 — (Optional) Build a release archive
+
+```bash
+./scripts/release.sh v0.1.0-alpha.1 x86_64-unknown-linux-musl
+```
+
+The archive is written to `dist/`.
+
+## Troubleshooting
+
+**`error: could not find native static library 'c'` when building musl** — The `musl-tools` package is not installed. Run `sudo apt-get install musl-tools` (Debian/Ubuntu) or the equivalent for your distribution.
+
+**`taplo: command not found`** — `$HOME/.cargo/bin` is not on your PATH. Add it to your shell profile (see Step 4).
+
+**`make gate-fast` fails with clippy warnings** — The project compiles with `-D warnings` (warnings as errors). Check the clippy output and fix the flagged items before committing.

--- a/docs/src/installation/macos.md
+++ b/docs/src/installation/macos.md
@@ -1,0 +1,141 @@
+# Build from Source — macOS
+
+Tested on macOS 12 Monterey and later, both Intel and Apple Silicon.
+
+## Step 1 — Install Xcode Command Line Tools
+
+The Xcode CLT provides `git`, `make`, `clang`, and the macOS SDK headers. If you already have Xcode or the CLT installed this step is a no-op.
+
+```bash
+xcode-select --install
+```
+
+A dialog will appear. Click Install and wait for the download to complete. Verify:
+
+```bash
+xcode-select -p
+# expected: /Library/Developer/CommandLineTools or /Applications/Xcode.app/Contents/Developer
+```
+
+## Step 2 — Install Homebrew (optional but recommended)
+
+Homebrew provides `taplo` and other tooling used by the Makefile targets. Skip this step if you manage those tools another way.
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+Follow the post-install instructions to add Homebrew to your shell path. On Apple Silicon:
+
+```bash
+echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
+eval "$(/opt/homebrew/bin/brew shellenv)"
+```
+
+Verify:
+
+```bash
+brew --version
+```
+
+## Step 3 — Install Rust via rustup
+
+Do not use the Homebrew Rust package. The project requires the stable toolchain managed by rustup so that toolchain pinning and component installation work correctly.
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+Choose option 1 (default installation). Then reload your shell environment:
+
+```bash
+source "$HOME/.cargo/env"
+```
+
+Verify:
+
+```bash
+rustup show
+cargo --version
+```
+
+The project targets stable Rust. Confirm you have at least 1.75:
+
+```bash
+rustup update stable
+```
+
+## Step 4 — Install taplo (TOML formatter and validator)
+
+The `make gate-fast` target uses `scripts/taplo_safe.sh` to validate TOML files. taplo is available via Homebrew:
+
+```bash
+brew install taplo
+```
+
+Or via cargo:
+
+```bash
+cargo install taplo-cli --locked
+```
+
+Verify:
+
+```bash
+taplo --version
+```
+
+## Step 5 — Clone and build
+
+```bash
+git clone https://github.com/aistar-au/vexcoder.git
+cd vexcoder
+```
+
+Run the full gate first to confirm the toolchain is set up correctly:
+
+```bash
+make gate-fast
+```
+
+This runs `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test --all-targets`. A green gate confirms the build environment is complete.
+
+Then build the release binary:
+
+```bash
+cargo build --release
+```
+
+The binary is at `target/release/vex`.
+
+## Step 6 — Run
+
+```bash
+VEX_MODEL_URL=http://localhost:8000/v1/messages \
+./target/release/vex
+```
+
+Or install to your Cargo bin path:
+
+```bash
+cargo install --path .
+vex
+```
+
+## Step 7 — (Optional) Build a release archive
+
+To produce the same `.tar.gz` archive used by GitHub Releases:
+
+```bash
+./scripts/release.sh v0.1.0-alpha.1 x86_64-apple-darwin
+```
+
+The archive is written to the `dist/` directory.
+
+## Troubleshooting
+
+**`error: linker 'cc' not found`** — The Xcode CLT installation did not complete or the path was not picked up. Run `xcode-select --install` again or set `CC=clang` in your environment.
+
+**`taplo: command not found`** — Install taplo via Homebrew or cargo (Step 4). The gate will fail if taplo is absent.
+
+**`cargo fmt --check` fails** — Run `cargo fmt` and commit the result before re-running the gate.

--- a/docs/src/installation/windows.md
+++ b/docs/src/installation/windows.md
@@ -1,0 +1,148 @@
+# Build from Source — Windows
+
+Tested on Windows 10 21H2 and Windows 11, using PowerShell 7 and the MSVC toolchain. WSL 2 is a viable alternative and follows the [Linux guide](linux.md) exactly.
+
+## Prerequisites overview
+
+- PowerShell 7 (not Windows PowerShell 5.1)
+- Visual Studio Build Tools with the Desktop development with C++ workload
+- Rust stable toolchain via rustup
+- taplo (TOML validator)
+
+## Step 1 — Install PowerShell 7
+
+PowerShell 7 is required. The release scripts and some Makefile paths use syntax not available in Windows PowerShell 5.1.
+
+Install via winget:
+
+```powershell
+winget install --id Microsoft.PowerShell --source winget
+```
+
+Or download the MSI installer from the [PowerShell GitHub releases page](https://github.com/PowerShell/PowerShell/releases).
+
+Open a new PowerShell 7 window (`pwsh.exe`) for all remaining steps.
+
+Verify:
+
+```powershell
+$PSVersionTable.PSVersion
+# Major should be 7 or later
+```
+
+## Step 2 — Install Visual Studio Build Tools
+
+The MSVC linker and Windows SDK headers are required. The free Build Tools installer provides everything needed without a full Visual Studio installation.
+
+Download the Build Tools installer from the [Visual Studio downloads page](https://visualstudio.microsoft.com/downloads/) (scroll to "Tools for Visual Studio", then "Build Tools for Visual Studio").
+
+Run the installer and select the **Desktop development with C++** workload. The required components are:
+
+- MSVC v143 (or later) build tools
+- Windows 11 (or 10) SDK
+- C++ CMake tools (optional but recommended)
+
+The installation requires approximately 6 GB of disk space.
+
+Verify from a new PowerShell 7 window:
+
+```powershell
+cl.exe /?
+# should print Microsoft C/C++ compiler version info
+# if not found, ensure "Developer PowerShell" or add MSVC bin to PATH
+```
+
+Alternatively, use the "Developer PowerShell for VS" shortcut which sets the MSVC paths automatically.
+
+## Step 3 — Install Rust via rustup
+
+Download and run the rustup installer:
+
+```powershell
+Invoke-WebRequest -Uri "https://win.rustup.rs/x86_64" -OutFile rustup-init.exe
+.\rustup-init.exe
+```
+
+Select option 1 (default installation). The default Windows toolchain is `stable-x86_64-pc-windows-msvc`. Close and reopen PowerShell 7 after installation.
+
+Verify:
+
+```powershell
+rustup show
+cargo --version
+```
+
+Ensure the Cargo bin directory is on your path. The installer adds it to the user `PATH` automatically; if not:
+
+```powershell
+$env:PATH = "$env:USERPROFILE\.cargo\bin;$env:PATH"
+```
+
+Add this line to your PowerShell profile to persist it:
+
+```powershell
+Add-Content -Path $PROFILE -Value '$env:PATH = "$env:USERPROFILE\.cargo\bin;$env:PATH"'
+```
+
+## Step 4 — Install taplo
+
+```powershell
+cargo install taplo-cli --locked
+taplo --version
+```
+
+## Step 5 — Clone and build
+
+```powershell
+git clone https://github.com/aistar-au/vexcoder.git
+cd vexcoder
+```
+
+Build the release binary:
+
+```powershell
+cargo build --release --bin vex
+```
+
+The binary is at `target\release\vex.exe`.
+
+The `make gate-fast` target requires GNU `make`. If you have it installed (via Git for Windows or Scoop), run it to confirm the gate is green:
+
+```powershell
+make gate-fast
+```
+
+Otherwise run the individual commands directly:
+
+```powershell
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+cargo test --all-targets
+```
+
+## Step 6 — Run
+
+```powershell
+$env:VEX_MODEL_URL = "http://localhost:8000/v1/messages"
+.\target\release\vex.exe
+```
+
+## Step 7 — (Optional) Build a release archive
+
+To produce the same `.zip` archive used by GitHub Releases, install the Visual Studio Build Tools C++ workload (Step 2) and run:
+
+```powershell
+.\scripts\release.ps1 -Version v0.1.0-alpha.1 -Target x86_64-pc-windows-msvc -RunGate
+```
+
+The archive is written to `dist\`.
+
+Note: release archives are currently unsigned. SmartScreen will display an "Unknown Publisher" warning when you try to run the extracted binary. This is expected until Authenticode signing is added. You can bypass it by right-clicking the binary, selecting Properties, and checking Unblock.
+
+## Troubleshooting
+
+**`error: linker 'link.exe' not found`** — The MSVC Build Tools are not installed or not on PATH. Install the Desktop development with C++ workload (Step 2) and open a new Developer PowerShell or add the MSVC bin path to your environment.
+
+**`cargo fmt --check` fails** — Run `cargo fmt` and re-run the check. The formatter output is canonical; manual line-width adjustments will be overwritten.
+
+**`rustup-init.exe` requests admin elevation** — This is normal for the first-time install. The toolchain itself is installed per-user and does not require admin after the initial setup.

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,0 +1,32 @@
+# Introduction
+
+VexCoder is a terminal-first coding assistant. It streams responses from a language model, executes shell tools on your behalf, and renders everything in an interactive terminal UI built with Ratatui.
+
+## Key properties
+
+VexCoder is designed around three invariants.
+
+**Deterministic dispatch.** Every tool call follows an explicit approval path. There are no hidden routing alternatives. The runtime enforces a single canonical path from user input to tool execution and back.
+
+**Dual-protocol support.** VexCoder speaks both a native `messages-v1` protocol and an OpenAI-compatible `chat-compat` protocol. The protocol is inferred from the endpoint URL so the same binary works against local inference servers and hosted remote APIs without reconfiguration.
+
+**Headless and TUI modes.** The same core runtime powers both an interactive Ratatui terminal session and a headless mode suitable for scripting and CI pipelines. The mode boundary is enforced at the runtime seam, not via conditional branches inside business logic.
+
+## What VexCoder is not
+
+VexCoder is not a cloud service. It is a local binary that connects to whichever inference endpoint you configure. There is no telemetry, no account, and no network requirement other than the connection to your model endpoint.
+
+## Source layout
+
+```
+src/
+  bin/vex.rs          entry point
+  app.rs              command and mode surface
+  runtime/            orchestration and policy wiring
+  state/              conversation and task-state persistence
+  tools/              tool execution and workspace confinement
+  api/                HTTP client, streaming parser, protocol detection
+  ui/                 Ratatui render loop and layout
+```
+
+Architecture decisions are recorded incrementally in [`docs/adr/`](../adr/ADR-README.md). Start with the ADR README for a map of what each record covers.

--- a/docs/src/quick-start.md
+++ b/docs/src/quick-start.md
@@ -1,0 +1,43 @@
+# Quick Start
+
+This page gets you from zero to a running session in the fewest steps. For full platform-specific prerequisites and build options, see the [Installation](installation/index.md) guide.
+
+## Prerequisites
+
+- Rust stable toolchain (1.75 or later). Install via [rustup](https://rustup.rs).
+- A running inference endpoint that accepts either the `messages-v1` or `chat-compat` (OpenAI-compatible) API.
+
+## Run against a local endpoint
+
+```bash
+git clone https://github.com/aistar-au/vexcoder.git
+cd vexcoder
+VEX_MODEL_URL=http://localhost:8000/v1/messages cargo run
+```
+
+VexCoder infers the protocol from the URL. An endpoint path containing `/v1/messages` uses `messages-v1`. An endpoint path containing `/chat/completions` or ending in `/v1` uses `chat-compat`.
+
+## Run against a remote endpoint
+
+```bash
+VEX_MODEL_URL=https://your-inference-server/v1/messages \
+VEX_MODEL_TOKEN=your-token \
+VEX_MODEL_NAME=your-model-name \
+cargo run
+```
+
+## Verify the build gate passes
+
+Before running in a development context, confirm the full gate is green:
+
+```bash
+make gate-fast
+```
+
+This runs `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test --all-targets`. A green gate is the baseline for any code contribution.
+
+## Next steps
+
+- [Configuration reference](configuration.md) — all environment variables
+- [TUI Commands](commands.md) — what you can type inside the session
+- [Installation](installation/index.md) — platform-specific release builds


### PR DESCRIPTION
## Motivation

**Repo:** `aistar-au/vexcoder`

This PR reorganizes the public documentation surface around the ADR-022 roadmap. It adds 771 lines and removes 102 lines across 14 files to move installation, configuration, commands, and ADR navigation into an mdBook layout with a shorter top-level README.

### Why

Why: the public docs surface is easier to maintain once installation, configuration, contributor guidance, and the ADR index all live in one navigable book structure instead of being split between an oversized README and disconnected pages.

### Files changed

- `README.md` (+16 -102)
- `book.toml` (+11 -0)
- `docs/src/SUMMARY.md` (+21 -0)
- `docs/src/adr/index.md` (+15 -0)
- `docs/src/architecture.md` (+54 -0)
- `docs/src/commands.md` (+33 -0)
- `docs/src/configuration.md` (+60 -0)
- `docs/src/contributing.md` (+14 -0)
- `docs/src/installation/index.md` (+43 -0)
- `docs/src/installation/linux.md` (+140 -0)
- `docs/src/installation/macos.md` (+141 -0)
- `docs/src/installation/windows.md` (+148 -0)
- `docs/src/introduction.md` (+32 -0)
- `docs/src/quick-start.md` (+43 -0)

### References

- [ADR-022 Free/Open coding agent roadmap](https://github.com/aistar-au/vexcoder/blob/main/docs/adr/ADR-022-free-open-coding-agent-roadmap.md)