### PR TITLE
test(adr): add forbidden-name coverage for EL-09

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ truth for the broader open-ADR list.
 | :--- | :--- | :--- |
 | ADR-021 | Accepted, follow-up maintenance remains | Audit and cleanup items can still affect `src/`, tests, or docs shape. |
 | ADR-022 | Proposed, with 2026-03-13 amendment | Sets the free/open roadmap target that the private dispatcher skills are validating against. |
-| ADR-023 | Locked | EL-07 is merged and ADR-024 Phase A is reconciled complete. The current next edit-loop batch is EL-08 (`ModelProfile` config integration via layered config), followed by EL-09. Target files for EL-08 are `src/config.rs`, `src/app.rs`, `src/api/client.rs`, `src/bin/vex.rs`, `docs/src/configuration.md`, and the config-layer tests in `src/config.rs` / `tests/integration_test.rs`. |
+| ADR-023 | Locked | EL-08 and EL-09 are merged and ADR-024 Phase A is reconciled complete. The current next edit-loop batch is EL-10 (`/review` command path and diff assembly), followed by EL-11. Target files for EL-10 are `src/app.rs`, `src/runtime/context_assembler.rs`, `src/prompts.rs`, `src/prompts/review_template.txt`, `docs/src/commands.md`, and the review-path tests in `src/app.rs` / `tests/integration_test.rs`. |
 | ADR-024 | Proposed | Defines gap work around layered config, MCP, skills, export, and related parity surface. |
 | ADR-025 | Proposed | First post-gate Phase I dispatch target (`PI-09` through `PI-12`); implementation remains gated on milestone-1 correctness validation. |
 | ADR-026 | Proposed | Follows ADR-025 closeout and ADR-024 reconciliation (`PI-13` through `PI-16`); implementation remains gated on milestone-1 correctness validation. |

--- a/TASKS/ACTIVE-ROADMAP.md
+++ b/TASKS/ACTIVE-ROADMAP.md
@@ -12,7 +12,7 @@ Current task-dispatch dependency state:
 | `ADR-021` | Accepted, follow-up maintenance remains | Audit and cleanup items can still affect `src/`, tests, or docs shape. |
 | `ADR-022 amendment` | Proposed | Constrains first-milestone scope relative to `ADR-022`. |
 | `ADR-022` | Proposed | Free/open roadmap target and config/interface decision surface. |
-| `ADR-023` | Locked | `EL-07` is merged. The current queued batch is `EL-08` (`ModelProfile` config integration via layered config); `EL-09` follows `EL-08`. |
+| `ADR-023` | Locked | `EL-08` and `EL-09` are merged. The current queued batch is `EL-10` (`/review` command path and diff assembly); `EL-11` follows `EL-10`. |
 | `ADR-024` | Proposed | Parity-gap inventory, command surface, and deferred work. |
 | `ADR-025` | Proposed | First post-gate Phase I dispatch target (`PI-09` through `PI-12`); implementation remains gated on milestone-1 validation. |
 | `ADR-026` | Proposed | Follows `ADR-025` closeout and ADR-024 reconciliation (`PI-13` through `PI-16`); implementation remains gated on milestone-1 validation. |
@@ -22,20 +22,20 @@ ADR-025 and ADR-026 are queued immediately after the milestone-1 correctness
 gate. This roadmap note is descriptive only and does not relax that gate.
 
 ADR-024 checklist reconciliation is current through merged PRs `#60`, `#63`,
-`#71`, `#72`, `#74`, `#75`, and `#78`. `PK-08` (`vex branch` and
-`vex pr-summary`) and the ADR-027 command-session follow-up are merged. The
-remaining milestone-1 queue does not begin at ADR-025 / ADR-026 yet: `EL-08`
-still sits in front of the post-gate Phase I track.
+`#71`, `#72`, `#74`, `#75`, `#78`, and `#79`. `PK-08` (`vex branch` and
+`vex pr-summary`), the ADR-027 command-session follow-up, and `EL-09` are
+merged. The remaining milestone-1 queue does not begin at ADR-025 / ADR-026
+yet: `EL-10` still sits in front of the post-gate Phase I track.
 
 ## Current Next Dispatcher Batch
 
