### PR TITLE
fix: add filesystem-safety validation for agent and team names

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -130,6 +130,17 @@ fn validate(config: &AgentsConfig, path: &Path) -> Result<()> {
 /// Agent names must be non-empty, within filesystem-safe length, and unique.
 const MAX_AGENT_NAME_LEN: usize = 64;
 
+/// Returns `true` when `name` is safe for use as a single filesystem path
+/// component. Rejects path separators, control characters (including NUL),
+/// and the reserved relative-directory names `.` and `..`.
+fn is_filesystem_safe(name: &str) -> bool {
+    if name == "." || name == ".." {
+        return false;
+    }
+    name.bytes()
+        .all(|b| b > 0x1F && b != b'/' && b != b'\\' && b != b'\0')
+}
+
 fn validate_agent_names(config: &AgentsConfig, path: &Path) -> Result<()> {
     let mut seen = HashSet::new();
     for agent in &config.agent_profiles {
@@ -139,6 +150,13 @@ fn validate_agent_names(config: &AgentsConfig, path: &Path) -> Result<()> {
         if agent.name.len() > MAX_AGENT_NAME_LEN {
             bail!(
                 "agent name '{}' exceeds {MAX_AGENT_NAME_LEN}-byte limit in '{}'",
+                agent.name,
+                path.display()
+            );
+        }
+        if !is_filesystem_safe(&agent.name) {
+            bail!(
+                "agent name '{}' contains characters unsafe for filesystem paths in '{}'",
                 agent.name,
                 path.display()
             );
@@ -168,6 +186,13 @@ fn validate_team_members(config: &AgentsConfig, path: &Path) -> Result<()> {
     for team in &config.team_definitions {
         if team.name.is_empty() {
             bail!("team name must not be empty in '{}'", path.display());
+        }
+        if !is_filesystem_safe(&team.name) {
+            bail!(
+                "team name '{}' contains characters unsafe for filesystem paths in '{}'",
+                team.name,
+                path.display()
+            );
         }
         if !team_names.insert(&team.name) {
             bail!(
@@ -539,5 +564,91 @@ scheduler = "sequential"
             config.team_definitions[0].scheduler,
             TeamScheduler::Sequential
         );
+    }
+
+    #[test]
+    fn rejects_agent_name_with_path_separator() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_config(dir.path(), "[[agents]]\nname = \"../escape\"\n");
+        let err = load_agents_config_from_path(&path).unwrap_err();
+        assert!(
+            err.to_string().contains("unsafe for filesystem"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[test]
+    fn rejects_agent_name_with_backslash() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_config(dir.path(), "[[agents]]\nname = \"back\\\\slash\"\n");
+        let err = load_agents_config_from_path(&path).unwrap_err();
+        assert!(
+            err.to_string().contains("unsafe for filesystem"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[test]
+    fn rejects_agent_name_with_control_char() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_config(dir.path(), "[[agents]]\nname = \"bad\\u0001name\"\n");
+        let err = load_agents_config_from_path(&path).unwrap_err();
+        assert!(
+            err.to_string().contains("unsafe for filesystem"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[test]
+    fn rejects_dot_dot_agent_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_config(dir.path(), "[[agents]]\nname = \"..\"\n");
+        let err = load_agents_config_from_path(&path).unwrap_err();
+        assert!(
+            err.to_string().contains("unsafe for filesystem"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[test]
+    fn rejects_dot_agent_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_config(dir.path(), "[[agents]]\nname = \".\"\n");
+        let err = load_agents_config_from_path(&path).unwrap_err();
+        assert!(
+            err.to_string().contains("unsafe for filesystem"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[test]
+    fn rejects_team_name_with_path_separator() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_config(
+            dir.path(),
+            "[[agents]]\nname = \"a\"\n\n[[teams]]\nname = \"bad/team\"\nmembers = [\"a\"]\n",
+        );
+        let err = load_agents_config_from_path(&path).unwrap_err();
+        assert!(
+            err.to_string().contains("unsafe for filesystem"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[test]
+    fn is_filesystem_safe_accepts_valid_names() {
+        assert!(super::is_filesystem_safe("fixer"));
+        assert!(super::is_filesystem_safe("rust-fixer-01"));
+        assert!(super::is_filesystem_safe("my_agent.v2"));
+    }
+
+    #[test]
+    fn is_filesystem_safe_rejects_dangerous_names() {
+        assert!(!super::is_filesystem_safe("."));
+        assert!(!super::is_filesystem_safe(".."));
+        assert!(!super::is_filesystem_safe("a/b"));
+        assert!(!super::is_filesystem_safe("a\\b"));
+        assert!(!super::is_filesystem_safe("a\0b"));
+        assert!(!super::is_filesystem_safe("a\x01b"));
     }
 }


### PR DESCRIPTION
## Summary

Add filesystem-safety validation for agent and team names in `src/agents.rs`, closing a gap where path separators, null bytes, control characters, and reserved dot names (`.`, `..`) were accepted despite the documented filesystem-safe contract.

## Motivation

Agent names declared in `.vex/agents.toml` are used to derive worktree paths under the ADR-034 isolation model. The existing `validate_agent_names` enforced non-empty, max-length, and uniqueness constraints, but did not reject characters that are unsafe in filesystem path components. A malicious or malformed agent name such as `../escape` or one containing a null byte could produce path-traversal or undefined filesystem behavior when the runtime creates worktree directories. Team names had no path-safety check at all.

## Approach

Introduce a focused `is_filesystem_safe()` predicate that rejects: the reserved relative-directory names `.` and `..`; forward and backward path separators (`/`, `\`); the NUL byte; and all control characters in the 0x00-0x1F range. The predicate is called from both `validate_agent_names()` and `validate_team_members()` so that every name entering the config surface is guaranteed safe for single-component path use.

An alternative considered was an allowlist regex (`[a-zA-Z0-9_-]+`), but that would be overly restrictive for internationalized agent names while not materially improving safety beyond the denylist approach. The denylist targets exactly the byte values that cause filesystem or shell interpretation issues.

Eight new unit tests cover forward-slash, backslash, control-character, single-dot, double-dot, and team-name variants, plus positive and negative cases for `is_filesystem_safe` directly. All existing tests remain unmodified and passing.

## Validation

- `cargo fmt --check` -- clean, no diffs.
- `cargo clippy --all-targets -- -D warnings` -- zero warnings.
- `cargo nextest run -j 2` -- 1321 tests run, 1321 passed, 0 skipped.

## Risks

- **Duplication / missed shared-code opportunity**: `is_filesystem_safe` is the only path-component validator in the codebase. No existing helper overlaps with it. If a similar check is later needed elsewhere (e.g., skill names), this function should be extracted to a shared validation module.
- **Unused code**: None. Every new function and constant is exercised by the added tests and the production validation path.
- **Bugs / regression risk**: The new validation runs on every `load_agents_config` call. Existing valid names (alphanumeric, hyphens, underscores, dots in non-reserved positions) pass `is_filesystem_safe` without change. A regression could occur only if a deployed config already contains names with control characters or path separators, which would indicate a pre-existing misconfiguration. The byte-level check avoids locale-dependent behavior.
- **Inconsistency with ADRs**: ADR-034 Section 3 specifies worktree isolation keyed on agent name. This change enforces the implicit contract that names are safe path components, consistent with the ADR intent. No ADR boundary is violated.
- **Test coverage gaps**: The `is_filesystem_safe` function is tested directly and indirectly via config rejection tests. The NUL-byte path is tested via the control-character test (0x01 range); a direct 0x00 test is omitted because TOML string parsing rejects raw NUL before it reaches validation, but the runtime guard remains as defense in depth.
- **Follow-up work deferred**: Team name length validation is not added in this change; teams do not currently derive filesystem paths, but a future ADR revision could benefit from a parallel max-length check.