### PR TITLE
feat: persistent four-region TUI layout (ADR-031 Batch A/B)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,7 @@ for the broader open-ADR list.
 | ADR-028 | Active | Phase 1 / Phase 2 facade extraction and 2026-03-17 debug fixes are in the current tree; remaining work continues to shrink `src/app.rs` and harden facade/transport seams. |
 | ADR-029 | Proposed | Defines stream parser completeness across `messages-v1` and `chat-compat`, including metadata retention for usage, chunk, choice, and tool-call fields plus task-state plan/note/cache persistence. |
 | ADR-030 | Active | Defines the task-state-owned orchestrator model so provider events normalize into runtime events, task state remains the source of truth, and command-session lifetime stays runtime-owned. |
-| ADR-031 | Proposed | Defines the timeline-driven operator surface overhaul, merge-gated UI batch ordering, and task-state-first selection/inspector behavior layered on ADR-030. |
+| ADR-031 | Active | Defines the timeline-driven operator surface overhaul, merge-gated UI batch ordering, and task-state-first selection/inspector behavior layered on ADR-030. Batch A/B core implemented: persistent four-region layout, last-turn data preservation, enriched paragraph rendering in the output pane. |
 
 ## Verification baseline
 

--- a/adr/ADR-031-operator-surface-ui-overhaul.md
+++ b/adr/ADR-031-operator-surface-ui-overhaul.md
@@ -1,6 +1,6 @@
 # ADR-031: Operator Surface UI Overhaul
 
-- **Status:** Proposed
+- **Status:** Active
 - **Date:** 2026-03-18
 - **Deciders:** Core maintainer
 - **Depends on:** ADR-022, ADR-027, ADR-028, ADR-030

--- a/src/app.rs
+++ b/src/app.rs
@@ -576,6 +576,12 @@ pub struct TuiMode {
     pending_turn_tool_calls: std::collections::HashMap<String, PendingTurnToolCall>,
     /// Index of the currently selected timeline entry in the activity pane.
     selected_timeline_index: usize,
+    /// Last completed turn's tool invocations (kept for persistent display).
+    last_turn_tool_invocations: Vec<ToolInvocationSummary>,
+    /// Last completed turn's response text (kept for persistent display).
+    last_turn_response: String,
+    /// Last completed turn's input text (kept for persistent display).
+    last_turn_input_display: String,
     #[cfg(test)]
     pub last_turn_input: Option<String>,
 }

--- a/src/app/accessors.rs
+++ b/src/app/accessors.rs
@@ -106,12 +106,29 @@ impl TuiMode {
         if !self.command_sessions.is_empty() {
             return self.command_sessions.len().max(1);
         }
+
+        // Use current turn data if available, otherwise fall back to last turn.
+        let (input_text, tool_count) = if self.history_state.turn_in_progress
+            || !self.current_turn_input.trim().is_empty()
+            || !self.current_turn_tool_invocations.is_empty()
+            || !self.pending_turn_tool_calls.is_empty()
+        {
+            (
+                &self.current_turn_input,
+                self.current_turn_tool_invocations.len() + self.pending_turn_tool_calls.len(),
+            )
+        } else {
+            (
+                &self.last_turn_input_display,
+                self.last_turn_tool_invocations.len(),
+            )
+        };
+
         let mut count = 0;
-        if !self.current_turn_input.trim().is_empty() {
+        if !input_text.trim().is_empty() {
             count += 1;
         }
-        count += self.current_turn_tool_invocations.len();
-        count += self.pending_turn_tool_calls.len();
+        count += tool_count;
         count.max(1)
     }
 }

--- a/src/app/ctor.rs
+++ b/src/app/ctor.rs
@@ -43,6 +43,9 @@ impl TuiMode {
             current_turn_tool_invocations: Vec::new(),
             pending_turn_tool_calls: std::collections::HashMap::new(),
             selected_timeline_index: 0,
+            last_turn_tool_invocations: Vec::new(),
+            last_turn_response: String::new(),
+            last_turn_input_display: String::new(),
             #[cfg(test)]
             last_turn_input: None,
         }

