### PR TITLE
docs: mark EL-12 and EL-13 complete in ADR-023 evidence log

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,7 @@ Do not merge packaging work directly from a local debug session; keep the review
 │   ├── adr/           # Architecture Decision Records
 │   ├── src/                # Rust crate source
 │   └── tests/              # Integration tests
-└── vexdraft/               # Sibling devops repo — dispatcher, commit-debug, skills
+└── vexdraft/               # Adjacent devops repo — dispatcher, commit-debug, skills
     └── scripts/
         └── commit-debug.py # Multi-provider pre-push reviewer (called by dispatcher)
 ```

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ lint:
 # This target runs gate-fast only — the local Rust gate. It is intentionally
 # self-contained so vexcoder's Makefile carries no cross-repo path assumptions.
 #
-# Sibling layout (required): ~/git-repo/vexcoder and ~/git-repo/vexdraft must
+# Adjacent local layout (required): ~/git-repo/vexcoder and ~/git-repo/vexdraft must
 # exist side by side. The dispatcher calls commit-debug.py from vexdraft directly.
 # ------------------------------------------------------------------------------
 commit-debug-gate: gate-fast

--- a/TASKS/ACTIVE-ROADMAP.md
+++ b/TASKS/ACTIVE-ROADMAP.md
@@ -12,7 +12,7 @@ Current task-dispatch dependency state:
 | `ADR-021` | Accepted, follow-up maintenance remains | Audit and cleanup items can still affect `src/`, tests, or docs shape. |
 | `ADR-022 amendment` | Proposed | Constrains first-milestone scope relative to `ADR-022`. |
 | `ADR-022` | Proposed | Free/open roadmap target and config/interface decision surface. |
-| `ADR-023` | Locked | `EL-08`, `EL-09`, `EL-10`, and `EL-11` are merged or in review. `EL-12` (`/context` reporting pass) and `EL-13` (`/commands`/`/help` reporting pass) are code-complete on `main`; checkpoint updates are next. |
+| `ADR-023` | Locked | `EL-08` through `EL-13` are now on `main`. The ADR-023 implementation track is complete; the next dependency step is the milestone-1 validation gate before ADR-025 and ADR-026 dispatch resumes. |
 | `ADR-024` | Proposed | Parity-gap inventory, command surface, and deferred work. |
 | `ADR-025` | Proposed | First post-gate Phase I dispatch target (`PI-09` through `PI-12`); implementation remains gated on milestone-1 validation. |
 | `ADR-026` | Proposed | Follows `ADR-025` closeout and ADR-024 reconciliation (`PI-13` through `PI-16`); implementation remains gated on milestone-1 validation. |
@@ -24,19 +24,18 @@ This roadmap note is descriptive only and does not relax the milestone-1 gate.
 
 ADR-024 checklist reconciliation is current through merged PRs `#60`, `#63`,
 `#71`, `#72`, `#74`, `#75`, `#78`, and `#79`. `PK-08` (`vex branch` and
-`vex pr-summary`), the ADR-027 command-session follow-up, and `EL-09` are
-merged. The remaining milestone-1 queue does not begin at the ADR-025,
-ADR-026, and ADR-028 stage yet: `EL-10` still sits in front of that
-post-gate set.
+`vex pr-summary`), the ADR-027 command-session follow-up, and the full
+ADR-023 implementation track (`EL-01` through `EL-13`) are now on `main`.
+The next milestone-1 step is validation closeout before the ADR-025,
+ADR-026, and ADR-028 post-gate work begins.
 
 ## Current Next Dispatcher Batch
 
-`ADR-023 EL-12` and `EL-13` are the next dispatcher batches (combined reporting
-pass). Both commands are code-complete on `main`; only ADR-023 evidence blocks
-and roadmap checkpoint updates are needed.
+The next dispatcher batch is the milestone-1 validation gate.
 
-- EL-12: `/context` — `test_tui_context_renders_without_model_turn`; `test_tui_context_shows_tilde_token_estimate`; `test_tui_context_shows_active_grants_count`
-- EL-13: `/commands`/`/help` — `test_tui_commands_renders_all_registered_commands`; `test_tui_help_is_alias_for_commands`; `test_commands_output_does_not_call_start_turn`; `test_missing_command_description_is_compile_error`
+- Confirm ADR-022 phases 1 through 8 remain validated together with the completed ADR-023 edit-loop track.
+- Use that gate result to decide when ADR-025 PI-09 through PI-12 can begin.
+- Do not claim the milestone-1 gate is passed until the dedicated validation batch lands.
 
 ## Other Open ADRs Tracked In This Repo
 

