### PR TITLE
docs: formalize wording across vexcoder documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 
 `vexcoder` is the public product repo. The dispatcher skills, PR-contract
 rules, commit-debug tooling, docs automation, and roadmap automation that drive
-agent workflows now live in the internal private repo `../vexdraft`.
+agent workflows now live in the internal repository `../vexdraft`.
 
 This file is the bootstrap dependency map for agents working in `vexcoder`.
 Read it first, then follow the linked local and internal-repo sources.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 > The ADRs explain *why* the project is structured this way. Read them before opening a PR.
 >
 > **Agent bootstrap:** repo-local product guidance stays here, but the active
-> dispatcher skills now live in the internal private repo
+> dispatcher skills now live in the internal repository
 > `../vexdraft/.agents/skills/`.
 > Read [`AGENTS.md`](AGENTS.md) first for the dependency map and required load
 > order before using the private skill tree against this repo.
@@ -149,7 +149,7 @@ Do not merge packaging work directly from a local debug session; keep the review
 │   ├── docs/adr/           # Architecture Decision Records
 │   ├── src/                # Rust crate source
 │   └── tests/              # Integration tests
-└── vexdraft/               # Sibling devops repo — dispatcher, commit-debug, skills
+└── vexdraft/               # Internal devops repository — dispatcher, commit-debug, skills
     └── scripts/
         └── commit-debug.py # Multi-provider pre-push reviewer (called by dispatcher)
 ```

--- a/Makefile
+++ b/Makefile
@@ -134,12 +134,12 @@ lint:
 # Commit-debug gate
 #
 # For src/ and tests/ changes, multi-provider review (commit-debug.py) is owned
-# by the dispatcher in the internal devops repo at ../vexdraft relative to this
+# by the dispatcher in the internal devops repository at ../vexdraft relative to this
 # repo root. The dispatcher invokes it as part of the loop cycle before push.
 # This target runs gate-fast only — the local Rust gate. It is intentionally
 # self-contained so vexcoder's Makefile carries no cross-repo path assumptions.
 #
-# Sibling layout (required): ~/git-repo/vexcoder and ~/git-repo/vexdraft must
+# Repository layout (required): ~/git-repo/vexcoder and ~/git-repo/vexdraft must
 # exist side by side. The dispatcher calls commit-debug.py from vexdraft directly.
 # ------------------------------------------------------------------------------
 commit-debug-gate: gate-fast


### PR DESCRIPTION
Replace informal terms like 'sibling' and 'internal private repo' with neutral, formal wording across documentation and scripts. Changes: CONTRIBUTING.md, Makefile, AGENTS.md.