### PR TITLE
fix: harden api module against integer overflow from untrusted input

### DIFF
--- a/src/api/client/mod.rs
+++ b/src/api/client/mod.rs
@@ -831,7 +831,8 @@ fn resolve_max_tokens(default_max_tokens: u32, server_n_ctx: u32) -> u32 {
     // When server context is known, cap at 75% of n_ctx to leave room for
     // the prompt. When unknown (0), use a generous default ceiling.
     let ceiling = if server_n_ctx > 0 {
-        (server_n_ctx as f64 * 0.75) as u32
+        // Multiply in u64 to avoid f64 rounding issues on large context windows.
+        ((server_n_ctx as u64 * 3) / 4).min(u32::MAX as u64) as u32
     } else {
         16384
     };

--- a/src/api/stream.rs
+++ b/src/api/stream.rs
@@ -17,6 +17,11 @@ pub use self::text_normaliser::{NormalisedChunk, StreamTextNormaliser};
 /// real SSE frame.  ADR-021 Item 26.
 const MAX_SSE_BUFFER_BYTES: usize = 1_048_576;
 
+/// Hard ceiling on the tool-call index accepted from a chat-compat stream.
+/// Indices beyond this cap are clamped to prevent unbounded Vec allocation
+/// from untrusted server data.
+const MAX_TOOL_CALL_INDEX: usize = 1_024;
+
 #[derive(Default)]
 pub struct StreamParser {
     buffer: Vec<u8>,
@@ -110,7 +115,7 @@ impl StreamParser {
     }
 
     pub fn process(&mut self, chunk: &[u8]) -> Result<Vec<StreamEvent>> {
-        if self.buffer.len() + chunk.len() > MAX_SSE_BUFFER_BYTES {
+        if self.buffer.len().saturating_add(chunk.len()) > MAX_SSE_BUFFER_BYTES {
             return Ok(vec![StreamEvent::Error {
                 error: ApiStreamError {
                     error_type: "sse_buffer_overflow".to_string(),
@@ -395,7 +400,8 @@ impl StreamParser {
         tool_call: ChatCompatToolCallDelta,
         events: &mut Vec<StreamEvent>,
     ) {
-        let block_index = tool_call.index.unwrap_or(0) + 1;
+        let raw_index = tool_call.index.unwrap_or(0).min(MAX_TOOL_CALL_INDEX);
+        let block_index = raw_index.saturating_add(1);
         self.ensure_chat_compat_tool_state(block_index);
         let state = &mut self.chat_compat_tools[block_index];
         let call_type = tool_call.call_type.clone();
@@ -458,9 +464,10 @@ impl StreamParser {
     }
 
     fn ensure_chat_compat_tool_state(&mut self, index: usize) {
-        if self.chat_compat_tools.len() <= index {
+        let required = index.saturating_add(1);
+        if self.chat_compat_tools.len() < required {
             self.chat_compat_tools
-                .resize_with(index + 1, ChatCompatToolState::default);
+                .resize_with(required, ChatCompatToolState::default);
         }
     }
 


### PR DESCRIPTION
## Summary

Harden the api module against integer overflow reachable from untrusted server data. Four arithmetic paths in `stream.rs` and `client/mod.rs` are tightened using saturating arithmetic, input clamping, and exact integer division.

## Motivation

The api module deserialises JSON from remote servers into typed Rust structures. Several numeric fields (tool-call index, buffer lengths, context-window size) flow into addition or resize operations without overflow guards. In release builds, wrapping arithmetic silently produces incorrect values; in debug builds it panics. Both outcomes are unacceptable when the input originates from an untrusted network peer.

## Approach

Each fix targets the narrowest possible change:

- `stream.rs` `process()`: replaced `self.buffer.len() + chunk.len()` with `saturating_add` so an overflow saturates to `usize::MAX` and is caught by the existing limit check rather than wrapping to a small value.
- `stream.rs` `apply_chat_compat_tool_delta()`: clamped `tool_call.index` to a `MAX_TOOL_CALL_INDEX` constant (1024) before using it as a `Vec` index; computed `block_index` with `saturating_add` to prevent a wrap past zero.
- `stream.rs` `ensure_chat_compat_tool_state()`: switched the resize target from `index + 1` to `index.saturating_add(1)` so an index at `usize::MAX` cannot wrap to zero and truncate the vector.
- `client/mod.rs` `resolve_max_tokens()`: replaced the float cast `(n as f64 * 0.75) as u32` with `((n as u64 * 3) / 4) as u32`, avoiding floating-point rounding for large context sizes.

A full audit of all 10 requested safety categories (bad character handling, unsafe-block invariants, bounds checks on raw-pointer arithmetic, integer overflow in buffer and allocation sizing, wrapping arithmetic in copy lengths, unvalidated slice indexing, null-terminator assumptions, FFI boundary length validation, stack allocation sizing, and control-flow hardening around transmute or function-pointer casts) confirmed that no unsafe blocks, raw pointers, FFI boundaries, transmute, or function-pointer casts exist anywhere in the api module. The remaining categories are clean by design.

## Validation

- `cargo fmt --check` passes with no diff.
- `cargo clippy --all-targets -- -D warnings` passes with zero warnings.
- `cargo nextest run` passes all 1313 tests.
- `scripts/check_forbidden_names.sh` reports clean.

## Risks

**Duplication** -- None introduced. Each fix is local to its call site with no shared helper extraction needed.

**Unused code** -- The `MAX_TOOL_CALL_INDEX` constant is referenced only in `apply_chat_compat_tool_delta`. If that code path is later removed, the constant becomes orphaned; clippy will flag it.

**Bugs and regression risk** -- `saturating_add` changes overflow behaviour from wrap-to-zero (release) or panic (debug) to saturation at `usize::MAX`. The only behavioural difference observable in normal operation is that astronomically large indices are now clamped rather than accepted. This could theoretically reject a legitimate server response with more than 1024 parallel tool calls, though no known provider emits that many.

**ADR inconsistency** -- No existing architecture decision records govern overflow policy. A follow-up ADR codifying a `saturating_add`-by-default rule for untrusted numeric inputs would prevent drift.

**Test coverage gaps** -- No unit tests currently exercise the overflow paths. Adding property-based tests that feed `usize::MAX` and boundary indices into the stream parser would strengthen confidence in these guards.

**Follow-up work** -- Consider extending the same audit to modules outside `src/api/` that also deserialise untrusted input (e.g., `src/task/`, `src/agent/`).