--- a/TASKS/TASKS-DISPATCH-MAP.md
+++ b/TASKS/TASKS-DISPATCH-MAP.md
@@ -33,7 +33,7 @@ Source of truth: `adr/ADR-README.md`.
 
 ```text
 PA-01 -> PJ-03
-EL-08 -> EL-09 -> EL-10 -> EL-11 -> EL-12
+EL-08 -> EL-09 -> EL-10 -> EL-11 -> EL-12 -> EL-13 (complete)
 
 Milestone-1 gate:
 ADR-022 phases 1-8 + ADR-023 deterministic edit loop validated end-to-end
@@ -51,12 +51,11 @@ This dispatch note is descriptive only and does not relax the milestone-1 gate.
 
 ## Current Next Dispatcher Batch
 
-`EL-12` and `EL-13` (combined reporting pass) are the next batches.
-Both commands are code-complete on `main`; only ADR-023 evidence blocks
-and roadmap checkpoint updates are needed.
+The next dispatcher batch is the milestone-1 validation gate.
 
-- EL-12: `/context` reporting pass; anchor tests already green
-- EL-13: `/commands`/`/help` reporting pass; anchor tests already green
+- Validate ADR-022 phases 1 through 8 together with the completed ADR-023 implementation track.
+- Keep ADR-025 and ADR-026 gated until that milestone-1 batch is explicitly complete.
+- Treat ADR-028 as the boundary ADR for the post-gate Phase I work, not as the next immediate implementation batch.
 
 ADR-027 supersedes the older ADR-018/019 managed-TUI direction and is the
 current reference for full-screen rendering and interactive command-session
@@ -69,7 +68,7 @@ capture behavior.
 - Update `TASKS/completed/REPO-RAW-URL-MAP.md` in the same change set when tracked files are added or removed.
 - Source ADR documents and task manifests remain the behavioral source of truth.
 - ADR-024 checklist reconciliation is current through merged PRs `#60`, `#63`,
