### PR TITLE
fix: fold safety audit PRs #371-#373 - agent names, api overflow, client panics

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -130,6 +130,17 @@ fn validate(config: &AgentsConfig, path: &Path) -> Result<()> {
 /// Agent names must be non-empty, within filesystem-safe length, and unique.
 const MAX_AGENT_NAME_LEN: usize = 64;
 
+/// Returns `true` when `name` is safe for use as a single filesystem path
+/// component. Rejects path separators, control characters (including NUL),
+/// and the reserved relative-directory names `.` and `..`.
+fn is_filesystem_safe(name: &str) -> bool {
+    if name == "." || name == ".." {
+        return false;
+    }
+    name.bytes()
+        .all(|b| b > 0x1F && b != b'/' && b != b'\\' && b != b'\0')
+}
+
 fn validate_agent_names(config: &AgentsConfig, path: &Path) -> Result<()> {
     let mut seen = HashSet::new();
     for agent in &config.agent_profiles {
@@ -139,6 +150,13 @@ fn validate_agent_names(config: &AgentsConfig, path: &Path) -> Result<()> {
         if agent.name.len() > MAX_AGENT_NAME_LEN {
             bail!(
                 "agent name '{}' exceeds {MAX_AGENT_NAME_LEN}-byte limit in '{}'",
+                agent.name,
+                path.display()
+            );
+        }
+        if !is_filesystem_safe(&agent.name) {
+            bail!(
+                "agent name '{}' contains characters unsafe for filesystem paths in '{}'",
                 agent.name,
                 path.display()
             );
@@ -168,6 +186,13 @@ fn validate_team_members(config: &AgentsConfig, path: &Path) -> Result<()> {
     for team in &config.team_definitions {
         if team.name.is_empty() {
             bail!("team name must not be empty in '{}'", path.display());
+        }
+        if !is_filesystem_safe(&team.name) {
+            bail!(
+                "team name '{}' contains characters unsafe for filesystem paths in '{}'",
+                team.name,
+                path.display()
+            );
         }
         if !team_names.insert(&team.name) {
             bail!(
@@ -539,5 +564,91 @@ scheduler = "sequential"
             config.team_definitions[0].scheduler,
             TeamScheduler::Sequential
         );
+    }
+
+    #[test]
+    fn rejects_agent_name_with_path_separator() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_config(dir.path(), "[[agents]]\nname = \"../escape\"\n");
+        let err = load_agents_config_from_path(&path).unwrap_err();
+        assert!(
+            err.to_string().contains("unsafe for filesystem"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[test]
+    fn rejects_agent_name_with_backslash() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_config(dir.path(), "[[agents]]\nname = \"back\\\\slash\"\n");
+        let err = load_agents_config_from_path(&path).unwrap_err();
+        assert!(
+            err.to_string().contains("unsafe for filesystem"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[test]
+    fn rejects_agent_name_with_control_char() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_config(dir.path(), "[[agents]]\nname = \"bad\\u0001name\"\n");
+        let err = load_agents_config_from_path(&path).unwrap_err();
+        assert!(
+            err.to_string().contains("unsafe for filesystem"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[test]
+    fn rejects_dot_dot_agent_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_config(dir.path(), "[[agents]]\nname = \"..\"\n");
+        let err = load_agents_config_from_path(&path).unwrap_err();
+        assert!(
+            err.to_string().contains("unsafe for filesystem"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[test]
+    fn rejects_dot_agent_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_config(dir.path(), "[[agents]]\nname = \".\"\n");
+        let err = load_agents_config_from_path(&path).unwrap_err();
+        assert!(
+            err.to_string().contains("unsafe for filesystem"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[test]
+    fn rejects_team_name_with_path_separator() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_config(
+            dir.path(),
+            "[[agents]]\nname = \"a\"\n\n[[teams]]\nname = \"bad/team\"\nmembers = [\"a\"]\n",
+        );
+        let err = load_agents_config_from_path(&path).unwrap_err();
+        assert!(
+            err.to_string().contains("unsafe for filesystem"),
+            "unexpected error: {err}",
+        );
+    }
+
+    #[test]
+    fn is_filesystem_safe_accepts_valid_names() {
+        assert!(super::is_filesystem_safe("fixer"));
+        assert!(super::is_filesystem_safe("rust-fixer-01"));
+        assert!(super::is_filesystem_safe("my_agent.v2"));
+    }
+
+    #[test]
+    fn is_filesystem_safe_rejects_dangerous_names() {
+        assert!(!super::is_filesystem_safe("."));
+        assert!(!super::is_filesystem_safe(".."));
+        assert!(!super::is_filesystem_safe("a/b"));
+        assert!(!super::is_filesystem_safe("a\\b"));
+        assert!(!super::is_filesystem_safe("a\0b"));
+        assert!(!super::is_filesystem_safe("a\x01b"));
     }
 }

--- a/src/api/client/mod.rs
+++ b/src/api/client/mod.rs
@@ -836,7 +836,13 @@ fn resolve_max_tokens(default_max_tokens: u32, server_n_ctx: u32) -> u32 {
     } else {
         16384
     };
-    base.clamp(128, ceiling)
+    // Guard against ceiling < 128 (server reports n_ctx < 171) which would
+    // panic in clamp because min > max is not permitted.
+    if ceiling < 128 {
+        ceiling
+    } else {
+        base.clamp(128, ceiling)
+    }
 }
 
 fn infer_api_protocol(api_url: &str) -> ApiProtocol {
@@ -903,7 +909,7 @@ fn adapt_to_messages_v1_url(api_url: &str) -> String {
 }
 
 fn chat_compat_messages(messages: &[ApiMessage], system_prompt: &str) -> Vec<Value> {
-    let mut out = Vec::with_capacity(messages.len() + 1);
+    let mut out = Vec::with_capacity(messages.len().saturating_add(1));
     out.push(json!({
         "role": "system",
         "content": system_prompt

--- a/src/api/client/mod.rs
+++ b/src/api/client/mod.rs
@@ -831,7 +831,8 @@ fn resolve_max_tokens(default_max_tokens: u32, server_n_ctx: u32) -> u32 {
     // When server context is known, cap at 75% of n_ctx to leave room for
     // the prompt. When unknown (0), use a generous default ceiling.
     let ceiling = if server_n_ctx > 0 {
-        (server_n_ctx as f64 * 0.75) as u32
+        // Multiply in u64 to avoid f64 rounding issues on large context windows.
+        ((server_n_ctx as u64 * 3) / 4).min(u32::MAX as u64) as u32
     } else {
         16384
     };

--- a/src/api/client/tests.rs
+++ b/src/api/client/tests.rs
@@ -241,6 +241,20 @@ fn test_resolve_max_tokens_unknown_server_caps_at_ceiling() {
 }
 
 #[test]
+fn test_resolve_max_tokens_small_n_ctx_does_not_panic() {
+    // server_n_ctx=100 → ceiling=75 (< 128); must not panic in clamp
+    let tokens = resolve_max_tokens(4096, 100);
+    assert_eq!(tokens, 75);
+}
+
+#[test]
+fn test_resolve_max_tokens_n_ctx_one_returns_zero() {
+    // server_n_ctx=1 → ceiling=0; boundary case for very small context
+    let tokens = resolve_max_tokens(4096, 1);
+    assert_eq!(tokens, 0);
+}
+
+#[test]
 fn test_tool_definitions_cover_execute_tool_dispatch_names() {
     let expected: BTreeSet<&str> = BTreeSet::from([
         "read_file",

--- a/src/api/stream.rs
+++ b/src/api/stream.rs
@@ -17,6 +17,11 @@ pub use self::text_normaliser::{NormalisedChunk, StreamTextNormaliser};
 /// real SSE frame.  ADR-021 Item 26.
 const MAX_SSE_BUFFER_BYTES: usize = 1_048_576;
 
+/// Hard ceiling on the tool-call index accepted from a chat-compat stream.
+/// Indices beyond this cap are clamped to prevent unbounded Vec allocation
+/// from untrusted server data.
+const MAX_TOOL_CALL_INDEX: usize = 1_024;
+
 #[derive(Default)]
 pub struct StreamParser {
     buffer: Vec<u8>,
@@ -110,7 +115,7 @@ impl StreamParser {
     }
 
     pub fn process(&mut self, chunk: &[u8]) -> Result<Vec<StreamEvent>> {
-        if self.buffer.len() + chunk.len() > MAX_SSE_BUFFER_BYTES {
+        if self.buffer.len().saturating_add(chunk.len()) > MAX_SSE_BUFFER_BYTES {
             return Ok(vec![StreamEvent::Error {
                 error: ApiStreamError {
                     error_type: "sse_buffer_overflow".to_string(),
@@ -395,7 +400,8 @@ impl StreamParser {
         tool_call: ChatCompatToolCallDelta,
         events: &mut Vec<StreamEvent>,
     ) {
-        let block_index = tool_call.index.unwrap_or(0) + 1;
+        let raw_index = tool_call.index.unwrap_or(0).min(MAX_TOOL_CALL_INDEX);
+        let block_index = raw_index.saturating_add(1);
         self.ensure_chat_compat_tool_state(block_index);
         let state = &mut self.chat_compat_tools[block_index];
         let call_type = tool_call.call_type.clone();
@@ -458,9 +464,10 @@ impl StreamParser {
     }
 
     fn ensure_chat_compat_tool_state(&mut self, index: usize) {
-        if self.chat_compat_tools.len() <= index {
+        let required = index.saturating_add(1);
+        if self.chat_compat_tools.len() < required {
             self.chat_compat_tools
-                .resize_with(index + 1, ChatCompatToolState::default);
+                .resize_with(required, ChatCompatToolState::default);
         }
     }
 


### PR DESCRIPTION
## Summary

Folds three closed safety-audit PRs (#371, #372, #373) into a single mergeable branch. Hardens filesystem-safety for agent/team names, saturating arithmetic for api integer overflow, and clamp+addition guards in the client module.

## Motivation

PRs #371-#373 were opened individually, closed before merge, and need to land as one unit. Each addresses a distinct safety gap:
- #371: Agent and team names accepted path separators, null bytes, control characters, and reserved dot names despite the filesystem-safe contract.
- #372: Four arithmetic paths in `stream.rs` and `client/mod.rs` used wrapping arithmetic on untrusted server data.
- #373: `resolve_max_tokens` violated the `clamp` invariant when min > max, and `chat_compat_messages` used unchecked addition.

## Approach

Cherry-picked each single-commit PR branch onto current `main` (210a926). All three apply cleanly with one auto-merge in `src/api/client/mod.rs` (non-overlapping hunks from #372 and #373).

Files changed:
- `src/agents.rs` - filesystem-safety validation for agent and team names
- `src/api/stream.rs` - saturating arithmetic for token counters
- `src/api/client/mod.rs` - clamp guard, saturating addition, overflow protection
- `src/api/client/tests.rs` - regression tests for edge-case panics

## Validation

```
cargo fmt --check                             clean
cargo clippy --all-targets -- -D warnings     clean
cargo nextest run                             1332 passed, 0 skipped
bash scripts/check_forbidden_names.sh         clean
```

Supersedes: #371, #372, #373

## Risks

- The agent-name validation in #371 may reject names that were previously accepted but contained path separators. This is intentionally breaking: such names were a filesystem-safety violation.
- Saturating arithmetic in the api module means overflow now silently caps instead of panicking. In practice, the capped values are still unreasonably large; no functional behaviour changes for normal inputs.