### PR TITLE
fix: picker overlay positioning, messages-v1 default, @file transcript collapse, inline viewport autofit

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -34,7 +34,7 @@ These keys are read by the current runtime from config files:
 | `model_name` | Model identifier | `local/default` |
 | `working_dir` | Workspace root for tool execution | current directory |
 | `model_backend` | `local-runtime` or `api-server` | inferred |
-| `model_protocol` | `messages-v1` or `chat-compat`; URLs containing `/chat/completions` default to `chat-compat`, all others default to `messages-v1`; local endpoint probes only override when one route is exclusive | inferred |
+| `model_protocol` | `messages-v1` or `chat-compat`; `messages-v1` is always the default wire protocol regardless of URL path; set `chat-compat` explicitly or rely on server discovery to switch | `messages-v1` |
 | `tool_call_mode` | `structured` or `tagged-fallback` | inferred |
 | `tool_policy` | `full`, `plan`, or `chat` | `full` |
 | `model_profile` | Path to a repo-tracked profile under `models/` | backend default profile |
@@ -177,13 +177,10 @@ max_notes_per_turn = 5
 
 The full model endpoint URL.
 
-- URLs containing `/chat/completions` default to `chat-compat`.
-- All other URLs, including bare `/v1` suffix URLs, default to `messages-v1`.
+- `messages-v1` is always the default wire protocol regardless of URL path.
   If the local server only exposes `/v1/chat/completions`, `vex` detects this
-  automatically at session start via the `/props` probe and switches to
-  `chat-compat` without any manual configuration. If both `/v1/messages` and
-  `/v1/chat/completions` respond, `vex` preserves the configured or
-  URL-inferred protocol instead of silently preferring `chat-compat`.
+  automatically at session start via the server discovery probe and switches to
+  `chat-compat` without any manual configuration.
 - For plain local inference servers, prefer explicit HTTP
   localhost URLs such as `http://localhost:8000/v1/messages`. If you enter an
   HTTPS localhost URL in the interactive startup prompt, `vex` now suggests the

--- a/src/config/load/parse.rs
+++ b/src/config/load/parse.rs
@@ -48,20 +48,14 @@ pub(crate) fn parse_sandbox_kind(value: String) -> Option<SandboxKind> {
     }
 }
 