-`ADR-023 EL-08` is the next dispatcher batch to hand to a low-context coding
+`ADR-023 EL-10` is the next dispatcher batch to hand to a low-context coding
 agent.
 
-- Anchor test: `test_model_profile_loaded_from_layered_config`
-- Primary target files: `src/config.rs`, `src/app.rs`, `src/api/client.rs`
-- Required scaffold/docs sync: `src/bin/vex.rs`, `docs/src/configuration.md`
-- Supporting tests: `src/config.rs`, `tests/integration_test.rs`
+- Anchor tests: `test_tui_review_default_assembles_head_diff`; `test_tui_review_base_flag_validates_ref`; `test_tui_review_invalid_ref_emits_error_no_turn`
+- Primary target files: `src/app.rs`, `src/runtime/context_assembler.rs`, `src/prompts.rs`
+- Required scaffold/docs sync: `src/prompts/review_template.txt`, `docs/src/commands.md`
+- Supporting tests: `src/app.rs`, `tests/integration_test.rs`
 
 ## Other Open ADRs Tracked In This Repo
 

--- a/TASKS/TASKS-DISPATCH-MAP.md
+++ b/TASKS/TASKS-DISPATCH-MAP.md
@@ -32,7 +32,7 @@ Source of truth: `adr/ADR-README.md`.
 
 ```text
 PA-01 -> PJ-03
-EL-07 -> EL-08 -> EL-09
+EL-08 -> EL-09 -> EL-10 -> EL-11
 
 Milestone-1 gate:
 ADR-022 phases 1-8 + ADR-023 deterministic edit loop validated end-to-end
@@ -49,13 +49,13 @@ dispatch note is descriptive only and does not relax the milestone-1 gate.
 
 ## Current Next Dispatcher Batch
 
-`EL-08` is the current next batch, not the post-gate ADR-025 / ADR-026 track.
+`EL-10` is the current next batch, not the post-gate ADR-025 / ADR-026 track.
 
-- Scope: `ModelProfile` layered-config integration
-- Anchor test: `test_model_profile_loaded_from_layered_config`
-- Primary code files: `src/config.rs`, `src/app.rs`, `src/api/client.rs`
-- Required scaffold/docs sync: `src/bin/vex.rs`, `docs/src/configuration.md`
-- Supporting tests: `src/config.rs`, `tests/integration_test.rs`
+- Scope: `/review` command path and diff assembly
+- Anchor tests: `test_tui_review_default_assembles_head_diff`; `test_tui_review_base_flag_validates_ref`; `test_tui_review_invalid_ref_emits_error_no_turn`
+- Primary code files: `src/app.rs`, `src/runtime/context_assembler.rs`, `src/prompts.rs`
+- Required scaffold/docs sync: `src/prompts/review_template.txt`, `docs/src/commands.md`
+- Supporting tests: `src/app.rs`, `tests/integration_test.rs`
 
 ADR-027 supersedes the older ADR-018/019 managed-TUI direction and is the
 current reference for full-screen rendering and interactive command-session
@@ -68,5 +68,6 @@ capture behavior.
 - Update `TASKS/completed/REPO-RAW-URL-MAP.md` in the same change set when tracked files are added or removed.
 - Source ADR documents and task manifests remain the behavioral source of truth.
 - ADR-024 checklist reconciliation is current through merged PRs `#60`, `#63`,
-  `#71`, `#72`, `#74`, `#75`, and `#78`; `PK-08` is merged, but `EL-08`
-  remains ahead of the post-gate ADR-025 / ADR-026 track.
+  `#71`, `#72`, `#74`, `#75`, `#78`, and `#79`; `PK-08`, `EL-09`, and the
+  ADR-027 follow-up are merged, but `EL-10` remains ahead of the post-gate
+  ADR-025 / ADR-026 track.

