### PR TITLE
docs: replace non-neutral wording sibling with peer

### DIFF
--- a/adr/ADR-029-stream-parser-completeness-and-session-persistence.md
+++ b/adr/ADR-029-stream-parser-completeness-and-session-persistence.md
@@ -179,7 +179,7 @@ This field is present in the protocol when `stop_reason` is `"stop_sequence"`
 and carries the exact sequence that terminated the generation.
 
 **Critical wire-format fix:** The messages v1 `message_delta` event carries
-`usage` as a **top-level sibling** of `delta`, not nested inside the `delta`
+`usage` as a **top-level peer** of `delta`, not nested inside the `delta`
 object. The `StreamEvent::MessageDelta` variant must therefore carry `usage`
 at the variant level:
 

--- a/src/types/api_types.rs
+++ b/src/types/api_types.rs
@@ -332,7 +332,7 @@ mod tests {
 
     #[test]
     fn test_message_delta_event_top_level_usage_deserialises() {
-        // Messages v1 wire format: usage is a sibling of delta, not nested inside it
+        // Messages v1 wire format: usage is a peer of delta, not nested inside it
         let json = r#"{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":15}}"#;
         let evt: StreamEvent = serde_json::from_str(json).unwrap();
         match evt {


### PR DESCRIPTION
## Summary
- Replace "sibling" with "peer" in ADR-029 and `api_types.rs` test comment
- "sibling" is not a standard Rust or git term; "peer" is the neutral alternative

## Test plan
- [x] `cargo test` passes (no code logic change, only doc/comment wording)
- [x] `cargo fmt --all` clean
- [x] Grep confirms no remaining "sibling" occurrences

Generated with AI-assisted development tooling