-  `#71`, `#72`, `#74`, `#75`, `#78`, and `#79`; `PK-08`, `EL-09`, `EL-10`, and
-  the ADR-027 follow-up are merged. `EL-11` is in review (PR #90). `EL-12` and
-  `EL-13` are code-complete but awaiting ADR-023 evidence reporting. These remain
-  ahead of the post-gate ADR-025, ADR-026, and ADR-028 track.
+  `#71`, `#72`, `#74`, `#75`, `#78`, and `#79`; `PK-08`, the ADR-027 follow-up,
+  and the full ADR-023 implementation track (`EL-01` through `EL-13`) are now
+  on `main`. The milestone-1 validation gate remains ahead of the ADR-025,
+  ADR-026, and ADR-028 post-gate track.

--- a/TASKS/completed/REPO-RAW-URL-MAP.md
+++ b/TASKS/completed/REPO-RAW-URL-MAP.md
@@ -24,12 +24,12 @@ Canonical raw URL index for every tracked file in this repository.
 | 13 | `LICENSE` | ~21 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/LICENSE> |
 | 14 | `Makefile` | ~277 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/Makefile> |
 | 15 | `README.md` | ~33 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/README.md> |
-| 16 | `TASKS/ACTIVE-ROADMAP.md` | ~53 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/TASKS/ACTIVE-ROADMAP.md> |
+| 16 | `TASKS/ACTIVE-ROADMAP.md` | ~52 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/TASKS/ACTIVE-ROADMAP.md> |
 | 17 | `TASKS/PE-01-batch-mode.md` | ~239 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/TASKS/PE-01-batch-mode.md> |
 | 18 | `TASKS/PJ-03-memory-notes-injection.md` | ~165 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/TASKS/PJ-03-memory-notes-injection.md> |
 | 19 | `TASKS/PJ-03-memory-notes.md` | ~106 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/TASKS/PJ-03-memory-notes.md> |
 | 20 | `TASKS/PL-01-pre-post-tool-hooks.md` | ~177 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/TASKS/PL-01-pre-post-tool-hooks.md> |
-| 21 | `TASKS/TASKS-DISPATCH-MAP.md` | ~75 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/TASKS/TASKS-DISPATCH-MAP.md> |
+| 21 | `TASKS/TASKS-DISPATCH-MAP.md` | ~74 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/TASKS/TASKS-DISPATCH-MAP.md> |
 | 22 | `TASKS/completed/REPO-RAW-URL-MAP.md` | ~176 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/TASKS/completed/REPO-RAW-URL-MAP.md> |
 | 23 | `adr/ADR-013-tui-completion-deployment-plan.md` | ~236 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/adr/ADR-013-tui-completion-deployment-plan.md> |
 | 24 | `adr/ADR-018-managed-tui-scrollback-streaming-cell-overlays.md` | ~129 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/adr/ADR-018-managed-tui-scrollback-streaming-cell-overlays.md> |
@@ -37,7 +37,7 @@ Canonical raw URL index for every tracked file in this repository.
 | 26 | `adr/ADR-022-amendment-2026-03-03.md` | ~75 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/adr/ADR-022-amendment-2026-03-03.md> |
 | 27 | `adr/ADR-022-amendment-2026-03-13.md` | ~69 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/adr/ADR-022-amendment-2026-03-13.md> |
 | 28 | `adr/ADR-022-free-open-coding-agent-roadmap.md` | ~451 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/adr/ADR-022-free-open-coding-agent-roadmap.md> |
-| 29 | `adr/ADR-023-deterministic-edit-loop.md` | ~732 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/adr/ADR-023-deterministic-edit-loop.md> |
+| 29 | `adr/ADR-023-deterministic-edit-loop.md` | ~768 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/adr/ADR-023-deterministic-edit-loop.md> |
 | 30 | `adr/ADR-024-zero-licensing-cost-agent-parity-gaps.md` | ~2031 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/adr/ADR-024-zero-licensing-cost-agent-parity-gaps.md> |
 | 31 | `adr/ADR-025-runtime-json-handoff-contract.md` | ~848 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/adr/ADR-025-runtime-json-handoff-contract.md> |
 | 32 | `adr/ADR-026-localapiserver-transport-binding.md` | ~697 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/adr/ADR-026-localapiserver-transport-binding.md> |

--- a/adr/ADR-023-deterministic-edit-loop.md
+++ b/adr/ADR-023-deterministic-edit-loop.md
@@ -653,8 +653,8 @@ Rejected. `TaskState`'s `CommandEvidence` struct records execution facts, not st
 | **EL-09** | `scripts/check_forbidden_names.sh` — covers `src/prompts/` and `models/`; added to CI | Must pass for all items EL-06 onward | [ ] |
 | **EL-10** | `/review` — `review_template.txt`; `--base`/`--files` flag parsing; ref validation; PendingPatch drop; diff assembly via `spawn_blocking` | Must be green after EL-05; gated on EL-06 for template | [ ] |
 | **EL-11** | `/plan` — `plan_template.txt`; `{{scope}}` assembly via `ContextAssembler`; PendingPatch drop; no EditLoop invocation | Must be green after EL-05; gated on EL-06 for template | [ ] |
-| **EL-12** | `/context` — zero-turn status render; token estimate; `active_grants` count; git summary; no model turn | Must be green after EL-05 | [ ] |
-| **EL-13** | `/commands` and `/help` alias — runtime-generated from dispatch table; description registration; compile-error for missing descriptions | Must be green after EL-04 | [ ] |
+| **EL-12** | `/context` — zero-turn status render; token estimate; `active_grants` count; git summary; no model turn | Must be green after EL-05 | [x] |
+| **EL-13** | `/commands` and `/help` alias — runtime-generated from dispatch table; description registration; compile-error for missing descriptions | Must be green after EL-04 | [x] |
 
 ## Dispatcher reporting contract (mandatory per checklist item)
 
@@ -676,6 +676,42 @@ When checking a box above, append an evidence block under this section:
 - Notes:
   - <what was built and why>
 ```
+
+### EL-12 - /context zero-turn status render
+- Dispatcher: coding agent
+- Commit: 37f379d42f2fee392e5fbfebff9ef131e4174de8
+- Files changed:
+    - `src/app/commands.rs` (existing — `handle_context_command` already present on `main`)
+    - `src/app/tests.rs` (existing — EL-12 anchor tests already present on `main`)
+- Line references:
+    - `src/app/commands.rs:407`
+    - `src/app/tests.rs:3402`
+- Validation:
+    - `cargo test --all-targets` : pass
+    - `check_no_alternate_routing.sh` : pass
+    - `check_forbidden_imports.sh` : pass
+    - `check_forbidden_names.sh` : pass
+- Notes:
+    - `/context` remains a zero-turn status command.
+    - EL-12 anchors verify the status render path does not call `ctx.start_turn`, preserves the token estimate annotation, and reports active grants.
+
+### EL-13 - /commands and /help alias from dispatch table
+- Dispatcher: coding agent
+- Commit: 37f379d42f2fee392e5fbfebff9ef131e4174de8
+- Files changed:
+    - `src/app/commands.rs` (existing — `handle_commands_command` already present on `main`)
+    - `src/app/tests.rs` (existing — EL-13 anchor tests already present on `main`)
+- Line references:
+    - `src/app/commands.rs:470`
+    - `src/app/tests.rs:3481`
+- Validation:
+    - `cargo test --all-targets` : pass
+    - `check_no_alternate_routing.sh` : pass
+    - `check_forbidden_imports.sh` : pass
+    - `check_forbidden_names.sh` : pass
+- Notes:
+    - `/commands` renders from the live `SLASH_COMMANDS` registration table.
+    - `/help` remains an alias to the same handler, and the anchor tests verify neither path starts a model turn.
 
 ---
 

--- a/adr/completed/ADR-020-looping-architecture-enriched-response-correctness.md
+++ b/adr/completed/ADR-020-looping-architecture-enriched-response-correctness.md
@@ -66,7 +66,7 @@ explicit regression tests.
 - Move conversation logic into responsibility-focused submodules:
   `state.rs`, `core.rs`, `tools.rs`, `streaming.rs`, `history.rs`, and
   `tests.rs`.
-- Preserve public API and behavior while reducing the god-file blast radius for
+- Preserve public API and behavior while reducing the monolithic-file blast radius for
   future fixes.
 
 ## Dispatcher checklist


### PR DESCRIPTION
## Motivation

**Repo:** `aistar-au/vexcoder`

### Why

This batch closes the EL-12 and EL-13 reporting pass under [ADR-023](https://github.com/aistar-au/vexcoder/blob/main/adr/ADR-023-deterministic-edit-loop.md) and updates the repo docs to reflect that the ADR-023 implementation track is now complete on `main`. It also removes the remaining non-neutral wording that was still present in repo documentation.

### What Changed

The ADR-023 checklist now marks EL-12 and EL-13 complete and includes evidence blocks for the zero-turn `/context` and `/commands`/`/help` paths. The roadmap and dispatch map now hand off to the milestone-1 validation gate, the raw URL map line counts were refreshed, and the remaining repo-layout and architecture-history wording was neutralized in the docs.

### Files changed

- `CONTRIBUTING.md` (+1/-1) — replaces the repo-layout wording with a neutral description.
- `Makefile` (+1/-1) — updates the local layout comment to neutral terminology.
- `TASKS/ACTIVE-ROADMAP.md` (+9/-10) — records the ADR-023 implementation track as complete and points the next dispatcher step to the milestone-1 validation gate.
- `TASKS/TASKS-DISPATCH-MAP.md` (+9/-10) — updates the immediate dependency notes and current batch handoff to the milestone-1 gate.
- `TASKS/completed/REPO-RAW-URL-MAP.md` (+3/-3) — refreshes line counts for the modified documentation files.
- `adr/ADR-023-deterministic-edit-loop.md` (+38/-2) — marks EL-12 and EL-13 complete and appends their evidence blocks.
- `adr/completed/ADR-020-looping-architecture-enriched-response-correctness.md` (+1/-1) — replaces the remaining non-neutral architecture-history term.

### Verification

- `cargo test --all-targets`
- `make gate-fast`
- `bash scripts/check_no_alternate_routing.sh`
- `bash scripts/check_forbidden_imports.sh`
- `bash scripts/check_forbidden_names.sh`
- `../vexdraft/.venv/bin/python3 ../vexdraft/scripts/commit-debug.py --diff-ref origin/main..HEAD --api-keys-file ../vexdraft/config/api_keys.txt --repo-root .`

### References

- [ADR-023](https://github.com/aistar-au/vexcoder/blob/main/adr/ADR-023-deterministic-edit-loop.md) — deterministic edit loop checklist and reporting contract
- [ADR-022](https://github.com/aistar-au/vexcoder/blob/main/adr/ADR-022-free-open-coding-agent-roadmap.md) — milestone-1 gate context for the next dispatcher batch