--- a/scripts/check_forbidden_names.sh
+++ b/scripts/check_forbidden_names.sh
@@ -1,6 +1,150 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+PYTHON_BIN=""
+if command -v python3 >/dev/null 2>&1; then
+  PYTHON_BIN="python3"
+elif command -v python >/dev/null 2>&1; then
+  PYTHON_BIN="python"
+fi
+
+RG_BIN="${VEX_RG_BIN:-rg}"
+SCAN_BACKEND="rg"
+if [[ "$RG_BIN" == *"/"* || "$RG_BIN" == *"\\"* ]]; then
+  if [[ ! -x "$RG_BIN" ]]; then
+    echo "FAIL: ripgrep executable not found at $RG_BIN" >&2
+    exit 1
+  fi
+elif ! command -v "$RG_BIN" >/dev/null 2>&1; then
+  if command -v rg.exe >/dev/null 2>&1; then
+    RG_BIN="rg.exe"
+  elif [[ -n "$PYTHON_BIN" ]]; then
+    SCAN_BACKEND="python"
+  else
+    echo "FAIL: ripgrep executable not found (expected rg, rg.exe, or VEX_RG_BIN), and no python fallback is available" >&2
+    exit 1
+  fi
+fi
+
+scan_targets() {
+  local pattern="$1"
+  shift
+  if [[ "$SCAN_BACKEND" == "rg" ]]; then
+    "$RG_BIN" -n --hidden -i \
+      --glob '!.git' \
+      --glob '!.github/workflows/**' \
+      --glob '!scripts/check_forbidden_names.sh' \
+      "$pattern" "$@"
+    return
+  fi
+
+  "$PYTHON_BIN" - "$pattern" "$@" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+pattern = re.compile(sys.argv[1], re.IGNORECASE)
+roots = [Path(arg) for arg in sys.argv[2:]]
+matched = False
+
+for root in roots:
+    if not root.exists():
+        continue
+    paths = [root] if root.is_file() else [p for p in root.rglob("*") if p.is_file()]
+    for path in paths:
+        rel = path.as_posix()
+        if rel == "scripts/check_forbidden_names.sh":
+            continue
+        if rel.startswith(".git/") or rel.startswith(".github/workflows/"):
+            continue
+        try:
+            lines = path.read_text(encoding="utf-8", errors="ignore").splitlines()
+        except OSError as exc:
+            print(f"FAIL: unable to read {rel}: {exc}", file=sys.stderr)
+            sys.exit(2)
+        for line_number, line in enumerate(lines, start=1):
+            if pattern.search(line):
+                print(f"{rel}:{line_number}:{line}")
+                matched = True
+
+sys.exit(0 if matched else 1)
+PY
+}
+
+scan_workflows() {
+  if [[ "$SCAN_BACKEND" == "rg" ]]; then
+    "$RG_BIN" -n --hidden -i --glob '!.git' "$BRAND_PATTERN" .github/workflows/
+    return
+  fi
+
+  "$PYTHON_BIN" - "$BRAND_PATTERN" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+pattern = re.compile(sys.argv[1], re.IGNORECASE)
+root = Path(".github/workflows")
+matched = False
+
+for path in root.rglob("*"):
+    if not path.is_file():
+        continue
+    rel = path.as_posix()
+    try:
+        lines = path.read_text(encoding="utf-8", errors="ignore").splitlines()
+    except OSError as exc:
+        print(f"FAIL: unable to read {rel}: {exc}", file=sys.stderr)
+        sys.exit(2)
+    for line_number, line in enumerate(lines, start=1):
+        if pattern.search(line):
+            print(f"{rel}:{line_number}:{line}")
+            matched = True
+
+sys.exit(0 if matched else 1)
+PY
+}
+
+scan_path_names() {
+  local pattern="$1"
+  shift
+  if [[ -n "$PYTHON_BIN" ]]; then
+    "$PYTHON_BIN" - "$pattern" "$@" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+pattern = re.compile(sys.argv[1], re.IGNORECASE)
+roots = [Path(arg) for arg in sys.argv[2:]]
+matched = False
+
+for root in roots:
+    if not root.exists():
+        continue
+    paths = [root] if root.is_file() else [p for p in root.rglob("*") if p.is_file()]
+    for path in paths:
+        rel = path.as_posix()
+        if pattern.search(rel):
+            print(rel)
+            matched = True
+
+sys.exit(0 if matched else 1)
+PY
+    return
+  fi
+
+  local path_root
+  local matched=1
+  for path_root in "$@"; do
+    if [[ ! -d "$path_root" ]]; then
+      continue
+    fi
+    if find "$path_root" -type f -print | "$RG_BIN" -n -i "$pattern"; then
+      matched=0
+    fi
+  done
+  return "$matched"
+}
+
 # Keep this check scoped to proprietary/vendor-branded terms and
 # external repository-backed identifiers that are disallowed in
 # agent/workflow surfaces.
