### PR TITLE
fix: messages-v1 default without URL inference, collapse @file blocks in transcript

### DIFF
--- a/src/config/load/parse.rs
+++ b/src/config/load/parse.rs
@@ -48,20 +48,14 @@ pub(crate) fn parse_sandbox_kind(value: String) -> Option<SandboxKind> {
     }
 }
 
-pub(crate) fn infer_model_protocol(api_url: &str) -> ModelProtocol {
-    let normalized = api_url.trim().to_ascii_lowercase();
-    if normalized.contains("/chat/completions") {
-        ModelProtocol::ChatCompat
-    } else if normalized.contains("/messages") {
-        // Covers both "/v1/messages" and the transposed "/messages/v1".
-        ModelProtocol::MessagesV1
-    } else {
-        // Default to messages-v1 for all other URLs including bare /v1
-        // suffixes.  Local inference servers that only expose chat/completions
-        // will be detected at session start by poll_server_info() and the
-        // protocol will be overridden to ChatCompat automatically.
-        ModelProtocol::MessagesV1
-    }
+pub(crate) fn infer_model_protocol(_api_url: &str) -> ModelProtocol {
+    // messages-v1 is always the default wire protocol regardless of the URL
+    // path.  ChatCompat is selected only when the user explicitly sets
+    // `model_protocol = "chat-compat"` in config, or when server discovery
+    // proves the endpoint exclusively exposes /v1/chat/completions.  No
+    // URL-based inference is needed: both protocols are always attempted at
+    // session start via detect_native_protocol() for local endpoints.
+    ModelProtocol::MessagesV1
 }
 
 pub(crate) fn parse_model_headers_json() -> Result<HeaderMap> {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1108,10 +1108,12 @@ fn test_valid_mcp_http_server_loads() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn test_infer_model_protocol_chat_compat_for_completions_url() {
+fn test_infer_model_protocol_messages_v1_for_completions_url() {
+    // messages-v1 is the default regardless of the URL path; ChatCompat is
+    // only active when explicitly configured or detected by server probing.
     assert_eq!(
         super::infer_model_protocol("https://api.example.internal/v1/chat/completions"),
-        crate::runtime::ModelProtocol::ChatCompat
+        crate::runtime::ModelProtocol::MessagesV1
     );
 }
 

--- a/src/ui/render/transcript.rs
+++ b/src/ui/render/transcript.rs
@@ -478,7 +478,17 @@ pub(crate) fn expand_rows_for_display(rows: &[TranscriptRow], cols: u16) -> Vec<
     for row in rows {
         let text = row.as_display_str();
         if text.contains('\n') {
-            for sub in text.split('\n') {
+            // UserInput rows may contain expanded [file: path]\n```text\n...\n```
+            // blocks from @path mentions submitted to the API.  Collapse those
+            // back to compact @path tokens for the transcript display so that
+            // attaching a large file does not flood the output pane with
+            // thousands of file-content lines.
+            let cow: std::borrow::Cow<str> = if matches!(row, TranscriptRow::UserInput(_)) {
+                std::borrow::Cow::Owned(collapse_file_blocks_for_display(text))
+            } else {
+                std::borrow::Cow::Borrowed(text)
+            };
+            for sub in cow.split('\n') {
                 for wrapped in word_wrap_plain_row(sub, cols as usize) {
                     expanded.push(row.clone_with_text(wrapped));
                 }
@@ -497,6 +507,55 @@ pub(crate) fn expand_rows_for_display(rows: &[TranscriptRow], cols: u16) -> Vec<
         }
     }
     expanded
+}
+
+/// Collapse `[file: path]\n```text\n<content>\n``` ` (and dir equivalents)
+/// blocks in a user-input display string back to compact `@path` tokens.
+/// The full content is never discarded — it lives in the underlying turn data
+/// for the API context.  This only affects what is shown in the TUI pane.
+fn collapse_file_blocks_for_display(text: &str) -> String {
+    if !text.contains("[file: ") && !text.contains("[dir: ") {
+        return text.to_string();
+    }
+    let mut result: Vec<String> = Vec::new();
+    let mut lines = text.lines();
+    let mut in_code_fence = false;
+
+    while let Some(line) = lines.next() {
+        if in_code_fence {
+            if line == "```" {
+                in_code_fence = false;
+            }
+            // Skip all lines inside the fenced block body.
+            continue;
+        }
+        // Skip "[\u2014 excerpt limited...]" footer lines produced when a
+        // file was truncated by the byte cap.
+        if (line.starts_with("[file: ") || line.starts_with("[dir: "))
+            && line.contains('\u{2014}')
+            && line.ends_with(']')
+        {
+            continue;
+        }
+        // [file: path] header — emit @path, consume the opening ```text fence.
+        if let Some(rest) = line.strip_prefix("[file: ").and_then(|r| r.strip_suffix(']')) {
+            result.push(format!("@{rest}"));
+            if matches!(lines.next(), Some(l) if l == "```text") {
+                in_code_fence = true;
+            }
+            continue;
+        }
+        // [dir: path] header — emit @path/, consume the opening ```text fence.
+        if let Some(rest) = line.strip_prefix("[dir: ").and_then(|r| r.strip_suffix(']')) {
+            result.push(format!("@{rest}/"));
+            if matches!(lines.next(), Some(l) if l == "```text") {
+                in_code_fence = true;
+            }
+            continue;
+        }
+        result.push(line.to_string());
+    }
+    result.join("\n")
 }
 
 fn word_wrap_transcript_row(row: &TranscriptRow, cols: usize) -> Vec<String> {


### PR DESCRIPTION
## Summary

Fixes two issues discovered post-PR-368: messages-v1 default and @file transcript flooding.

### Fix 1 — messages-v1 is always the default (issue 1)

`infer_model_protocol()` in `src/config/load/parse.rs` returned `ChatCompat` when the
URL contained `/chat/completions`. With an unreachable server (`detect_native_protocol()`
returns None), the client used the URL-inferred ChatCompat → tried `/v1/chat/completions`
→ error.

Fix: `infer_model_protocol()` always returns `MessagesV1`. ChatCompat activates only when
explicitly set (`model_protocol = "chat-compat"`) or server discovery proves the endpoint
exclusively exposes `/v1/chat/completions`.

Test renamed: `test_infer_model_protocol_chat_compat_for_completions_url`
→ `test_infer_model_protocol_messages_v1_for_completions_url`.

---

### Fix 2 — @file attachment no longer floods the transcript (issue 3)

Root cause: `expand_inline_file_tokens()` replaces `@path` with a multi-line
`[file: path]\n```text\n<content>\n``` ` block. In `expand_rows_for_display()`, the
`text.contains('\n')` check fired before the structural-row guard, splitting every file
content line into a separate `TranscriptRow::UserInput` row — each rendered with `> `.
A 200-line YAML file → 200 transcript rows with `> ` prefix.

Fix: `expand_rows_for_display()` calls `collapse_file_blocks_for_display()` on `UserInput`
rows containing newlines. The fenced block bodies are stripped; `[file: path]\n...` becomes
`@path`. File content is still injected into the model context; only the TUI display is
condensed.

---

## Deferred research notes

### Issue 2 — composer `>` prefix and picker API reuse
`render_input()` uses `> ` on the first line only; continuation lines show `  `.
The flooding seen was transcript UserInput rows (now fixed). The `OverlayModal` enum
is the correct extension point for new composer overlays. No structural change needed.

### Issue 4 — tool-call paragraphs not yet in `insert_before()` path
`HostScrollbackSink` / `insert_before()` from ADR-041 D18 is not wired. All rows render
inside the inline viewport via `render_task_layout()`, including committed prior-turn tool
paragraphs. The intended architecture: push stable paragraphs above the viewport via
`tui.insert_before()`, keeping only the live turn + composer in the viewport. Needs
`committed_turns_count()` guard and a `HostScrollbackSink` wrapper. Own PR lane.

### Issue 5 — composer extensibility gaps vs. alternatives
1. `MAX_INPUT_PANE_ROWS = 6` — no expand-to-fill for long query drafting.
2. No in-compositor token count preview.
3. `@` and `/` picker overlays already prove the extensible floating pattern; same
   approach can add `#` variable picker, model selector without structural changes.
4. Most impactful quick win: raise `MAX_INPUT_PANE_ROWS` from 6 to ~12 and let the
   composer expand upward into surplus rows (the compact layout already supports this).