--- a/src/app/layout.rs
+++ b/src/app/layout.rs
@@ -28,6 +28,9 @@ impl TuiMode {
     /// Each entry carries lifecycle, label, and inspector detail so the
     /// renderer can highlight the selected step and show its content in
     /// the output/inspector pane.
+    ///
+    /// When no turn is in progress, entries are derived from the last
+    /// completed turn so the four-region layout remains populated.
     fn task_timeline_entries(&self) -> Vec<TimelineEntry> {
         let mut entries = Vec::new();
 
@@ -52,17 +55,37 @@ impl TuiMode {
             return entries;
         }
 
+        // Determine which turn data to display: current (in-progress) or
+        // last completed turn for persistent display.
+        let (input_text, tool_invocations, has_pending) = if self.history_state.turn_in_progress
+            || !self.current_turn_input.trim().is_empty()
+            || !self.current_turn_tool_invocations.is_empty()
+            || !self.pending_turn_tool_calls.is_empty()
+        {
+            (
+                &self.current_turn_input,
+                &self.current_turn_tool_invocations,
+                true,
+            )
+        } else {
+            (
+                &self.last_turn_input_display,
+                &self.last_turn_tool_invocations,
+                false,
+            )
+        };
+
         // User input echo.
-        if !self.current_turn_input.trim().is_empty() {
+        if !input_text.trim().is_empty() {
             entries.push(TimelineEntry {
                 lifecycle: StepLifecycle::UserInput,
-                label: self.current_turn_input.clone(),
-                detail: self.current_turn_input.clone(),
+                label: input_text.clone(),
+                detail: input_text.clone(),
             });
         }
 
         // Completed tool invocations — derived from canonical task state.
-        for invocation in &self.current_turn_tool_invocations {
+        for invocation in tool_invocations {
             let is_error = invocation.outcome.starts_with("error")
                 || invocation.outcome.starts_with("failed")
                 || invocation.outcome.starts_with("Error");
@@ -79,17 +102,19 @@ impl TuiMode {
 
         // In-flight tool calls from pending_turn_tool_calls (task-state owned).
         // Sort by key for stable iteration order across frames.
-        let mut pending_keys: Vec<&String> = self.pending_turn_tool_calls.keys().collect();
-        pending_keys.sort();
-        for key in pending_keys {
-            let pending = &self.pending_turn_tool_calls[key];
-            let input_preview = serde_json::to_string_pretty(&pending.input)
-                .unwrap_or_else(|_| pending.input.to_string());
-            entries.push(TimelineEntry {
-                lifecycle: StepLifecycle::Running,
-                label: format!("{}: running...", pending.name),
-                detail: format!("Tool: {}\nInput:\n{}", pending.name, input_preview),
-            });
+        if has_pending {
+            let mut pending_keys: Vec<&String> = self.pending_turn_tool_calls.keys().collect();
+            pending_keys.sort();
+            for key in pending_keys {
+                let pending = &self.pending_turn_tool_calls[key];
+                let input_preview = serde_json::to_string_pretty(&pending.input)
+                    .unwrap_or_else(|_| pending.input.to_string());
+                entries.push(TimelineEntry {
+                    lifecycle: StepLifecycle::Running,
+                    label: format!("{}: running...", pending.name),
+                    detail: format!("Tool: {}\nInput:\n{}", pending.name, input_preview),
+                });
+            }
         }
 
         entries
@@ -109,14 +134,38 @@ impl TuiMode {
 
         let mut rows = Vec::new();
 
-        // Prompt prefix for the current turn input.
-        if !self.current_turn_input.trim().is_empty() {
-            rows.push(format!("> {}", self.current_turn_input));
+        // Determine source: current turn or last completed turn.
+        let (input_text, tool_invocations) = if self.history_state.turn_in_progress
+            || !self.current_turn_input.trim().is_empty()
+            || !self.current_turn_tool_invocations.is_empty()
+            || !self.pending_turn_tool_calls.is_empty()
+        {
+            (
+                &self.current_turn_input,
+                &self.current_turn_tool_invocations,
+            )
+        } else if !self.last_turn_tool_invocations.is_empty()
+            || !self.last_turn_input_display.is_empty()
+        {
+            (
+                &self.last_turn_input_display,
+                &self.last_turn_tool_invocations,
+            )
+        } else {
+            (
+                &self.current_turn_input,
+                &self.current_turn_tool_invocations,
+            )
+        };
+
+        // Prompt prefix for the turn input.
+        if !input_text.trim().is_empty() {
+            rows.push(format!("> {}", input_text));
         }
 
         // Completed tool invocations — prefixed to match render_task_layout
         // style markers ([ok] / [!]).
-        for invocation in &self.current_turn_tool_invocations {
+        for invocation in tool_invocations {
             let prefix = if invocation.outcome.starts_with("error")
                 || invocation.outcome.starts_with("failed")
                 || invocation.outcome.starts_with("Error")
@@ -164,9 +213,15 @@ impl TuiMode {
             .collect()
     }
 
-    /// Derive output/inspector rows. When the timeline has a selected tool
-    /// step, the inspector detail for that step is shown; otherwise falls
-    /// back to current turn response or history tail.
+    /// Derive output/inspector rows for the output pane.
+    ///
+    /// Rendering strategy:
+    /// - During an active turn with timeline entries: inspector detail for the
+    ///   selected tool step, with streaming model response appended below.
+    /// - During an active turn without tool steps: streaming model response.
+    /// - After a completed turn: enriched paragraph view showing each tool
+    ///   invocation as a paragraph followed by the model response.
+    /// - Before any turn: welcome hint.
     fn task_output_rows(&self) -> Vec<String> {
         // If timeline has entries and a valid selection on a tool step
         // (not user input), show inspector detail.
@@ -205,22 +260,70 @@ impl TuiMode {
             return rows;
         }
 
-        self.history_state
-            .lines
-            .iter()
-            .rev()
-            .take(24)
-            .cloned()
-            .collect::<Vec<_>>()
-            .into_iter()
-            .rev()
-            .collect()
+        // After turn completes: show enriched paragraph view with tool
+        // invocations and model response from the last completed turn.
+        if !self.last_turn_tool_invocations.is_empty() || !self.last_turn_response.is_empty() {
+            return self.enriched_paragraph_rows();
+        }
+
+        // No turn data yet — show a welcome hint.
+        vec![
+            "Type a prompt below to begin.".to_string(),
+            String::new(),
+            "The orchestrator will call tools and stream results here.".to_string(),
+        ]
+    }
+
+    /// Build enriched paragraph rows from the last completed turn.
+    ///
+    /// Each tool invocation is rendered as a short paragraph:
+    ///   tool_name outcome
+    ///
+    /// Followed by the model response text.
+    fn enriched_paragraph_rows(&self) -> Vec<String> {
+        let mut rows = Vec::new();
+
+        for invocation in &self.last_turn_tool_invocations {
+            if !rows.is_empty() {
+                rows.push(String::new());
+            }
+            let status = if invocation.outcome.starts_with("error")
+                || invocation.outcome.starts_with("failed")
+                || invocation.outcome.starts_with("Error")
+            {
+                "[!]"
+            } else {
+                "[ok]"
+            };
+            rows.push(format!("{} {}", status, invocation.name));
+            // Wrap outcome text as a paragraph.
+            for line in invocation.outcome.lines() {
+                rows.push(format!("    {}", line));
+            }
+        }
+
+        if !self.last_turn_response.is_empty() {
+            if !rows.is_empty() {
+                rows.push(String::new());
+            }
+            for line in self.last_turn_response.lines() {
+                rows.push(line.to_string());
+            }
+        }
+
+        if rows.is_empty() {
+            rows.push("Turn completed.".to_string());
+        }
+
+        rows
     }
 
     pub fn task_layout_state(&self) -> Option<TaskLayoutState> {
-        if !self.history_state.turn_in_progress && !self.overlay_active() {
-            return None;
-        }
+        // Always return the four-region layout. The task-state control surface
+        // is persistent — it is never yielded back to the transcript-only
+        // three-pane view between tool calls or after a turn completes.
+        // This follows ADR-031: the operator surface derives from canonical
+        // task state and remains visible at all times.
 
         let pending_approval = if self.overlay_state.pending_patch_approval.is_some() {
             Some("ApplyPatch".to_string())

--- a/src/app/turn.rs
+++ b/src/app/turn.rs
@@ -14,6 +14,7 @@ impl TuiMode {
         self.last_assembled_context = None;
         self.read_only_turn_active = false;
         self.reset_turn_capture();
+        self.reset_last_turn_display();
     }
 
     pub(super) fn apply_resumed_task(&mut self, state: TaskState, ctx: &RuntimeContext) {
@@ -39,6 +40,12 @@ impl TuiMode {
         self.current_turn_tool_invocations.clear();
         self.pending_turn_tool_calls.clear();
         self.selected_timeline_index = 0;
+    }
+
+    pub(super) fn reset_last_turn_display(&mut self) {
+        self.last_turn_tool_invocations.clear();
+        self.last_turn_response.clear();
+        self.last_turn_input_display.clear();
     }
 
     pub(super) fn begin_turn_capture(&mut self, input: String) {
@@ -84,6 +91,11 @@ impl TuiMode {
             self.reset_turn_capture();
             return;
         }
+
+        // Preserve turn data for persistent display after the turn completes.
+        self.last_turn_tool_invocations = self.current_turn_tool_invocations.clone();
+        self.last_turn_response = self.current_turn_response.clone();
+        self.last_turn_input_display = self.current_turn_input.clone();
 
         let changed_files = self
             .current_turn_changed_files

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -651,13 +651,54 @@ impl TaskDraw {
             }
             let row = regions.output_start + 1 + vp_offset as u16;
             move_to(w, row, 0);
-            set_fg(w, GRAY);
-            let truncated = truncate_to_width(line, regions.cols as usize);
-            let _ = write!(w, "{truncated}");
-            reset_style(w);
+            self.draw_output_line(w, line, regions.cols);
         }
 
         self.output_lines_flushed = state.output_rows.len();
+    }
+
+    /// Render a single output line with paragraph-aware styling.
+    ///
+    /// Lines starting with `[ok]` or `[!]` get tool-result colors.
+    /// Lines starting with four spaces are indented detail text.
+    /// Separator lines (`---`) are dimmed.
+    fn draw_output_line<W: Write>(&self, w: &mut W, line: &str, cols: u16) {
+        if let Some(rest) = line.strip_prefix("[ok] ") {
+            set_bold(w);
+            set_fg(w, GREEN);
+            let _ = write!(w, "[ok] ");
+            reset_style(w);
+            set_fg(w, WHITE);
+            let truncated = truncate_to_width(rest, (cols as usize).saturating_sub(5));
+            let _ = write!(w, "{truncated}");
+            reset_style(w);
+        } else if let Some(rest) = line.strip_prefix("[!] ") {
+            set_bold(w);
+            set_fg(w, RED);
+            let _ = write!(w, "[!] ");
+            reset_style(w);
+            set_fg(w, WHITE);
+            let truncated = truncate_to_width(rest, (cols as usize).saturating_sub(4));
+            let _ = write!(w, "{truncated}");
+            reset_style(w);
+        } else if line.starts_with("    ") {
+            set_dim(w);
+            set_fg(w, GRAY);
+            let truncated = truncate_to_width(line, cols as usize);
+            let _ = write!(w, "{truncated}");
+            reset_style(w);
+        } else if line.starts_with("--- ") && line.ends_with(" ---") {
+            set_dim(w);
+            set_fg(w, DIM_GRAY);
+            let truncated = truncate_to_width(line, cols as usize);
+            let _ = write!(w, "{truncated}");
+            reset_style(w);
+        } else {
+            set_fg(w, GRAY);
+            let truncated = truncate_to_width(line, cols as usize);
+            let _ = write!(w, "{truncated}");
+            reset_style(w);
+        }
     }
 
     fn draw_output_incremental<W: Write>(
@@ -704,10 +745,7 @@ impl TaskDraw {
             let row = regions.output_start + 1 + viewport_offset as u16;
             move_to(w, row, 0);
             clear_line(w);
-            set_fg(w, GRAY);
-            let truncated = truncate_to_width(line, regions.cols as usize);
-            let _ = write!(w, "{truncated}");
-            reset_style(w);
+            self.draw_output_line(w, line, regions.cols);
         }
 
         // If output count exceeds viewport, we need to redraw the entire visible
@@ -725,11 +763,7 @@ impl TaskDraw {
                     let row = regions.output_start + 1 + vp_offset as u16;
                     move_to(w, row, 0);
                     clear_line(w);
-                    set_fg(w, GRAY);
-                    let truncated =
-                        truncate_to_width(&state.output_rows[src_index], regions.cols as usize);
-                    let _ = write!(w, "{truncated}");
-                    reset_style(w);
+                    self.draw_output_line(w, &state.output_rows[src_index], regions.cols);
                 }
             }
         }
@@ -1082,5 +1116,68 @@ mod tests {
         assert!(output.contains("Orchestrating"));
         assert!(output.contains("validate: running"));
         assert!(output.contains("ship it"));
+    }
+
+    #[test]
+    fn enriched_paragraph_output_renders_tool_status_colors() {
+        let mut buf = Vec::new();
+        let mut draw = TaskDraw::new();
+        let state = make_state(
+            vec![],
+            vec![
+                "[ok] read_file",
+                "    README.md: 42 lines",
+                "",
+                "[!] write_file",
+                "    error: permission denied",
+                "",
+                "The file was read successfully.",
+            ],
+        );
+
+        draw.draw(&mut buf, &state, 80, 24);
+        let output = String::from_utf8_lossy(&buf);
+
+        // Tool status markers must be drawn with appropriate ANSI colors.
+        assert!(output.contains("[ok]"), "success marker must be drawn");
+        assert!(output.contains("[!]"), "error marker must be drawn");
+        assert!(
+            output.contains("read_file"),
+            "tool name must appear in output"
+        );
+        assert!(
+            output.contains("README.md"),
+            "indented detail must appear in output"
+        );
+    }
+
+    #[test]
+    fn persistent_layout_shows_welcome_hint_before_first_turn() {
+        let mut buf = Vec::new();
+        let mut draw = TaskDraw::new();
+        let state = TaskLayoutState {
+            task_id: "test-001".into(),
+            status_line: "mode:ready approval:none".into(),
+            activity_rows: vec![],
+            timeline_entries: vec![],
+            selected_step: 0,
+            total_steps: 0,
+            output_rows: vec![
+                "Type a prompt below to begin.".into(),
+                String::new(),
+                "The orchestrator will call tools and stream results here.".into(),
+            ],
+            pending_approval: None,
+            input_hint: "> ".into(),
+            changed_files: vec![],
+        };
+
+        draw.draw(&mut buf, &state, 80, 24);
+        let output = String::from_utf8_lossy(&buf);
+
+        assert!(
+            output.contains("Type a prompt"),
+            "welcome hint must be drawn on first frame"
+        );
     }
 }


### PR DESCRIPTION
## Motivation

**Repo:** `aistar-au/vexcoder`

### Why

The four-region task-state control surface (header, timeline, output, input) was only shown during active model turns and disappeared back to the transcript-only three-pane view after each turn completed. This made the TUI appear broken — showing "[awaiting model response]" and then vanishing the entire orchestration view when the turn ended. [ADR-031](https://github.com/aistar-au/vexcoder/blob/main/adr/ADR-031-operator-surface-ui-overhaul.md) requires a persistent timeline-driven layout that derives from canonical task state and remains visible at all times.

### What Changed

The direct ANSI draw engine now owns the terminal for the entire session, not just during active turns. Last-turn data (tool invocations, response text, user input) is preserved across turn boundaries so the timeline and output pane remain populated between turns. The output pane renders completed tool invocations as flowing paragraphs with status markers and indented detail lines, styled with differentiated ANSI colors. A welcome hint is shown before the first turn begins.

### Files changed

- `src/app.rs` (+6/-0) — added last-turn display fields to TuiMode struct
- `src/app/ctor.rs` (+3/-0) — initialized new fields in constructor
- `src/app/turn.rs` (+12/-0) — preserve last-turn data before clearing, added reset helper
- `src/app/layout.rs` (+173/-46) — persistent task_layout_state, enriched paragraph output, timeline entries from last turn
- `src/app/accessors.rs` (+23/-8) — timeline_entry_count accounts for last-turn data
- `src/ui/draw.rs` (+121/-11) — paragraph-aware output line rendering with tool status colors, two new tests
- `AGENTS.md` (+1/-1) — ADR-031 status updated to Active
- `adr/ADR-031-operator-surface-ui-overhaul.md` (+1/-1) — status updated from Proposed to Active

### References

- [ADR-031](https://github.com/aistar-au/vexcoder/blob/main/adr/ADR-031-operator-surface-ui-overhaul.md) — operator surface UI overhaul (Batch A/B core)
- [ADR-030](https://github.com/aistar-au/vexcoder/blob/main/adr/ADR-030-runtime-task-state-and-orchestrator-control-flow.md) — runtime task state ownership model