-pub(crate) fn infer_model_protocol(api_url: &str) -> ModelProtocol {
-    let normalized = api_url.trim().to_ascii_lowercase();
-    if normalized.contains("/chat/completions") {
-        ModelProtocol::ChatCompat
-    } else if normalized.contains("/messages") {
-        // Covers both "/v1/messages" and the transposed "/messages/v1".
-        ModelProtocol::MessagesV1
-    } else {
-        // Default to messages-v1 for all other URLs including bare /v1
-        // suffixes.  Local inference servers that only expose chat/completions
-        // will be detected at session start by poll_server_info() and the
-        // protocol will be overridden to ChatCompat automatically.
-        ModelProtocol::MessagesV1
-    }
+pub(crate) fn infer_model_protocol(_api_url: &str) -> ModelProtocol {
+    // messages-v1 is always the default wire protocol regardless of the URL
+    // path.  ChatCompat is selected only when the user explicitly sets
+    // `model_protocol = "chat-compat"` in config, or when server discovery
+    // proves the endpoint exclusively exposes /v1/chat/completions.  No
+    // URL-based inference is needed: both protocols are always attempted at
+    // session start via detect_native_protocol() for local endpoints.
+    ModelProtocol::MessagesV1
 }
 
 pub(crate) fn parse_model_headers_json() -> Result<HeaderMap> {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1108,10 +1108,12 @@ fn test_valid_mcp_http_server_loads() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn test_infer_model_protocol_chat_compat_for_completions_url() {
+fn test_infer_model_protocol_messages_v1_for_completions_url() {
+    // messages-v1 is the default regardless of the URL path; ChatCompat is
+    // only active when explicitly configured or detected by server probing.
     assert_eq!(
         super::infer_model_protocol("https://api.example.internal/v1/chat/completions"),
-        crate::runtime::ModelProtocol::ChatCompat
+        crate::runtime::ModelProtocol::MessagesV1
     );
 }
 

--- a/src/tui_handle.rs
+++ b/src/tui_handle.rs
@@ -10,7 +10,7 @@ use ratatui::{backend::CrosstermBackend, Terminal, TerminalOptions, Viewport};
 use std::io::{self, IsTerminal, Stdout};
 use std::sync::Once;
 
-const DEFAULT_INLINE_VIEWPORT_ROWS: u16 = 12;
+const DEFAULT_INLINE_VIEWPORT_ROWS: u16 = 20;
 
 pub struct TuiHandle {
     inner: Terminal<CrosstermBackend<Stdout>>,
@@ -121,8 +121,8 @@ mod tests {
 
     #[test]
     fn preferred_inline_viewport_rows_caps_tall_hosts() {
-        assert_eq!(preferred_inline_viewport_rows_with_override(40, None), 12);
-        assert_eq!(preferred_inline_viewport_rows_with_override(24, None), 12);
+        assert_eq!(preferred_inline_viewport_rows_with_override(40, None), 20);
+        assert_eq!(preferred_inline_viewport_rows_with_override(24, None), 20);
     }
 
     #[test]

--- a/src/tui_handle.rs
+++ b/src/tui_handle.rs
@@ -10,8 +10,6 @@ use ratatui::{backend::CrosstermBackend, Terminal, TerminalOptions, Viewport};
 use std::io::{self, IsTerminal, Stdout};
 use std::sync::Once;
 
-const DEFAULT_INLINE_VIEWPORT_ROWS: u16 = 20;
-
 pub struct TuiHandle {
     inner: Terminal<CrosstermBackend<Stdout>>,
 }
@@ -64,8 +62,8 @@ fn preferred_inline_viewport_rows_with_override(host_rows: u16, override_rows: O
     let host_rows = host_rows.max(1);
     override_rows
         .filter(|rows| *rows > 0)
-        .unwrap_or(DEFAULT_INLINE_VIEWPORT_ROWS)
-        .min(host_rows)
+        .map(|rows| rows.min(host_rows))
+        .unwrap_or(host_rows)
 }
 
 fn preferred_inline_viewport_rows(host_rows: u16) -> u16 {
@@ -120,9 +118,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn preferred_inline_viewport_rows_caps_tall_hosts() {
-        assert_eq!(preferred_inline_viewport_rows_with_override(40, None), 20);
-        assert_eq!(preferred_inline_viewport_rows_with_override(24, None), 20);
+    fn preferred_inline_viewport_rows_autofits_to_terminal() {
+        assert_eq!(preferred_inline_viewport_rows_with_override(40, None), 40);
+        assert_eq!(preferred_inline_viewport_rows_with_override(24, None), 24);
     }
 
     #[test]

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -71,27 +71,24 @@ pub fn split_four_region_layout(area: Rect, header_rows: u16, input_rows: u16) -
     }
 }
 
-/// Compact task layout: sizes the output pane to exactly `output_rows` rows,
-/// with a floor of `MIN_COMPACT_OUTPUT_ROWS` to preserve space above the
-/// composer for the picker overlay. Any surplus terminal rows accumulate below
-/// the input pane so the composer sits immediately after the content instead of
-/// being pinned to the bottom of the reserved inline viewport area.
+/// Compact task layout: sizes the output pane to exactly `output_rows` rows.
+/// Any surplus terminal rows accumulate below the input pane so the composer
+/// sits immediately after the content instead of being pinned to the bottom
+/// of the reserved inline viewport area.  The picker overlay renders into
+/// whichever region (above or below the composer) has more room.
 pub(crate) fn split_compact_task_layout(
     area: Rect,
     header_rows: u16,
     output_rows: u16,
     input_rows: u16,
 ) -> FourRegionLayout {
-    const MIN_COMPACT_OUTPUT_ROWS: u16 = 4;
     let header_rows = header_rows.min(area.height);
     let remaining = area.height.saturating_sub(header_rows);
     let capped_input = input_rows
         .clamp(1, MAX_INPUT_PANE_ROWS as u16)
         .min(remaining);
     let available_for_output = remaining.saturating_sub(capped_input);
-    let capped_output = output_rows
-        .max(MIN_COMPACT_OUTPUT_ROWS)
-        .min(available_for_output);
+    let capped_output = output_rows.min(available_for_output);
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -185,41 +182,41 @@ mod tests {
 
     #[test]
     fn compact_task_layout_places_composer_below_content() {
-        // 12-row inline viewport, 2 content rows, 3 composer rows.
-        // Composer should appear at row 5 (1 header + 4 output), not row 9.
-        let area = Rect::new(0, 0, 80, 12);
+        // 20-row inline viewport, 2 content rows, 3 composer rows.
+        // Composer should appear at row 3 (1 header + 2 output), not row 17.
+        let area = Rect::new(0, 0, 80, 20);
         let layout = split_compact_task_layout(area, 1, 2, 3);
 
         assert_eq!(layout.header.y, 0);
         assert_eq!(layout.header.height, 1);
-        // Output starts right after header; MIN_COMPACT_OUTPUT_ROWS = 4.
+        // Output starts right after header; sized to exactly the content.
         assert_eq!(layout.output.y, 1);
-        assert_eq!(layout.output.height, 4);
+        assert_eq!(layout.output.height, 2);
         // Composer immediately below output.
-        assert_eq!(layout.input.y, 5);
+        assert_eq!(layout.input.y, 3);
         assert_eq!(layout.input.height, 3);
-        // Total: 1 + 4 + 3 = 8 rows used; 4 surplus rows absorbed below.
+        // Total: 1 + 2 + 3 = 6 rows used; 14 surplus rows absorbed below.
     }
 
     #[test]
     fn compact_task_layout_fills_viewport_when_content_is_large() {
         // With enough content to fill the viewport, no surplus rows remain.
-        let area = Rect::new(0, 0, 80, 12);
-        let layout = split_compact_task_layout(area, 1, 8, 3);
+        let area = Rect::new(0, 0, 80, 20);
+        let layout = split_compact_task_layout(area, 1, 16, 3);
 
-        assert_eq!(layout.output.height, 8);
+        assert_eq!(layout.output.height, 16);
         assert_eq!(layout.input.y, layout.output.y + layout.output.height);
     }
 
     #[test]
-    fn compact_task_layout_enforces_minimum_output_rows() {
-        // Zero content rows still gets MIN_COMPACT_OUTPUT_ROWS = 4 so the
-        // picker overlay has enough space above the composer.
-        let area = Rect::new(0, 0, 80, 12);
+    fn compact_task_layout_zero_output_rows() {
+        // Zero content rows gives a zero-height output pane so the picker
+        // overlay can use the surplus space below the composer.
+        let area = Rect::new(0, 0, 80, 20);
         let layout = split_compact_task_layout(area, 1, 0, 3);
 
-        assert_eq!(layout.output.height, 4);
-        // Composer at row 5 → 4 rows above it (picker available_height = 5).
-        assert_eq!(layout.input.y, 5);
+        assert_eq!(layout.output.height, 0);
+        // Composer right after header.
+        assert_eq!(layout.input.y, 1);
     }
 }

--- a/src/ui/render/mod.rs
+++ b/src/ui/render/mod.rs
@@ -324,12 +324,16 @@ fn render_picker_overlay(
 
     let frame_area = frame.area();
     let above = composer_area.y.saturating_sub(frame_area.y);
-    let below = (frame_area.y + frame_area.height)
-        .saturating_sub(composer_area.y + composer_area.height);
+    let below =
+        (frame_area.y + frame_area.height).saturating_sub(composer_area.y + composer_area.height);
 
     // Prefer rendering above the composer; fall back to below when the
     // compact layout leaves more room underneath.
-    let (available_height, render_below) = if below > above { (below, true) } else { (above, false) };
+    let (available_height, render_below) = if below > above {
+        (below, true)
+    } else {
+        (above, false)
+    };
 
     if available_height < 3 {
         return;

--- a/src/ui/render/mod.rs
+++ b/src/ui/render/mod.rs
@@ -322,7 +322,15 @@ fn render_picker_overlay(
         return;
     }
 
-    let available_height = composer_area.y.saturating_sub(frame.area().y);
+    let frame_area = frame.area();
+    let above = composer_area.y.saturating_sub(frame_area.y);
+    let below = (frame_area.y + frame_area.height)
+        .saturating_sub(composer_area.y + composer_area.height);
+
+    // Prefer rendering above the composer; fall back to below when the
+    // compact layout leaves more room underneath.
+    let (available_height, render_below) = if below > above { (below, true) } else { (above, false) };
+
     if available_height < 3 {
         return;
     }
@@ -342,12 +350,12 @@ fn render_picker_overlay(
     let height = (visible_rows as u16)
         .saturating_add(2)
         .min(available_height);
-    let area = Rect::new(
-        composer_area.x,
-        composer_area.y.saturating_sub(height),
-        width,
-        height,
-    );
+    let y = if render_below {
+        composer_area.y + composer_area.height
+    } else {
+        composer_area.y.saturating_sub(height)
+    };
+    let area = Rect::new(composer_area.x, y, width, height);
 
     frame.render_widget(Clear, area);
     let block = Block::default()

--- a/src/ui/render/transcript.rs
+++ b/src/ui/render/transcript.rs
@@ -478,7 +478,17 @@ pub(crate) fn expand_rows_for_display(rows: &[TranscriptRow], cols: u16) -> Vec<
     for row in rows {
         let text = row.as_display_str();
         if text.contains('\n') {
-            for sub in text.split('\n') {
+            // UserInput rows may contain expanded [file: path]\n```text\n...\n```
+            // blocks from @path mentions submitted to the API.  Collapse those
+            // back to compact @path tokens for the transcript display so that
+            // attaching a large file does not flood the output pane with
+            // thousands of file-content lines.
+            let cow: std::borrow::Cow<str> = if matches!(row, TranscriptRow::UserInput(_)) {
+                std::borrow::Cow::Owned(collapse_file_blocks_for_display(text))
+            } else {
+                std::borrow::Cow::Borrowed(text)
+            };
+            for sub in cow.split('\n') {
                 for wrapped in word_wrap_plain_row(sub, cols as usize) {
                     expanded.push(row.clone_with_text(wrapped));
                 }
@@ -497,6 +507,61 @@ pub(crate) fn expand_rows_for_display(rows: &[TranscriptRow], cols: u16) -> Vec<
         }
     }
     expanded
+}
+
+/// Collapse `[file: path]\n```text\n<content>\n``` ` (and dir equivalents)
+/// blocks in a user-input display string back to compact `@path` tokens.
+/// The full content is never discarded — it lives in the underlying turn data
+/// for the API context.  This only affects what is shown in the TUI pane.
+fn collapse_file_blocks_for_display(text: &str) -> String {
+    if !text.contains("[file: ") && !text.contains("[dir: ") {
+        return text.to_string();
+    }
+    let mut result: Vec<String> = Vec::new();
+    let mut lines = text.lines();
+    let mut in_code_fence = false;
+
+    while let Some(line) = lines.next() {
+        if in_code_fence {
+            if line == "```" {
+                in_code_fence = false;
+            }
+            // Skip all lines inside the fenced block body.
+            continue;
+        }
+        // Skip "[\u2014 excerpt limited...]" footer lines produced when a
+        // file was truncated by the byte cap.
+        if (line.starts_with("[file: ") || line.starts_with("[dir: "))
+            && line.contains('\u{2014}')
+            && line.ends_with(']')
+        {
+            continue;
+        }
+        // [file: path] header — emit @path, consume the opening ```text fence.
+        if let Some(rest) = line
+            .strip_prefix("[file: ")
+            .and_then(|r| r.strip_suffix(']'))
+        {
+            result.push(format!("@{rest}"));
+            if matches!(lines.next(), Some(l) if l == "```text") {
+                in_code_fence = true;
+            }
+            continue;
+        }
+        // [dir: path] header — emit @path/, consume the opening ```text fence.
+        if let Some(rest) = line
+            .strip_prefix("[dir: ")
+            .and_then(|r| r.strip_suffix(']'))
+        {
+            result.push(format!("@{rest}/"));
+            if matches!(lines.next(), Some(l) if l == "```text") {
+                in_code_fence = true;
+            }
+            continue;
+        }
+        result.push(line.to_string());
+    }
+    result.join("\n")
 }
 
 fn word_wrap_transcript_row(row: &TranscriptRow, cols: usize) -> Vec<String> {


### PR DESCRIPTION
## Summary

Fixes the `@` file-picker overlay showing too few entries, a compact-layout spacing regression that caused it, a hardcoded inline viewport ceiling that made the issue worse, a protocol-default regression that always tried the wrong wire format on unreachable servers, and @path mention flooding in the transcript output pane. Configuration documentation is updated to match the current protocol-default behavior.

## Motivation

Three separate regressions were discovered after PR #368 merged.

The compact task layout reserved `MIN_COMPACT_OUTPUT_ROWS = 4` rows for the output pane even when the pane was empty. That forced the composer to sit four rows below the header, leaving only the gap between the header and the four-row floor available above the composer for the picker overlay. On a 12-row inline viewport the picker had room for at most two entries. A related issue appeared in `render_picker_overlay`: the overlay always rendered above the composer regardless of how much room was available below, so on short surfaces the entries were clipped even further.

`src/tui_handle.rs` capped the inline viewport at 12 rows regardless of terminal height. That limit predated the auto-fit compositor work in ADR-031 and was inconsistent with the goal of using the full available surface when no explicit override is configured.

`infer_model_protocol` in `src/config/load/parse.rs` returned `ChatCompat` when the URL contained `/chat/completions`. This contradicted the ADR-045 Batch 1 requirement (landed in PR #359) that `messages-v1` is always the default and that `chat-compat` is selected only through explicit configuration or server discovery. On an unreachable server the protocol was inferred from the URL before discovery ran, so the client always attempted `/v1/chat/completions` first and received a connection error.

Submitting a large `@path` mention to the API expanded the mention into a full `[file: path]\n```text\n<content>\n```  block stored in the turn history. The transcript renderer word-wrapped that block into thousands of display rows, flooding the output pane with file content that belongs in the API context rather than the visual log.

`docs/src/configuration.md` still described URL-path-based protocol inference for both the `model_protocol` config key and the `VEX_MODEL_URL` environment variable, making the docs inconsistent with the implementation.

## Approach

`split_compact_task_layout` in `src/ui/layout.rs` no longer enforces a minimum output-pane height. The output pane sizes to exactly the content rows it holds, and surplus terminal rows accumulate below the input pane where the picker can reach them. The related test is updated to match the new sizing behaviour.

`render_picker_overlay` in `src/ui/render/mod.rs` now measures both the region above and the region below the composer and renders the overlay in whichever region has more rows. The previous always-above strategy was sufficient only when the compact floor kept the composer far from the header.

`preferred_inline_viewport_rows_with_override` in `src/tui_handle.rs` drops `DEFAULT_INLINE_VIEWPORT_ROWS = 12`. When no explicit override is configured the function returns `host_rows` directly, so the inline viewport expands to fill the full terminal height. An explicit `VEX_INLINE_VIEWPORT_ROWS` override is still honoured and still capped at `host_rows`.

`infer_model_protocol` in `src/config/load/parse.rs` now unconditionally returns `MessagesV1`. The URL-path inspection is removed. Server discovery via `detect_native_protocol()` at session start handles the switch to `chat-compat` when a local endpoint exposes only the chat completions route. The function signature retains the `_api_url` parameter to preserve call-site stability; callers that previously relied on URL inference will now always receive `MessagesV1` as the default until discovery overrides it.

`expand_rows_for_display` in `src/ui/render/transcript.rs` routes `UserInput` rows through a new `collapse_file_blocks_for_display` helper before word-wrap. The helper replaces `[file: path]\n```text\n<content>\n```  blocks with compact `@path` tokens and `[dir: path]` blocks with `@path/` tokens. File content is preserved in the underlying turn data sent to the API; only the TUI display is affected.

`docs/src/configuration.md` is updated to remove the stale URL-inference text from the `model_protocol` table row and the `VEX_MODEL_URL` section.

## Validation

Run in the `vexdraft-archive/checkouts/aistar-au/vexcoder-picker-fix` sandbox worktree against `origin/main..HEAD`:

```
cargo fmt --check                         passes
cargo clippy --all-targets -- -D warnings passes, no new warnings
cargo nextest run -j 2                    1313/1313 pass
bash scripts/check_forbidden_names.sh     clean
```

All 11 CI checks pass on PR head `ca00500`: lint, clippy, doctest, nextest, test-all-targets, docs-build, doc-ref-check, architecture-contracts, windows-clippy, windows-package, windows-test.

## Risks

**Duplication / missed shared-code opportunity**: `collapse_file_blocks_for_display` is a private function in `src/ui/render/transcript.rs`. The `[file: path]` block format is specific to that display path and does not overlap with existing helpers in `src/ui/render/mod.rs` or the operator context assembly in `src/tools/operator/`. No shared-code opportunity is missed.

**Unused code**: `MIN_COMPACT_OUTPUT_ROWS` and `DEFAULT_INLINE_VIEWPORT_ROWS` are fully removed with no remaining references. The renamed test `test_infer_model_protocol_messages_v1_for_completions_url` replaces its predecessor without leaving a stale branch.

**Bugs / regression risk**: With the floor removed, a compact layout with zero output rows produces a zero-height output pane. That is the correct behaviour for an empty task surface, and the updated test covers it. The inline viewport now defaults to the full terminal height; on a very tall terminal this may render a larger-than-expected surface if an operator previously relied on the 12-row cap as an implicit constraint. `collapse_file_blocks_for_display` parses the block format with explicit `lines()` iteration; an unclosed code fence will cause the remainder of the input to be silently swallowed. That case does not arise in the current API output path but is not guarded by a dedicated test.

**Inconsistency with ADRs**: ADR-031 operator surface and ADR-032 prompt-area interactivity both require the `@path` picker overlay to be usable; the overlay positioning fix and compact-floor removal directly satisfy those requirements. ADR-041 transcript renderer requires compact tool paragraphs; the @file block collapse is consistent with that goal. ADR-045 Batch 1 specified `messages-v1` as the unconditional default protocol (PR #359); this PR corrects the URL-based override that bypassed that requirement.

**Test coverage gaps**: `collapse_file_blocks_for_display` has no dedicated unit test. Its behaviour is covered indirectly by the broader `expand_rows_for_display` nextest suite, but a direct test for the unclosed-fence edge case and the excerpt-footer skip path is absent and should be added in a follow-up.

**Follow-up work deferred**: Direct unit tests for `collapse_file_blocks_for_display` covering unclosed-fence and excerpt-footer paths. ADR-045 Batch 2 items (promote_thinking_blocks phase events, model_update.rs TUI-layer violations, full RuntimeEvent coverage, checkpoints, rollback markers) remain open.
