### PR TITLE
Overhaul task-surface transcript scrolling and multiline composer

### DIFF
--- a/adr/ADR-028-application-facade-and-transport-boundaries.md
+++ b/adr/ADR-028-application-facade-and-transport-boundaries.md
@@ -326,23 +326,21 @@ the matching endpoint path for the configured protocol.
 - `test_local_bare_v1_endpoint_resolves_messages_v1_url`
 - `test_local_bare_v1_endpoint_resolves_chat_compat_url`
 
-### Bug 2 — TUI must stay on the primary terminal surface
+### Bug 2 — TUI must own the alternate-screen session surface
 
 **Location:** `src/terminal.rs`
 
-**Root cause:** The terminal lifecycle drifted away from the intended primary
-surface behaviour.  The TUI must remain in raw mode on the current terminal
-surface, not switch into a separate alternate buffer.
-
-**Fix:** `terminal.rs` now keeps rendering on the primary terminal surface,
-using raw mode and bracketed paste only, and restores the prompt cleanly on
-exit without a buffer switch.
-PageUp in the host terminal shows only the last rendered frame, not the
-session history.
+**Root cause:** The terminal lifecycle notes drifted into contradictory wording.
+The interactive task surface is a fullscreen session and therefore must own the
+alternate screen buffer consistently instead of mixing primary-surface wording
+with alternate-screen enter/leave calls.
 
 **Fix:** `enter_full_screen_mode()` now executes `EnterAlternateScreen` before
 `EnableBracketedPaste`.  `restore()` now executes `LeaveAlternateScreen` before
-`Show`, cleanly returning the user to their pre-session terminal state.
+`Show`, cleanly returning the user to their pre-session terminal state. The
+fullscreen task surface keeps its own transcript scroll model inside the
+session; host-terminal PageUp after exit shows the pre-session shell history,
+not the in-session transcript.
 
 ### Bug 3 — Orchestrator activity pane does not show live steps
 

--- a/adr/ADR-031-operator-surface-ui-overhaul.md
+++ b/adr/ADR-031-operator-surface-ui-overhaul.md
@@ -20,6 +20,11 @@ renderer owns a human-readable header plus transcript/composer path, and the
 task surface includes structured prefix styling, inline approval cards, and a
 cumulative context indicator in the header.
 
+The active operator surface now also keeps transcript scroll anchored to the
+prompt edge and expands the composer into a larger multiline surface so slash
+commands, `@path` expansion, pasted blocks, and long prompts remain usable
+without dropping out of fullscreen task mode.
+
 The next step is the remaining alignment pass for that UI overhaul. The
 remaining ADR-031 scope:
 
@@ -77,9 +82,12 @@ Key changes from the current implementation:
    across the direct ANSI and fallback renderers.
 3. Scroll ownership moves to the task surface: the timeline remains
    independently navigable, while the transcript/output area redraws from the
-   same task-derived state.
+   same task-derived state and scrolls upward from the prompt edge.
 4. The visible timeline window scales with terminal height instead of
    remaining fixed at six rows.
+5. The composer becomes a larger multiline prompt surface with persistent
+   affordances for slash commands, `@path` expansion, pasted blocks, and
+   newline insertion.
 
 ### Task-state-first rule for this ADR
 

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -11,7 +11,7 @@ Most interactive application coordination still lives in `src/app.rs`. The runti
 
 - `src/bin/vex.rs` parses CLI arguments, loads config, and routes startup into the interactive UI, batch mode, export, compatibility helpers, and other CLI paths.
 - `src/app.rs` owns the current interactive command surface, transcript state, approval prompts, and runtime-facing coordination for the full-screen TUI.
-- `src/ui/draw.rs` owns the direct ANSI task-surface renderer used while a task is active; it draws a human-readable header, optional changed-files row, adaptive timeline, transcript area, adaptive composer, and cumulative context indicator without allocating a ratatui frame buffer per update.
+- `src/ui/draw.rs` owns the direct ANSI task-surface renderer used while the fullscreen task surface is active; it draws a human-readable header, optional changed-files row, adaptive timeline, prompt-anchored transcript area, larger multiline composer, and cumulative context indicator without allocating a ratatui frame buffer per update.
 - `src/batch_mode.rs` runs the same runtime headlessly for `vex exec` and writes JSONL or text output.
 - `src/runtime/` contains the reusable runtime machinery: context assembly, the edit loop, command and sandbox plumbing, project instructions, task state, and validation.
 
@@ -40,6 +40,6 @@ The long-term architecture work is tracked in the ADR set under `adr/`.
 - ADR-026 defines the proposed `LocalApiServer` transport binding over that contract.
 - ADR-028 is now active in the current tree: the facade helpers live under `src/app/`, the localhost `/v1/messages` protocol-routing fix is in place, and the full-screen task surface now keeps live orchestration rows visible while follow-up work continues to shrink `src/app.rs` behind the facade boundary.
 - ADR-030 defines the runtime control-flow rule: provider events normalize into canonical runtime events, task state owns execution truth, and the orchestrator decides whether the task continues or stops.
-- ADR-031 extends the active operator surface with timeline selection, stable step identity, explicit approved/running/completed lifecycle rendering, adaptive timeline sizing, transcript/composer rendering, direct ANSI task rendering during orchestration, and keyboard navigation for a terminal-height-scaled timeline window.
+- ADR-031 extends the active operator surface with timeline selection, stable step identity, explicit approved/running/completed lifecycle rendering, adaptive timeline sizing, prompt-anchored transcript scrolling, a larger multiline composer, direct ANSI task rendering during orchestration, and keyboard navigation for a terminal-height-scaled timeline window.
 
 That means the current `src/app.rs`-centric layout is still the live implementation, but it is not intended to be the permanent shape for machine-readable runtime access or local server transports.

--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -8,10 +8,11 @@ This page documents the commands and flags implemented in the current binary.
 
 Starts the interactive full-screen CLI UI. While a task is running, the task
 surface uses a direct ANSI renderer for a human-readable header, optional
-changed-file row, adaptive timeline, transcript area, and adaptive composer.
-When completed turns record usage metadata, the header appends a compact
-`~N.Nk ctx` cumulative session indicator. Idle prompting and overlay modals
-still use the ratatui-backed path.
+changed-file row, adaptive timeline, prompt-anchored transcript area, and a
+larger multiline composer. When completed turns record usage metadata, the
+header appends a compact `~N.Nk ctx` cumulative session indicator. The prompt
+surface keeps `/` commands, `@path` expansion, pasted blocks, and multiline
+editing available in the same fullscreen layout.
 
 ### `vex --resume [task-id]`
 
@@ -208,4 +209,7 @@ session totals.
 - `Alt+Up` and `Alt+Down` move the selected entry in the adaptive task timeline.
 - `Tab` and `Shift+Tab` also move timeline selection forward and backward while the task surface is active.
 - The visible timeline window scales with terminal height instead of staying fixed at six rows.
-- Pasted text is inserted into the input box during normal editing.
+- `PageUp`, `PageDown`, `Ctrl+Up`, and `Ctrl+Down` scroll the transcript/output pane upward from the prompt edge instead of moving the cursor.
+- `Ctrl+Home` jumps to the oldest visible transcript content, and `Ctrl+End` returns to the live bottom edge.
+- `Shift+Enter` inserts a newline without submitting the turn.
+- Pasted text is inserted into the larger multiline prompt surface during normal editing.

--- a/src/app.rs
+++ b/src/app.rs
@@ -531,6 +531,16 @@ pub struct TimelineEntry {
     pub session_id: Option<u64>,
 }
 