@@ -16,6 +160,9 @@ set -euo pipefail
 #   Pass 2 (BRAND_PATTERN): brand-name-only subset, *including* .github/workflows/**
 #           Ensures no proprietary assistant-brand names appear in workflow YAML even
 #           though action-reference patterns are excluded there.
+#   Pass 3 (PATH_PATTERN): brand-name subset over prompt/model file paths so
+#           branded fixture/template filenames are rejected even when file
+#           contents are generic.
 brand_words=(
   $'\x63\x6c\x61\x75\x64\x65'
   $'\x61\x6e\x74\x68\x72\x6f\x70\x69\x63'
@@ -60,17 +207,18 @@ fi
 failed=0
 
 # Pass 1: full pattern — .github/workflows/** excluded (.github non-workflow files still scanned)
-if rg -n --hidden -i \
-    --glob '!.git' \
-    --glob '!.github/workflows/**' \
-    --glob '!scripts/check_forbidden_names.sh' \
-    "$PATTERN" "${TARGETS[@]}"; then
+if scan_targets "$PATTERN" "${TARGETS[@]}"; then
   failed=1
 fi
 
 # Pass 2: brand names only — also covers .github/workflows/ (no AI brand names in CI YAML)
 if [[ -d .github/workflows ]] && \
-   rg -n --hidden -i --glob '!.git' "$BRAND_PATTERN" .github/workflows/; then
+   scan_workflows; then
+  failed=1
+fi
+
+# Pass 3: filenames in src/prompts/ and models/ must also stay generic.
+if scan_path_names "$BRAND_PATTERN" src/prompts models; then
   failed=1
 fi
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -10,6 +10,104 @@ mod test_support {
     pub static ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 }
 
+fn prepare_forbidden_names_fixture() -> tempfile::TempDir {
+    let temp = tempfile::tempdir().unwrap();
+    for dir in [
+        "TASKS",
+        "adr",
+        "docs/src",
+        "src/prompts",
+        "tests",
+        "scripts",
+        ".github/workflows",
+        "models",
+    ] {
+        std::fs::create_dir_all(temp.path().join(dir)).unwrap();
+    }
+    for file in [".gitignore", "AGENTS.md", "CONTRIBUTING.md", "Makefile"] {
+        std::fs::write(temp.path().join(file), "\n").unwrap();
+    }
+    temp
+}
+
+fn forbidden_names_shell() -> std::path::PathBuf {
+    if cfg!(windows) {
+        for var in ["ProgramW6432", "ProgramFiles", "ProgramFiles(x86)"] {
+            if let Some(root) = std::env::var_os(var) {
+                let root = std::path::PathBuf::from(root);
+                for candidate in [
+                    root.join("Git").join("bin").join("bash.exe"),
+                    root.join("Git").join("usr").join("bin").join("bash.exe"),
+                ] {
+                    if candidate.is_file() {
+                        return candidate;
+                    }
+                }
+            }
+        }
+    }
+
+    std::path::PathBuf::from("bash")
+}
+
+fn windows_ripgrep_binary() -> Option<std::path::PathBuf> {
+    if !cfg!(windows) {
+        return None;
+    }
+
+    if let Ok(output) = std::process::Command::new("where").arg("rg.exe").output() {
+        if output.status.success() {
+            if let Some(path) = String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .map(str::trim)
+                .find(|line| !line.is_empty())
+            {
+                return Some(std::path::PathBuf::from(path));
+            }
+        }
+    }
+
+    [
+        std::env::var_os("CARGO_HOME")
+            .map(std::path::PathBuf::from)
+            .map(|root| root.join("bin").join("rg.exe")),
+        std::env::var_os("USERPROFILE")
+            .map(std::path::PathBuf::from)
+            .map(|root| root.join(".cargo").join("bin").join("rg.exe")),
+    ]
+    .into_iter()
+    .flatten()
+    .find(|path| path.is_file())
+}
+
+fn run_forbidden_names_check(repo_root: &std::path::Path) -> std::process::Output {
+    let script = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("scripts/check_forbidden_names.sh");
+    let mut command = std::process::Command::new(forbidden_names_shell());
+    command.arg(script).current_dir(repo_root);
+
+    if let Some(rg_binary) = windows_ripgrep_binary() {
+        command.env("VEX_RG_BIN", rg_binary.to_string_lossy().replace('\\', "/"));
+    }
+
+    command.output().unwrap()
+}
+
+fn forbidden_prompt_content() -> String {
+    String::from_utf8(vec![
+        0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2d, 0x62, 0x72, 0x61, 0x6e, 0x64, 0x65, 0x64, 0x20,
+        0x70, 0x72, 0x6f, 0x6d, 0x70, 0x74, 0x20, 0x74, 0x65, 0x78, 0x74, 0x0a,
+    ])
+    .unwrap()
+}
+
+fn forbidden_model_filename() -> String {
+    String::from_utf8(vec![
+        0x71, 0x77, 0x65, 0x6e, 0x2d, 0x63, 0x6f, 0x64, 0x65, 0x72, 0x2e, 0x74, 0x6f, 0x6d, 0x6c,
+    ])
+    .unwrap()
+}
+
 #[test]
 fn test_config_validation_rejects_local_model_for_remote_endpoint() {
     let config = Config {
@@ -151,6 +249,59 @@ fn test_config_rejects_unknown_toml_keys() {
     assert!(
         msg.contains("user.toml"),
         "expected file name in error: {msg}"
+    );
+}
+
+#[test]
+fn check_forbidden_names_sh_blocks_proprietary_name_in_prompts_dir() {
+    let temp = prepare_forbidden_names_fixture();
+    std::fs::write(
+        temp.path().join("src/prompts/coder_system.txt"),
+        forbidden_prompt_content(),
+    )
+    .unwrap();
+
+    let output = run_forbidden_names_check(temp.path());
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        !output.status.success(),
+        "expected forbidden-name check to fail for prompt content: {text}"
+    );
+    assert!(
+        text.contains("src/prompts/coder_system.txt"),
+        "expected prompt path in output: {text}"
+    );
+}
+
+#[test]
+fn check_forbidden_names_sh_blocks_proprietary_name_in_model_filename() {
+    let temp = prepare_forbidden_names_fixture();
+    let forbidden_filename = forbidden_model_filename();
+    std::fs::write(
+        temp.path().join("models").join(&forbidden_filename),
+        "name = \"api-structured\"\n",
+    )
+    .unwrap();
+
+    let output = run_forbidden_names_check(temp.path());
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        !output.status.success(),
+        "expected forbidden-name check to fail for model filename: {text}"
+    );
+    assert!(
+        text.contains(&format!("models/{forbidden_filename}")),
+        "expected model path in output: {text}"
     );
 }
 


### PR DESCRIPTION
## Summary
- add EL-09 forbidden-name coverage to `scripts/check_forbidden_names.sh`, including Windows-safe path scanning for banned prompt/model names
- add integration coverage for forbidden prompt content and forbidden model filenames
- advance `AGENTS.md` and dispatcher task maps so the next handoff becomes EL-10

## Verification
- `bash scripts/check_forbidden_names.sh`
- `bash scripts/check_no_alternate_routing.sh`
- `bash scripts/check_forbidden_imports.sh`
- `cargo test --all-targets`