+/// Scroll semantics for the output pane.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum OutputScrollAnchor {
+    /// Scroll offsets count from the first visible row.
+    Top,
+    /// Scroll offsets count upward from the prompt/composer edge.
+    #[default]
+    Bottom,
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct TaskLayoutState {
     pub task_id: String,
@@ -543,7 +553,12 @@ pub struct TaskLayoutState {
     pub selected_step: usize,
     /// Total number of steps (including those scrolled out of view).
     pub total_steps: usize,
+    /// Human-readable title for the output pane.
+    pub output_title: String,
     pub output_rows: Vec<String>,
+    /// Scroll amount for the output pane, interpreted using `output_scroll_anchor`.
+    pub output_scroll_offset: usize,
+    pub output_scroll_anchor: OutputScrollAnchor,
     pub pending_approval: Option<String>,
     pub input_hint: String,
     /// Live composer buffer for the fullscreen task surface.
@@ -594,6 +609,10 @@ pub struct TuiMode {
     /// When true, selection auto-advances to the latest timeline entry.
     /// Set to false when the operator scrolls manually; reset on new turn.
     timeline_follow_mode: bool,
+    /// Transcript scrollback measured upward from the composer edge.
+    transcript_scroll_offset: usize,
+    /// Inspector/detail scroll offset measured downward from the top.
+    inspector_scroll_offset: usize,
     /// Last completed turn's tool invocations (kept for persistent display).
     last_turn_tool_invocations: Vec<ToolInvocationSummary>,
     /// Last completed turn's response text (kept for persistent display).
@@ -648,6 +667,8 @@ impl RuntimeMode for TuiMode {
                 } else if target == ScrollTarget::Timeline {
                     let total = self.timeline_entry_count();
                     self.apply_timeline_scroll_action(action, total);
+                } else if target == ScrollTarget::Output {
+                    self.apply_output_scroll_action(action);
                 } else if target == ScrollTarget::History {
                     self.apply_history_scroll_action(action);
                 }

--- a/src/app/ctor.rs
+++ b/src/app/ctor.rs
@@ -45,6 +45,8 @@ impl TuiMode {
             selected_timeline_index: 0,
             next_step_id: 1,
             timeline_follow_mode: true,
+            transcript_scroll_offset: 0,
+            inspector_scroll_offset: 0,
             last_turn_tool_invocations: Vec::new(),
             last_turn_response: String::new(),
             last_turn_input_display: String::new(),

--- a/src/app/layout.rs
+++ b/src/app/layout.rs
@@ -230,7 +230,7 @@ impl TuiMode {
     /// - After a completed turn: enriched paragraph view showing each tool
     ///   invocation as a paragraph followed by the model response.
     /// - Before any turn: welcome hint.
-    fn task_output_rows(&self) -> Vec<String> {
+    pub(super) fn task_output_view(&self) -> (String, Vec<String>, OutputScrollAnchor) {
         // If timeline has entries and a valid selection on a tool step
         // (not user input), show inspector detail.
         let entries = self.task_timeline_entries();
@@ -251,7 +251,7 @@ impl TuiMode {
                         rows.push("--- model response ---".to_string());
                         rows.extend(self.current_turn_response.lines().map(ToOwned::to_owned));
                     }
-                    return rows;
+                    return ("Inspector".to_string(), rows, OutputScrollAnchor::Top);
                 }
             }
         }
@@ -263,23 +263,35 @@ impl TuiMode {
                 .map(ToOwned::to_owned)
                 .collect::<Vec<_>>();
             if rows.is_empty() {
-                return vec!["[awaiting model response]".to_string()];
+                return (
+                    "Transcript".to_string(),
+                    vec!["[awaiting model response]".to_string()],
+                    OutputScrollAnchor::Bottom,
+                );
             }
-            return rows;
+            return ("Transcript".to_string(), rows, OutputScrollAnchor::Bottom);
         }
 
         // After turn completes: show enriched paragraph view with tool
         // invocations and model response from the last completed turn.
         if !self.last_turn_tool_invocations.is_empty() || !self.last_turn_response.is_empty() {
-            return self.enriched_paragraph_rows();
+            return (
+                "Transcript".to_string(),
+                self.enriched_paragraph_rows(),
+                OutputScrollAnchor::Bottom,
+            );
         }
 
         // No turn data yet — show a welcome hint.
-        vec![
-            "Type a prompt below to begin.".to_string(),
-            String::new(),
-            "The orchestrator will call tools and stream results here.".to_string(),
-        ]
+        (
+            "Transcript".to_string(),
+            vec![
+                "Type a prompt below to begin.".to_string(),
+                String::new(),
+                "The orchestrator will call tools and stream results here.".to_string(),
+            ],
+            OutputScrollAnchor::Bottom,
+        )
     }
 
     /// Build enriched paragraph rows from the last completed turn.
@@ -349,13 +361,18 @@ impl TuiMode {
         let selected_step = self
             .selected_timeline_index
             .min(total_steps.saturating_sub(1));
+        let (output_title, output_rows, output_scroll_anchor) = self.task_output_view();
+        let output_scroll_offset = match output_scroll_anchor {
+            OutputScrollAnchor::Bottom => self.transcript_scroll_offset,
+            OutputScrollAnchor::Top => self.inspector_scroll_offset,
+        };
 
         let input_hint = if let Some(approval) = pending_approval.clone() {
             format!("{approval}\n[y/n/s] ")
         } else if self.command_session_active() {
-            "[command session active \u{2014} Ctrl+C to cancel]".to_string()
+            "Prompt\nCommand session active. Ctrl+C cancels the running command.".to_string()
         } else {
-            "> ".to_string()
+            "Prompt\nUse `/` for commands, `@path` to inline files, paste large blocks, and Shift+Enter for a newline.".to_string()
         };
         Some(TaskLayoutState {
             task_id: self.current_task.id.clone(),
@@ -364,7 +381,10 @@ impl TuiMode {
             timeline_entries,
             selected_step,
             total_steps,
-            output_rows: self.task_output_rows(),
+            output_title,
+            output_rows,
+            output_scroll_offset,
+            output_scroll_anchor,
             pending_approval,
             input_hint,
             composer_text: String::new(),

--- a/src/app/model_update.rs
+++ b/src/app/model_update.rs
@@ -4,6 +4,7 @@ impl TuiMode {
     pub(super) fn on_model_update(&mut self, update: UiUpdate, ctx: &mut RuntimeContext) {
         match update {
             UiUpdate::TranscriptLine(line) => {
+                let previous_output_len = self.task_output_view().1.len();
                 if self.history_state.turn_in_progress {
                     if !self.current_turn_response.is_empty() {
                         self.current_turn_response.push('\n');
@@ -11,8 +12,10 @@ impl TuiMode {
                     self.current_turn_response.push_str(&line);
                 }
                 self.push_history_line(line);
+                self.preserve_transcript_scroll_on_growth(previous_output_len);
             }
             UiUpdate::StreamDelta(text) => {
+                let previous_output_len = self.task_output_view().1.len();
                 if self.history_state.cancel_pending {
                     return;
                 }
@@ -36,6 +39,7 @@ impl TuiMode {
                 if self.history_state.auto_follow {
                     self.set_scroll_to_bottom();
                 }
+                self.preserve_transcript_scroll_on_growth(previous_output_len);
             }
             UiUpdate::StreamBlockStart { index, block } => {
                 match &block {
@@ -56,6 +60,7 @@ impl TuiMode {
                         if self.timeline_follow_mode {
                             let total = self.timeline_entry_count();
                             self.selected_timeline_index = total.saturating_sub(1);
+                            self.inspector_scroll_offset = 0;
                         }
                     }
                     StreamBlock::ToolResult {
@@ -200,6 +205,8 @@ impl TuiMode {
                 } else {
                     self.clamp_scroll_offset();
                 }
+                self.transcript_scroll_offset = 0;
+                self.inspector_scroll_offset = 0;
             }
             UiUpdate::CommandSessionStarted {
                 session_id,
@@ -242,6 +249,8 @@ impl TuiMode {
                 } else {
                     self.clamp_scroll_offset();
                 }
+                self.transcript_scroll_offset = 0;
+                self.inspector_scroll_offset = 0;
             }
             UiUpdate::Error(msg) => {
                 self.command_sessions.clear();
@@ -255,6 +264,8 @@ impl TuiMode {
                 self.history_state.turn_in_progress = false;
                 self.history_state.active_assistant_index = None;
                 self.read_only_turn_active = false;
+                self.transcript_scroll_offset = 0;
+                self.inspector_scroll_offset = 0;
             }
         }
     }

--- a/src/app/scroll.rs
+++ b/src/app/scroll.rs
@@ -6,6 +6,32 @@ use crate::ui::render::input_visual_rows;
 use std::time::{Duration, Instant};
 
 impl TuiMode {
+    fn clamp_transcript_scroll_offset(&mut self, total_rows: usize) {
+        self.transcript_scroll_offset = self
+            .transcript_scroll_offset
+            .min(total_rows.saturating_sub(1));
+    }
+
+    fn clamp_inspector_scroll_offset(&mut self, total_rows: usize) {
+        self.inspector_scroll_offset = self
+            .inspector_scroll_offset
+            .min(total_rows.saturating_sub(1));
+    }
+
+    pub(super) fn preserve_transcript_scroll_on_growth(&mut self, previous_rows: usize) {
+        if self.transcript_scroll_offset == 0 {
+            return;
+        }
+
+        let (_, rows, anchor) = self.task_output_view();
+        if anchor == OutputScrollAnchor::Bottom && rows.len() > previous_rows {
+            self.transcript_scroll_offset = self
+                .transcript_scroll_offset
+                .saturating_add(rows.len() - previous_rows);
+        }
+        self.clamp_transcript_scroll_offset(rows.len());
+    }
+
     pub(super) fn push_history_line(&mut self, line: String) {
         self.history_state.lines.push(line);
         self.enforce_history_cap();
@@ -89,6 +115,7 @@ impl TuiMode {
     pub(super) fn apply_timeline_up(&mut self) {
         self.selected_timeline_index = self.selected_timeline_index.saturating_sub(1);
         self.timeline_follow_mode = false;
+        self.inspector_scroll_offset = 0;
     }
 
     /// Move the selected timeline entry down by one step, clamped to the
@@ -97,18 +124,21 @@ impl TuiMode {
         let max = total_entries.saturating_sub(1);
         self.selected_timeline_index = (self.selected_timeline_index + 1).min(max);
         self.timeline_follow_mode = self.selected_timeline_index >= max;
+        self.inspector_scroll_offset = 0;
     }
 
     /// Jump to the first timeline entry.
     pub(super) fn apply_timeline_home(&mut self) {
         self.selected_timeline_index = 0;
         self.timeline_follow_mode = false;
+        self.inspector_scroll_offset = 0;
     }
 
     /// Jump to the last timeline entry.
     pub(super) fn apply_timeline_end(&mut self, total_entries: usize) {
         self.selected_timeline_index = total_entries.saturating_sub(1);
         self.timeline_follow_mode = true;
+        self.inspector_scroll_offset = 0;
     }
 
     /// Dispatch a scroll action to the timeline selection.
@@ -124,6 +154,7 @@ impl TuiMode {
                 self.selected_timeline_index =
                     self.selected_timeline_index.saturating_sub(step.max(1));
                 self.timeline_follow_mode = false;
+                self.inspector_scroll_offset = 0;
             }
             ScrollAction::PageDown(step) => {
                 let max = total_entries.saturating_sub(1);
@@ -132,9 +163,67 @@ impl TuiMode {
                     .saturating_add(step.max(1))
                     .min(max);
                 self.timeline_follow_mode = self.selected_timeline_index >= max;
+                self.inspector_scroll_offset = 0;
             }
             ScrollAction::Home => self.apply_timeline_home(),
             ScrollAction::End => self.apply_timeline_end(total_entries),
+        }
+    }
+
+    pub(super) fn apply_output_scroll_action(&mut self, action: ScrollAction) {
+        let (_, rows, anchor) = self.task_output_view();
+        let total_rows = rows.len();
+
+        match anchor {
+            OutputScrollAnchor::Bottom => match action {
+                ScrollAction::LineUp => {
+                    self.transcript_scroll_offset = self.transcript_scroll_offset.saturating_add(1);
+                }
+                ScrollAction::LineDown => {
+                    self.transcript_scroll_offset = self.transcript_scroll_offset.saturating_sub(1);
+                }
+                ScrollAction::PageUp(step) => {
+                    self.transcript_scroll_offset =
+                        self.transcript_scroll_offset.saturating_add(step.max(1));
+                }
+                ScrollAction::PageDown(step) => {
+                    self.transcript_scroll_offset =
+                        self.transcript_scroll_offset.saturating_sub(step.max(1));
+                }
+                ScrollAction::Home => {
+                    self.transcript_scroll_offset = total_rows.saturating_sub(1);
+                }
+                ScrollAction::End => {
+                    self.transcript_scroll_offset = 0;
+                }
+            },
+            OutputScrollAnchor::Top => match action {
+                ScrollAction::LineUp => {
+                    self.inspector_scroll_offset = self.inspector_scroll_offset.saturating_sub(1);
+                }
+                ScrollAction::LineDown => {
+                    self.inspector_scroll_offset = self.inspector_scroll_offset.saturating_add(1);
+                }
+                ScrollAction::PageUp(step) => {
+                    self.inspector_scroll_offset =
+                        self.inspector_scroll_offset.saturating_sub(step.max(1));
+                }
+                ScrollAction::PageDown(step) => {
+                    self.inspector_scroll_offset =
+                        self.inspector_scroll_offset.saturating_add(step.max(1));
+                }
+                ScrollAction::Home => {
+                    self.inspector_scroll_offset = 0;
+                }
+                ScrollAction::End => {
+                    self.inspector_scroll_offset = total_rows.saturating_sub(1);
+                }
+            },
+        }
+
+        match anchor {
+            OutputScrollAnchor::Bottom => self.clamp_transcript_scroll_offset(total_rows),
+            OutputScrollAnchor::Top => self.clamp_inspector_scroll_offset(total_rows),
         }
     }
 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -524,6 +524,48 @@ fn test_scrollback_commands_update_scroll_state() {
 }
 
 #[test]
+fn test_output_scroll_commands_use_bottom_anchored_prompt_surface() {
+    let mut mode = TuiMode::new();
+    let mut ctx = setup_ctx();
+
+    mode.on_user_input("summarise the diff".to_string(), &mut ctx);
+    mode.on_model_update(UiUpdate::TranscriptLine("line-1".to_string()), &mut ctx);
+    mode.on_model_update(UiUpdate::TranscriptLine("line-2".to_string()), &mut ctx);
+    mode.on_model_update(UiUpdate::TranscriptLine("line-3".to_string()), &mut ctx);
+
+    mode.on_frontend_event(
+        UserInputEvent::Scroll {
+            target: ScrollTarget::Output,
+            action: ScrollAction::PageUp(2),
+        },
+        &mut ctx,
+    );
+    let state = mode.task_layout_state().expect("task layout state");
+    assert_eq!(state.output_scroll_anchor, OutputScrollAnchor::Bottom);
+    assert_eq!(state.output_scroll_offset, 2);
+
+    mode.on_frontend_event(
+        UserInputEvent::Scroll {
+            target: ScrollTarget::Output,
+            action: ScrollAction::LineDown,
+        },
+        &mut ctx,
+    );
+    let state = mode.task_layout_state().expect("task layout state");
+    assert_eq!(state.output_scroll_offset, 1);
+
+    mode.on_frontend_event(
+        UserInputEvent::Scroll {
+            target: ScrollTarget::Output,
+            action: ScrollAction::End,
+        },
+        &mut ctx,
+    );
+    let state = mode.task_layout_state().expect("task layout state");
+    assert_eq!(state.output_scroll_offset, 0);
+}
+
+#[test]
 fn test_history_status_and_scroll_use_visual_rows() {
     let mode = TuiMode {
         history_state: HistoryState {

--- a/src/app/turn.rs
+++ b/src/app/turn.rs
@@ -10,6 +10,8 @@ impl TuiMode {
         self.history_state.active_assistant_index = None;
         self.history_state.scroll_offset = 0;
         self.history_state.auto_follow = true;
+        self.transcript_scroll_offset = 0;
+        self.inspector_scroll_offset = 0;
         self.active_stream_blocks.clear();
         self.last_assembled_context = None;
         self.read_only_turn_active = false;
@@ -41,6 +43,7 @@ impl TuiMode {
         self.pending_turn_tool_calls.clear();
         self.selected_timeline_index = 0;
         self.timeline_follow_mode = true;
+        self.inspector_scroll_offset = 0;
     }
 
     pub(super) fn reset_last_turn_display(&mut self) {
@@ -53,6 +56,7 @@ impl TuiMode {
         self.reset_turn_capture();
         self.current_turn_input = input;
         self.current_task.status = TaskStatus::Running;
+        self.transcript_scroll_offset = 0;
     }
 
     pub(super) fn begin_command_session(&mut self, command: String) -> u64 {
@@ -134,6 +138,8 @@ impl TuiMode {
         if let Err(error) = self.current_task.save(&dir) {
             self.push_history_line(format!("[state] save failed: {error}"));
         }
+        self.transcript_scroll_offset = 0;
+        self.inspector_scroll_offset = 0;
         self.reset_turn_capture();
     }
 

--- a/src/bin/vex.rs
+++ b/src/bin/vex.rs
@@ -334,34 +334,34 @@ impl ManagedTuiFrontend {
                 action: ScrollAction::LineDown,
             }),
             KeyCode::PageUp => Some(UserInputEvent::Scroll {
-                target: ScrollTarget::History,
+                target: ScrollTarget::Output,
                 action: ScrollAction::PageUp(10),
             }),
             KeyCode::PageDown => Some(UserInputEvent::Scroll {
-                target: ScrollTarget::History,
+                target: ScrollTarget::Output,
                 action: ScrollAction::PageDown(10),
             }),
             KeyCode::Up if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 Some(UserInputEvent::Scroll {
-                    target: ScrollTarget::History,
+                    target: ScrollTarget::Output,
                     action: ScrollAction::LineUp,
                 })
             }
             KeyCode::Down if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 Some(UserInputEvent::Scroll {
-                    target: ScrollTarget::History,
+                    target: ScrollTarget::Output,
                     action: ScrollAction::LineDown,
                 })
             }
             KeyCode::Home if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 Some(UserInputEvent::Scroll {
-                    target: ScrollTarget::History,
+                    target: ScrollTarget::Output,
                     action: ScrollAction::Home,
                 })
             }
             KeyCode::End if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 Some(UserInputEvent::Scroll {
-                    target: ScrollTarget::History,
+                    target: ScrollTarget::Output,
                     action: ScrollAction::End,
                 })
             }
@@ -378,34 +378,34 @@ impl ManagedTuiFrontend {
                 Some(UserInputEvent::Interrupt)
             }
             KeyCode::PageUp => Some(UserInputEvent::Scroll {
-                target: ScrollTarget::History,
+                target: ScrollTarget::Output,
                 action: ScrollAction::PageUp(10),
             }),
             KeyCode::PageDown => Some(UserInputEvent::Scroll {
-                target: ScrollTarget::History,
+                target: ScrollTarget::Output,
                 action: ScrollAction::PageDown(10),
             }),
             KeyCode::Home if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 Some(UserInputEvent::Scroll {
-                    target: ScrollTarget::History,
+                    target: ScrollTarget::Output,
                     action: ScrollAction::Home,
                 })
             }
             KeyCode::End if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 Some(UserInputEvent::Scroll {
-                    target: ScrollTarget::History,
+                    target: ScrollTarget::Output,
                     action: ScrollAction::End,
                 })
             }
             KeyCode::Up if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 Some(UserInputEvent::Scroll {
-                    target: ScrollTarget::History,
+                    target: ScrollTarget::Output,
                     action: ScrollAction::LineUp,
                 })
             }
             KeyCode::Down if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 Some(UserInputEvent::Scroll {
-                    target: ScrollTarget::History,
+                    target: ScrollTarget::Output,
                     action: ScrollAction::LineDown,
                 })
             }

--- a/src/runtime/frontend.rs
+++ b/src/runtime/frontend.rs
@@ -4,6 +4,7 @@ use super::mode::RuntimeMode;
 pub enum ScrollTarget {
     History,
     Overlay,
+    Output,
     /// Timeline/activity pane — moves selected step up or down.
     Timeline,
 }

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -17,7 +17,7 @@
 //! The public entry point is [`TaskDraw`] which persists across the
 //! session and is called from the `FrontendAdapter::render` path.
 
-use crate::app::{StepLifecycle, TaskLayoutState, TimelineEntry};
+use crate::app::{OutputScrollAnchor, StepLifecycle, TaskLayoutState, TimelineEntry};
 use crate::ui::input_metrics::{
     cursor_row_col, display_width, truncate_to_display_width, wrap_input_lines,
 };
@@ -122,7 +122,7 @@ fn lifecycle_prefix(lifecycle: &StepLifecycle) -> &'static str {
 /// row 1        ├─ changed files (optional) ──────┤  (0..1 rows)
 /// row H..T     ├─ timeline (adaptive height) ────┤  (3..40% of rows)
 /// row T..C     │  transcript (remaining rows)    │  (fills remaining)
-/// row C..end   ├─ composer (adaptive) ───────────┤  (1..3 rows)
+/// row C..end   ├─ composer (adaptive) ───────────┤  (4..8 rows)
 ///              └─────────────────────────────────┘
 /// ```
 struct Regions {
@@ -141,12 +141,26 @@ struct Regions {
 
 /// Minimum timeline rows (below this the timeline is hidden).
 const MIN_TIMELINE_ROWS: u16 = 3;
+/// Minimum transcript rows reserved above the prompt surface.
+const MIN_TRANSCRIPT_ROWS: u16 = 2;
 /// Maximum fraction of terminal for the timeline.
 const MAX_TIMELINE_FRACTION: f32 = 0.35;
-/// Minimum composer rows.
-const MIN_COMPOSER_ROWS: u16 = 1;
-/// Preferred composer rows (when space allows).
-const PREFERRED_COMPOSER_ROWS: u16 = 3;
+/// Minimum fullscreen prompt rows (toolbar + multiline input).
+const MIN_COMPOSER_ROWS: u16 = 3;
+
+fn preferred_composer_rows(rows: u16) -> u16 {
+    if rows >= 36 {
+        8
+    } else if rows >= 28 {
+        7
+    } else if rows >= 22 {
+        6
+    } else if rows >= 16 {
+        5
+    } else {
+        4
+    }
+}
 
 impl Regions {
     fn compute(cols: u16, rows: u16, has_files: bool, timeline_entry_count: usize) -> Self {
@@ -157,19 +171,18 @@ impl Regions {
         // Reserve 1 row for status bar at the very bottom.
         let status_bar_row = rows.saturating_sub(1);
 
-        // Composer: scales from 1 to 3 rows based on terminal height.
-        let composer_rows = if rows >= 30 {
-            PREFERRED_COMPOSER_ROWS
-        } else if rows >= 15 {
-            2
-        } else {
-            MIN_COMPOSER_ROWS
-        };
+        // Composer: dedicate a larger bottom-docked prompt surface while
+        // preserving minimum room for timeline and transcript.
+        let available = rows.saturating_sub(header_height).saturating_sub(1);
+        let max_composer_rows = available
+            .saturating_sub(MIN_TIMELINE_ROWS)
+            .saturating_sub(MIN_TRANSCRIPT_ROWS)
+            .max(MIN_COMPOSER_ROWS);
+        let composer_rows = preferred_composer_rows(rows)
+            .max(MIN_COMPOSER_ROWS)
+            .min(max_composer_rows);
 
-        let available = rows
-            .saturating_sub(header_height)
-            .saturating_sub(composer_rows)
-            .saturating_sub(1); // -1 for status bar
+        let available = available.saturating_sub(composer_rows);
 
         // Timeline: adaptive height based on content and terminal size.
         // Uses up to MAX_TIMELINE_FRACTION of available space, but at least
@@ -473,6 +486,16 @@ impl TaskDraw {
             reset_style(w);
         }
 
+        if state.total_steps > 0 {
+            set_fg(w, DIM_GRAY);
+            let _ = write!(w, " \u{00b7} ");
+            reset_style(w);
+            set_dim(w);
+            set_fg(w, BLUE);
+            let _ = write!(w, "step {}/{}", state.selected_step + 1, state.total_steps);
+            reset_style(w);
+        }
+
         // Context-window token counter — shown once at least one turn has
         // completed and session tokens have been recorded.  Expressed as a
         // compact "~1.2k ctx" indicator so the operator can see how much of
@@ -618,7 +641,7 @@ impl TaskDraw {
         // Separator line between timeline and transcript — star accent.
         let sep_row = regions.transcript_start.saturating_sub(1);
         if sep_row >= regions.timeline_start {
-            draw_star_separator(w, sep_row, regions.cols);
+            draw_labeled_separator(w, sep_row, regions.cols, &state.output_title);
         }
     }
 
@@ -646,7 +669,7 @@ impl TaskDraw {
         // Separator — star accent.
         let sep_row = regions.transcript_start.saturating_sub(1);
         if sep_row >= regions.timeline_start {
-            draw_star_separator(w, sep_row, regions.cols);
+            draw_labeled_separator(w, sep_row, regions.cols, &state.output_title);
         }
     }
 
@@ -764,6 +787,7 @@ impl TaskDraw {
         regions: &Regions,
     ) {
         let viewport_height = regions.transcript_rows as usize;
+        let (visible_start, visible_end) = transcript_window(state, viewport_height);
 
         // Clear the transcript area.
         for vp_offset in 0..viewport_height {
@@ -774,7 +798,6 @@ impl TaskDraw {
 
         // Reset code block state for full redraws.
         self.in_code_block = false;
-        let visible_start = state.output_rows.len().saturating_sub(viewport_height);
         // Walk all lines from the start to track code block state correctly,
         // but only render lines in the visible window.
         for (i, line) in state.output_rows.iter().enumerate() {
@@ -786,7 +809,7 @@ impl TaskDraw {
                 continue;
             }
             let vp_offset = i - visible_start;
-            if vp_offset >= viewport_height {
+            if i >= visible_end || vp_offset >= viewport_height {
                 break;
             }
             let row = regions.transcript_start + vp_offset as u16;
@@ -809,7 +832,7 @@ impl TaskDraw {
         }
 
         let viewport_height = regions.transcript_rows as usize;
-        let visible_start = total_output.saturating_sub(viewport_height);
+        let (visible_start, visible_end) = transcript_window(state, viewport_height);
 
         // Rebuild code-block state by scanning all lines before the viewport.
         self.in_code_block = false;
@@ -822,7 +845,7 @@ impl TaskDraw {
         // Redraw the entire visible window so code-block state is consistent.
         for vp_offset in 0..viewport_height {
             let src_index = visible_start + vp_offset;
-            if src_index >= total_output {
+            if src_index >= visible_end || src_index >= total_output {
                 break;
             }
             let row = regions.transcript_start + vp_offset as u16;
@@ -1096,6 +1119,12 @@ impl TaskDraw {
     }
 
     fn transcript_is_append_only(&self, state: &TaskLayoutState) -> bool {
+        if state.output_scroll_anchor != OutputScrollAnchor::Bottom
+            || state.output_scroll_offset > 0
+        {
+            return false;
+        }
+
         if state.pending_approval.is_some() {
             return false;
         }
@@ -1126,85 +1155,80 @@ impl TaskDraw {
         move_to(w, regions.composer_start, 0);
 
         if let Some(ref approval) = state.pending_approval {
-            // Inline approval card.
             set_bold(w);
             set_fg(w, YELLOW);
-            let _ = write!(w, "\u{25cf} ");
+            let _ = write!(w, "Approval");
             reset_style(w);
-            set_fg(w, YELLOW);
-            let lines: Vec<&str> = approval.lines().collect();
-            let first = lines.first().copied().unwrap_or("");
-            let truncated = truncate_to_width(first, (regions.cols as usize).saturating_sub(2));
+            set_dim(w);
+            set_fg(w, DIM_GRAY);
+            let actions = "  y approve  n deny  s approve all";
+            let truncated = truncate_to_width(actions, regions.cols.saturating_sub(10) as usize);
             let _ = write!(w, "{truncated}");
             reset_style(w);
 
-            // Approval choices.
-            if regions.composer_start + 1 < regions.rows {
-                move_to(w, regions.composer_start + 1, 0);
-                set_fg(w, DIM_GRAY);
-                let _ = write!(w, "  ");
+            let lines: Vec<&str> = approval.lines().collect();
+            let body_width = regions.cols.saturating_sub(2).max(1) as usize;
+            for offset in 0..regions.composer_rows.saturating_sub(1) as usize {
+                let row = regions.composer_start + 1 + offset as u16;
+                if row >= regions.rows {
+                    break;
+                }
+                move_to(w, row, 0);
+                set_fg(w, YELLOW);
+                let _ = write!(w, "• ");
                 reset_style(w);
-                set_fg(w, GREEN);
-                set_bold(w);
-                let _ = write!(w, "y");
-                reset_style(w);
-                set_fg(w, DIM_GRAY);
-                let _ = write!(w, " approve  ");
-                set_fg(w, RED);
-                set_bold(w);
-                let _ = write!(w, "n");
-                reset_style(w);
-                set_fg(w, DIM_GRAY);
-                let _ = write!(w, " deny  ");
-                set_fg(w, BLUE);
-                set_bold(w);
-                let _ = write!(w, "s");
-                reset_style(w);
-                set_fg(w, DIM_GRAY);
-                let _ = write!(w, " approve all");
-                reset_style(w);
+                if let Some(line) = lines.get(offset).copied().filter(|line| !line.is_empty()) {
+                    set_fg(w, GRAY);
+                    let truncated = truncate_to_width(line, body_width);
+                    let _ = write!(w, "{truncated}");
+                    reset_style(w);
+                }
             }
         } else {
             let input_width = regions.cols.saturating_sub(2).max(1) as usize;
             let input_lines = wrap_input_lines(&state.composer_text, input_width);
             let (cursor_row, _) =
                 cursor_row_col(&state.composer_text, state.composer_cursor, input_width);
-            let window_start =
-                composer_window_start(cursor_row, regions.composer_rows.max(1) as usize);
+            let body_rows = regions.composer_rows.saturating_sub(1).max(1) as usize;
+            let window_start = composer_window_start(cursor_row, body_rows);
             let hint_lines: Vec<&str> = state.input_hint.lines().collect();
 
-            for offset in 0..regions.composer_rows as usize {
-                let row = regions.composer_start + offset as u16;
+            set_bold(w);
+            set_fg(w, WHITE);
+            let _ = write!(w, "Prompt");
+            reset_style(w);
+            set_dim(w);
+            set_fg(w, DIM_GRAY);
+            let chrome = "  / command  @ file  ! shell  paste block  Shift+Enter newline";
+            let truncated = truncate_to_width(chrome, regions.cols.saturating_sub(8) as usize);
+            let _ = write!(w, "{truncated}");
+            reset_style(w);
+
+            for offset in 0..body_rows {
+                let row = regions.composer_start + 1 + offset as u16;
                 if row >= regions.rows {
                     break;
                 }
                 move_to(w, row, 0);
 
-                set_bold(w);
-                set_fg(w, YELLOW);
-                let _ = write!(w, "{}", if offset == 0 { "\u{2726} " } else { "  " });
+                set_fg(w, CYAN);
+                let _ = write!(w, "{}", if offset == 0 { "› " } else { "  " });
                 reset_style(w);
 
                 let line_index = window_start + offset;
                 if let Some(line) = input_lines.get(line_index).filter(|line| !line.is_empty()) {
-                    set_fg(w, GRAY);
+                    set_fg(w, WHITE);
                     let truncated = truncate_to_width(line, input_width);
                     let _ = write!(w, "{truncated}");
                     reset_style(w);
                     continue;
                 }
 
-                let hint = if line_index == 0 {
-                    hint_lines
-                        .first()
-                        .copied()
-                        .filter(|line| *line != "> " && !line.is_empty())
-                } else {
-                    hint_lines
-                        .get(line_index)
-                        .copied()
-                        .filter(|line| !line.is_empty())
-                };
+                let hint = hint_lines
+                    .get(line_index + 1)
+                    .copied()
+                    .or_else(|| hint_lines.get(1).copied())
+                    .filter(|line| !line.is_empty());
                 if let Some(hint) = hint {
                     set_fg(w, DIM_GRAY);
                     let truncated = truncate_to_width(hint, input_width);
@@ -1230,13 +1254,25 @@ impl TaskDraw {
         let hints = if is_approval {
             " y approve  n deny  s approve all"
         } else {
-            " Ctrl+C cancel  \u{2191}/\u{2193} scroll  Enter submit"
+            " PgUp/PgDn transcript  Alt+\u{2191}/\u{2193} steps  Shift+Enter newline  Enter submit"
         };
         let _ = write!(w, "{hints}");
 
         // Right side: task ID (right-aligned).
         if !state.task_id.is_empty() {
-            let right_text = format!("task:{} ", state.task_id);
+            let scroll_state = if state.output_scroll_offset > 0 {
+                match state.output_scroll_anchor {
+                    OutputScrollAnchor::Bottom => {
+                        format!("scroll:+{}  ", state.output_scroll_offset)
+                    }
+                    OutputScrollAnchor::Top => {
+                        format!("detail:{}  ", state.output_scroll_offset + 1)
+                    }
+                }
+            } else {
+                String::new()
+            };
+            let right_text = format!("{scroll_state}task:{} ", state.task_id);
             let right_len = display_width(&right_text);
             let left_len = display_width(hints);
             let gap = (regions.cols as usize).saturating_sub(left_len + right_len);
@@ -1298,6 +1334,18 @@ impl TaskDraw {
 
     fn compute_transcript_hash(&self, state: &TaskLayoutState) -> u64 {
         let mut h: u64 = state.output_rows.len() as u64;
+        h = h
+            .wrapping_mul(31)
+            .wrapping_add(simple_hash(&state.output_title));
+        h = h
+            .wrapping_mul(31)
+            .wrapping_add(state.output_scroll_offset as u64);
+        h = h
+            .wrapping_mul(31)
+            .wrapping_add(match state.output_scroll_anchor {
+                OutputScrollAnchor::Top => 1,
+                OutputScrollAnchor::Bottom => 2,
+            });
         for row in &state.output_rows {
             h = h.wrapping_mul(31).wrapping_add(simple_hash(row));
         }
@@ -1370,22 +1418,55 @@ fn parse_status_parts(status: &str) -> StatusParts {
 
 // ── Utilities ───────────────────────────────────────────────────────
 
-/// Draw a star-accented separator line at the given row.
-fn draw_star_separator(w: &mut dyn Write, row: u16, cols: u16) {
+fn transcript_window(state: &TaskLayoutState, viewport_height: usize) -> (usize, usize) {
+    let total = state.output_rows.len();
+    if viewport_height == 0 || total == 0 {
+        return (0, 0);
+    }
+
+    match state.output_scroll_anchor {
+        OutputScrollAnchor::Bottom => {
+            let max_offset = total.saturating_sub(viewport_height);
+            let offset = state.output_scroll_offset.min(max_offset);
+            let start = total.saturating_sub(viewport_height.saturating_add(offset));
+            let end = (start + viewport_height).min(total);
+            (start, end)
+        }
+        OutputScrollAnchor::Top => {
+            let start = state.output_scroll_offset.min(total.saturating_sub(1));
+            let end = (start + viewport_height).min(total);
+            (start, end)
+        }
+    }
+}
+
+/// Draw a labeled separator line at the given row.
+fn draw_labeled_separator(w: &mut dyn Write, row: u16, cols: u16, label: &str) {
     move_to(w, row, 0);
     clear_line(w);
     set_dim(w);
     set_fg(w, DIM_GRAY);
-    let sep_width = (cols as usize).min(120);
-    let star_pos = sep_width / 2;
-    for i in 0..sep_width {
-        if i == star_pos {
-            set_fg(w, YELLOW);
-            let _ = write!(w, "\u{2726}"); // ✦
-            set_fg(w, DIM_GRAY);
+    let safe_label = truncate_to_width(label, cols.saturating_sub(10) as usize);
+    let left_rule = 3.min(cols as usize);
+    for _ in 0..left_rule {
+        let _ = write!(w, "\u{2500}");
+    }
+    if !safe_label.is_empty() {
+        set_fg(w, BLUE);
+        let _ = write!(w, " {safe_label} ");
+        set_fg(w, DIM_GRAY);
+    } else {
+        let _ = write!(w, "\u{2500}");
+    }
+
+    let used = left_rule
+        + if safe_label.is_empty() {
+            1
         } else {
-            let _ = write!(w, "\u{2500}"); // ─
-        }
+            display_width(&safe_label) + 2
+        };
+    for _ in 0..(cols as usize).saturating_sub(used).min(120) {
+        let _ = write!(w, "\u{2500}");
     }
     reset_style(w);
 }
@@ -1431,10 +1512,12 @@ fn composer_cursor_position(state: &TaskLayoutState, regions: &Regions) -> (u16,
     let input_width = regions.cols.saturating_sub(2).max(1) as usize;
     let (cursor_row, cursor_col) =
         cursor_row_col(&state.composer_text, state.composer_cursor, input_width);
-    let window_start = composer_window_start(cursor_row, regions.composer_rows.max(1) as usize);
+    let body_rows = regions.composer_rows.saturating_sub(1).max(1) as usize;
+    let window_start = composer_window_start(cursor_row, body_rows);
     let visible_row = cursor_row.saturating_sub(window_start) as u16;
     let row = regions
         .composer_start
+        .saturating_add(1)
         .saturating_add(visible_row)
         .min(regions.rows.saturating_sub(1));
     let col = (2 + cursor_col as u16).min(regions.cols.saturating_sub(1));
@@ -1453,12 +1536,15 @@ mod tests {
             task_id: "test-001".into(),
             status_line: "mode:streaming approval:none repo:vexcoder inst:AGENTS.md".into(),
             activity_rows: vec![],
+            total_steps: entries.len(),
             timeline_entries: entries,
             selected_step: 0,
-            total_steps: 0,
+            output_title: "Transcript".into(),
             output_rows: output.into_iter().map(|s| s.to_string()).collect(),
+            output_scroll_offset: 0,
+            output_scroll_anchor: OutputScrollAnchor::Bottom,
             pending_approval: None,
-            input_hint: "> ".into(),
+            input_hint: "Prompt\nUse `/` for commands, `@path` to inline files, paste large blocks, and Shift+Enter for a newline.".into(),
             composer_text: String::new(),
             composer_cursor: 0,
             changed_files: vec![],
@@ -1540,6 +1626,27 @@ mod tests {
 
         assert!(output.contains("line 2"), "new line 2 must be drawn");
         assert!(output.contains("line 3"), "new line 3 must be drawn");
+    }
+
+    #[test]
+    fn transcript_scroll_offset_renders_older_rows_from_prompt_edge() {
+        let mut buf = Vec::new();
+        let mut draw = TaskDraw::new();
+        let mut state = make_state(vec![], vec![]);
+        state.output_rows = (0..20).map(|i| format!("line-{i}")).collect();
+        state.output_scroll_offset = 2;
+
+        draw.draw(&mut buf, &state, 80, 12);
+        let output = String::from_utf8_lossy(&buf);
+
+        assert!(
+            output.contains("line-15"),
+            "older transcript rows must stay visible"
+        );
+        assert!(
+            !output.contains("line-19"),
+            "bottom-most rows must move out of view when scrolled upward"
+        );
     }
 
     #[test]
@@ -1665,9 +1772,12 @@ mod tests {
             ],
             selected_step: 0,
             total_steps: 2,
+            output_title: "Inspector".into(),
             output_rows: vec!["Tool: read_file".into(), "Outcome: ok".into()],
+            output_scroll_offset: 0,
+            output_scroll_anchor: OutputScrollAnchor::Top,
             pending_approval: None,
-            input_hint: "> ".into(),
+            input_hint: "Prompt\nUse `/` for commands, `@path` to inline files, paste large blocks, and Shift+Enter for a newline.".into(),
             composer_text: String::new(),
             composer_cursor: 0,
             changed_files: vec![],
@@ -1701,9 +1811,12 @@ mod tests {
             timeline_entries: vec![],
             selected_step: 0,
             total_steps: 0,
+            output_title: "Transcript".into(),
             output_rows: vec!["line 1".into()],
+            output_scroll_offset: 0,
+            output_scroll_anchor: OutputScrollAnchor::Bottom,
             pending_approval: None,
-            input_hint: "> ".into(),
+            input_hint: "Prompt\nUse `/` for commands, `@path` to inline files, paste large blocks, and Shift+Enter for a newline.".into(),
             composer_text: String::new(),
             composer_cursor: 0,
             changed_files: vec![],
@@ -1769,13 +1882,16 @@ mod tests {
             timeline_entries: vec![],
             selected_step: 0,
             total_steps: 0,
+            output_title: "Transcript".into(),
             output_rows: vec![
                 "Type a prompt below to begin.".into(),
                 String::new(),
                 "The orchestrator will call tools and stream results here.".into(),
             ],
+            output_scroll_offset: 0,
+            output_scroll_anchor: OutputScrollAnchor::Bottom,
             pending_approval: None,
-            input_hint: "> ".into(),
+            input_hint: "Prompt\nUse `/` for commands, `@path` to inline files, paste large blocks, and Shift+Enter for a newline.".into(),
             composer_text: String::new(),
             composer_cursor: 0,
             changed_files: vec![],
@@ -1820,16 +1936,22 @@ mod tests {
     #[test]
     fn adaptive_composer_scales_with_terminal_height() {
         let small = Regions::compute(80, 12, false, 0);
-        assert_eq!(small.composer_rows, 1, "small terminal gets 1-row composer");
+        assert_eq!(
+            small.composer_rows, 4,
+            "small terminal keeps a usable multiline prompt surface"
+        );
 
         let medium = Regions::compute(80, 20, false, 0);
         assert_eq!(
-            medium.composer_rows, 2,
-            "medium terminal gets 2-row composer"
+            medium.composer_rows, 5,
+            "medium terminal gets a larger multiline prompt surface"
         );
 
         let large = Regions::compute(80, 40, false, 0);
-        assert_eq!(large.composer_rows, 3, "large terminal gets 3-row composer");
+        assert_eq!(
+            large.composer_rows, 8,
+            "large terminal gets an expanded prompt surface"
+        );
     }
 
     #[test]
@@ -1849,9 +1971,12 @@ mod tests {
             }],
             selected_step: 0,
             total_steps: 1,
+            output_title: "Transcript".into(),
             output_rows: vec![],
+            output_scroll_offset: 0,
+            output_scroll_anchor: OutputScrollAnchor::Bottom,
             pending_approval: None,
-            input_hint: "> ".into(),
+            input_hint: "Prompt\nUse `/` for commands, `@path` to inline files, paste large blocks, and Shift+Enter for a newline.".into(),
             composer_text: String::new(),
             composer_cursor: 0,
             changed_files: vec!["src/main.rs".into()],
@@ -1880,9 +2005,12 @@ mod tests {
             timeline_entries: vec![],
             selected_step: 0,
             total_steps: 0,
+            output_title: "Transcript".into(),
             output_rows: vec![],
+            output_scroll_offset: 0,
+            output_scroll_anchor: OutputScrollAnchor::Bottom,
             pending_approval: Some("write_file: src/main.rs".into()),
-            input_hint: "> ".into(),
+            input_hint: "Approval\n[y/n/s]".into(),
             composer_text: String::new(),
             composer_cursor: 0,
             changed_files: vec![],
@@ -1936,9 +2064,12 @@ mod tests {
             timeline_entries: vec![],
             selected_step: 0,
             total_steps: 0,
+            output_title: "Transcript".into(),
             output_rows: vec![],
+            output_scroll_offset: 0,
+            output_scroll_anchor: OutputScrollAnchor::Bottom,
             pending_approval: None,
-            input_hint: "> ".into(),
+            input_hint: "Prompt\nUse `/` for commands, `@path` to inline files, paste large blocks, and Shift+Enter for a newline.".into(),
             composer_text: String::new(),
             composer_cursor: 0,
             changed_files: vec![],
@@ -1971,9 +2102,12 @@ mod tests {
             timeline_entries: vec![],
             selected_step: 0,
             total_steps: 0,
+            output_title: "Transcript".into(),
             output_rows: vec![],
+            output_scroll_offset: 0,
+            output_scroll_anchor: OutputScrollAnchor::Bottom,
             pending_approval: None,
-            input_hint: "> ".into(),
+            input_hint: "Prompt\nUse `/` for commands, `@path` to inline files, paste large blocks, and Shift+Enter for a newline.".into(),
             composer_text: String::new(),
             composer_cursor: 0,
             changed_files: vec![],
@@ -2000,9 +2134,12 @@ mod tests {
             timeline_entries: vec![],
             selected_step: 0,
             total_steps: 0,
+            output_title: "Transcript".into(),
             output_rows: vec![],
+            output_scroll_offset: 0,
+            output_scroll_anchor: OutputScrollAnchor::Bottom,
             pending_approval: None,
-            input_hint: "> ".into(),
+            input_hint: "Prompt\nUse `/` for commands, `@path` to inline files, paste large blocks, and Shift+Enter for a newline.".into(),
             composer_text: "hello fullscreen".into(),
             composer_cursor: "hello fullscreen".len(),
             changed_files: vec![],
@@ -2028,9 +2165,12 @@ mod tests {
             timeline_entries: vec![],
             selected_step: 0,
             total_steps: 0,
+            output_title: "Transcript".into(),
             output_rows: vec![],
+            output_scroll_offset: 0,
+            output_scroll_anchor: OutputScrollAnchor::Bottom,
             pending_approval: None,
-            input_hint: "> ".into(),
+            input_hint: "Prompt\nUse `/` for commands, `@path` to inline files, paste large blocks, and Shift+Enter for a newline.".into(),
             composer_text: "first".into(),
             composer_cursor: 5,
             changed_files: vec![],
@@ -2059,9 +2199,12 @@ mod tests {
             timeline_entries: vec![],
             selected_step: 0,
             total_steps: 0,
+            output_title: "Transcript".into(),
             output_rows: vec![],
+            output_scroll_offset: 0,
+            output_scroll_anchor: OutputScrollAnchor::Bottom,
             pending_approval: None,
-            input_hint: "> ".into(),
+            input_hint: "Prompt\nUse `/` for commands, `@path` to inline files, paste large blocks, and Shift+Enter for a newline.".into(),
             composer_text: "same text".into(),
             composer_cursor: 2,
             changed_files: vec![],

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -35,7 +35,7 @@ pub struct FourRegionLayout {
 
 pub fn split_four_region_layout(area: Rect, header_rows: u16, input_rows: u16) -> FourRegionLayout {
     let header_rows = header_rows.clamp(1, 2);
-    let input_rows = input_rows.clamp(3, 4);
+    let input_rows = input_rows.clamp(3, 8);
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -219,7 +219,20 @@ pub fn render_status_line(frame: &mut Frame<'_>, area: Rect, status: &str) {
 pub fn render_task_layout(frame: &mut Frame<'_>, state: &TaskLayoutState) {
     use crate::app::StepLifecycle;
 
-    let layout = split_four_region_layout(frame.area(), 2, 3);
+    let preferred_input_rows = if frame.area().height >= 30 {
+        7
+    } else if frame.area().height >= 22 {
+        6
+    } else if frame.area().height >= 16 {
+        5
+    } else {
+        4
+    };
+    let input_rows = preferred_input_rows.max(input_visual_rows(
+        &state.composer_text,
+        frame.area().width.max(1) as usize,
+    ));
+    let layout = split_four_region_layout(frame.area(), 2, input_rows as u16);
     frame.render_widget(Clear, frame.area());
 
     // --- Header ---
@@ -329,24 +342,28 @@ pub fn render_task_layout(frame: &mut Frame<'_>, state: &TaskLayoutState) {
     }
 
     // --- Output / Inspector pane ---
-    let output_title = if !state.timeline_entries.is_empty() {
-        "Inspector"
-    } else {
-        "Output"
-    };
-
     let output_lines: Vec<Line> = state
         .output_rows
         .iter()
         .map(|row| Line::from(row.to_string()))
         .collect();
-    let output_scroll = output_lines
-        .len()
-        .saturating_sub(layout.output.height.max(1) as usize) as u16;
+    let output_scroll = match state.output_scroll_anchor {
+        crate::app::OutputScrollAnchor::Bottom => output_lines
+            .len()
+            .saturating_sub(layout.output.height.max(1) as usize + state.output_scroll_offset)
+            as u16,
+        crate::app::OutputScrollAnchor::Top => {
+            state.output_scroll_offset.min(u16::MAX as usize) as u16
+        }
+    };
 
     frame.render_widget(
         Paragraph::new(Text::from(output_lines))
-            .block(Block::default().borders(Borders::NONE).title(output_title))
+            .block(
+                Block::default()
+                    .borders(Borders::NONE)
+                    .title(state.output_title.clone()),
+            )
             .scroll((output_scroll, 0))
             .wrap(Wrap { trim: false }),
         layout.output,
@@ -831,7 +848,10 @@ mod tests {
             }],
             selected_step: 0,
             total_steps: 1,
+            output_title: "Transcript".into(),
             output_rows: vec![],
+            output_scroll_offset: 0,
+            output_scroll_anchor: crate::app::OutputScrollAnchor::Bottom,
             changed_files: vec!["src/main.rs".into()],
             pending_approval: Some("ApplyPatch: src/main.rs".into()),
             input_hint: "ApplyPatch: src/main.rs\n[y/n/s] ".into(),
@@ -892,7 +912,10 @@ mod tests {
             ],
             selected_step: 1,
             total_steps: 2,
+            output_title: "Inspector".into(),
             output_rows: vec!["streamed output".into()],
+            output_scroll_offset: 0,
+            output_scroll_anchor: crate::app::OutputScrollAnchor::Top,
             changed_files: vec![],
             pending_approval: None,
             input_hint: "> ".into(),


### PR DESCRIPTION
## Motivation

**Repo:** `aistar-au/vexcoder`

This change updates the active task surface so transcript output grows upward from the composer edge, the prompt area supports larger multiline editing, and the task-state/UI contract stays aligned with [ADR-031](https://github.com/aistar-au/vexcoder/blob/main/adr/ADR-031-operator-surface-ui-overhaul.md), [ADR-027](https://github.com/aistar-au/vexcoder/blob/main/adr/ADR-027-full-screen-tui-command-session-capture.md), and [ADR-028](https://github.com/aistar-au/vexcoder/blob/main/adr/ADR-028-application-facade-and-transport-boundaries.md). It resolves the current mismatch between the fullscreen operator surface and the expected terminal workflow by moving output scrolling, composer sizing, and documentation to the same runtime-owned contract.

### What Changed

The task-layout state now distinguishes transcript output from inspector/detail output with explicit scroll anchors and per-pane scroll offsets, so transcript navigation remains bottom-anchored while inspector content remains top-anchored. The direct ANSI renderer and the ratatui fallback now consume the same output-title and scroll metadata, and the composer grows into a larger multiline surface with prompt affordances for slash commands, file insertion, pasted blocks, and newline insertion. Keybindings now route `PageUp`, `PageDown`, `Ctrl+Up`, `Ctrl+Down`, `Ctrl+Home`, and `Ctrl+End` to the output pane, while turn and stream updates preserve or reset scroll offsets at the appropriate lifecycle boundaries. The related architecture and operator-surface documents were refreshed to match the shipped behavior, and the pre-push review gate completed without findings after the fallback review path returned a clean result.

### Files changed

- `adr/ADR-028-application-facade-and-transport-boundaries.md` (+10/-12) — clarifies alternate-screen ownership so the architecture notes match the current fullscreen session model.
- `adr/ADR-031-operator-surface-ui-overhaul.md` (+9/-1) — records the prompt-anchored transcript flow and larger multiline composer behavior in the active operator-surface ADR.
- `docs/src/architecture.md` (+2/-2) — updates the architecture summary to describe stable step identity together with prompt-anchored transcript scrolling and the larger composer.
- `docs/src/commands.md` (+9/-5) — refreshes operator-surface guidance and keyboard behavior for output scrolling, multiline entry, and pasted prompt text.
- `src/app.rs` (+21/-0) — adds output scroll-anchor metadata and separate transcript and inspector scroll state to the task layout and TUI mode structs.
- `src/app/ctor.rs` (+2/-0) — initializes the new scroll state fields for each task-surface session.
- `src/app/layout.rs` (+33/-13) — refactors task output selection into a shared output-view model with titles, rows, and anchor semantics.
- `src/app/model_update.rs` (+11/-0) — preserves transcript position on output growth and resets inspector position when timeline selection follows new activity.
- `src/app/scroll.rs` (+89/-0) — adds output-pane scrolling logic, clamping, and prompt-edge semantics for transcript navigation.
- `src/app/tests.rs` (+42/-0) — covers the new bottom-anchored output scrolling behavior.
- `src/app/turn.rs` (+6/-0) — resets the new scroll state during turn lifecycle transitions.
- `src/bin/vex.rs` (+12/-12) — reroutes task-surface keybindings from history scrolling to output scrolling.
- `src/runtime/frontend.rs` (+1/-0) — adds the new output scroll target for runtime/frontend event routing.
- `src/ui/draw.rs` (+246/-103) — overhauls the fullscreen renderer with labeled output sections, prompt-edge transcript windowing, and a larger multiline composer.
- `src/ui/layout.rs` (+1/-1) — increases the allowed composer height range for the larger prompt surface.
- `src/ui/render.rs` (+34/-11) — aligns the ratatui renderer with the new output-title, anchor, and adaptive composer sizing model.

### References

- [ADR-027](https://github.com/aistar-au/vexcoder/blob/main/adr/ADR-027-full-screen-tui-command-session-capture.md) — fullscreen TUI command-session capture and transcript ownership.
- [ADR-028](https://github.com/aistar-au/vexcoder/blob/main/adr/ADR-028-application-facade-and-transport-boundaries.md) — application facade and transport boundary rules.
- [ADR-031](https://github.com/aistar-au/vexcoder/blob/main/adr/ADR-031-operator-surface-ui-overhaul.md) — operator-surface layout, timeline, and prompt-surface direction.
