### PR TITLE
Generalize naming terms

### DIFF
--- a/.github/instructions/repository.instructions.md
+++ b/.github/instructions/repository.instructions.md
@@ -15,7 +15,7 @@ applyTo: "**"
   This covers PR bodies, review text, commit messages, inline comments,
   plan text, log messages, and findings. Use plain ASCII and standard Markdown.
 - Banned vocabulary: use "unused code", "unreferenced code", or "code that is
-  never called" instead of any phrasing flagged by
+  never called" instead of any phrasing matched by
   ``scripts/check_forbidden_names.sh``. The Rust compiler lint name may appear
   only when quoting compiler output verbatim.
 
@@ -107,7 +107,7 @@ gh pr view <pr> --json headRefName,commits,statusCheckRollup
 gh pr checks <pr> --watch
 ```
 
-- Keep the model pinned in the agent profile rather than adding model flags at
+- Keep the model pinned in the agent profile rather than adding model options at
   invocation time. If the hosting surface ignores the profile pin, report that
   behavior explicitly instead of silently changing the command.
 - Do not move on to PR inspection, review, promotion, or merge work until the

--- a/TASKS/PE-01-batch-mode.md
+++ b/TASKS/PE-01-batch-mode.md
@@ -37,7 +37,7 @@ command line, but config-layer resolution must already be stable for the
    `crossterm` imports anywhere in the file or any module reachable only through
    `vex exec`.
 
-2. Add a `vex exec` subcommand to `src/bin/vex.rs` with the following flags:
+2. Add a `vex exec` subcommand to `src/bin/vex.rs` with the following options:
    - `--task <TEXT>` — task prompt (mutually exclusive with `--task-file`)
    - `--task-file <PATH>` — read task prompt from file
    - `--auto-approve <SCOPE>` — optional; accepted values: `once`, `task`

--- a/TASKS/PR-4-renderer-simplification.md
+++ b/TASKS/PR-4-renderer-simplification.md
@@ -182,4 +182,4 @@ are added. Suggested split boundaries:
   replacement.
 - Keep naming explicit in both production and test modules. Prefer file names
   like `transcript_projection.rs` or `task_view_projection.rs` over generic
-  buckets such as `helpers2.rs` or `misc.rs`.
+  groups such as `helpers2.rs` or `misc.rs`.

--- a/adr/ADR-023-deterministic-edit-loop.md
+++ b/adr/ADR-023-deterministic-edit-loop.md
@@ -261,7 +261,7 @@ Constraints:
 - `EditLoop` must not call `ToolOperator` directly. File mutations flow through the conversation tool dispatch layer only.
 - `EditLoop` must not exceed `max_turns` under any circumstance. The counter is checked *before* `ctx.start_turn()`, not after.
 - **Reentrancy is prohibited.** `TuiMode::try_handle_slash_command` must check whether `active_edit_loop` is already `Some` before spawning a new loop. If a loop is in progress, the `/edit` and `/fix` commands must emit `[edit loop already active — cancel with Ctrl+C before starting a new task]` and return without spawning. Nested or concurrent loop invocations are not supported and must not be possible through any code path.
-- On `MaxTurnsReached`, the loop outcome and last error string are surfaced to the operator via `push_history_line` in the TUI transcript. `TaskState::command_history` records the `CommandEvidence` entries (program, exit code, interrupted flag) for each validation command that ran — it does not hold a structured error string, and the loop must not attempt to write one there. `[source: task_state.rs CommandEvidence struct — fields: program, exit_code, interrupted]`. If the operator wants to resume, they use `/fix` in the same session (sourced from `last_validation_result`) or `vex exec` with the task file and JSONL output for offline inspection.
+- On `MaxTurnsReached`, the loop outcome and last error string are surfaced to the operator via `push_history_line` in the TUI transcript. `TaskState::command_history` records the `CommandEvidence` entries (program, exit code, interrupted boolean) for each validation command that ran — it does not hold a structured error string, and the loop must not attempt to write one there. `[source: task_state.rs CommandEvidence struct — fields: program, exit_code, interrupted]`. If the operator wants to resume, they use `/fix` in the same session (sourced from `last_validation_result`) or `vex exec` with the task file and JSONL output for offline inspection.
 - `EditLoop` is not a `RuntimeMode`.
 
 ---
@@ -326,7 +326,7 @@ The dispatch is introduced at the top of `on_user_input` after the overlay and b
 if let Some(outcome) = self.try_handle_slash_command(&input, ctx) {
     self.push_history_line(format!("> {input}"));
     self.push_history_line(String::new());
-    // slash commands that do not start a turn skip the turn_in_progress flag
+    // slash commands that do not start a turn skip the turn_in_progress marker
     match outcome {
         SlashCommandOutcome::Handled => {}
         SlashCommandOutcome::StartTurn(rendered) => {
@@ -494,7 +494,7 @@ active_edit_loop: Option<EditLoop>,  // carries last_validation_result between /
                          is used in place of a diff. Incompatible with --base;
                          providing both emits "[review: --base and --files are
                          mutually exclusive]" and returns.
-      (neither flag)     Equivalent to --base HEAD: assembles `git diff HEAD`
+    (neither option)   Equivalent to --base HEAD: assembles `git diff HEAD`
                          (staged + unstaged changes in the working tree).
       <instruction>      Optional free-text appended to the {{instruction}}
                          substitution site in review_template.txt. If absent,
@@ -563,7 +563,7 @@ The validation infrastructure is useful independently of model turns. Making the
 
 ### Why does `/fix` not fall back to `TaskState::command_history`?
 
-`command_history` records `CommandEvidence` (program name, exit code, interrupted flag) — not structured validation output. `[source: task_state.rs CommandEvidence struct]`. Reconstructing a useful error context from those fields would require heuristics. The `ValidationResult` held in `last_validation_result` already contains `stdout_tail`, `stderr_tail`, and `passed`, which is exactly what `fix_template.txt` needs.
+`command_history` records `CommandEvidence` (program name, exit code, interrupted boolean) — not structured validation output. `[source: task_state.rs CommandEvidence struct]`. Reconstructing a useful error context from those fields would require heuristics. The `ValidationResult` held in `last_validation_result` already contains `stdout_tail`, `stderr_tail`, and `passed`, which is exactly what `fix_template.txt` needs.
 
 ---
 
@@ -651,7 +651,7 @@ Rejected. `TaskState`'s `CommandEvidence` struct records execution facts, not st
 | **EL-07** | `ModelProfile` struct; `models/*.toml` files; `default_for_backend` fallback | Must be green; EL-08 gated separately | [x] |
 | **EL-08** | `ModelProfile` config integration via layered config | **Gated: ADR-022 Phase 1 must be complete** | [x] |
 | **EL-09** | `scripts/check_forbidden_names.sh` — covers `src/prompts/` and `models/`; added to CI | Must pass for all items EL-06 onward | [x] |
-| **EL-10** | `/review` — `review_template.txt`; `--base`/`--files` flag parsing; ref validation; PendingPatch drop; diff assembly via `spawn_blocking` | Must be green after EL-05; gated on EL-06 for template | [x] |
+| **EL-10** | `/review` — `review_template.txt`; `--base`/`--files` option parsing; ref validation; PendingPatch drop; diff assembly via `spawn_blocking` | Must be green after EL-05; gated on EL-06 for template | [x] |
 | **EL-11** | `/plan` — `plan_template.txt`; `{{scope}}` assembly via `ContextAssembler`; PendingPatch drop; no EditLoop invocation | Must be green after EL-05; gated on EL-06 for template | [x] |
 | **EL-12** | `/context` — zero-turn status render; token estimate; `active_grants` count; git summary; no model turn | Must be green after EL-05 | [x] |
 | **EL-13** | `/commands` and `/help` alias — runtime-generated from dispatch table; description registration; compile-error for missing descriptions | Must be green after EL-04 | [x] |
@@ -861,7 +861,7 @@ When checking a box above, append an evidence block under this section:
 | EL-07 | `ModelProfile` struct; `models/*.toml`; `default_for_backend`; `structured_tools` fallback | `test_model_profile_loads_from_toml`; `test_model_profile_invalid_path_is_hard_failure`; `test_model_profile_structured_tools_false_uses_tagged_fallback`; `test_context_assembler_invalid_git_timeout_env_falls_back_to_default` | Must be green; EL-08 gated separately |
 | EL-08 | `ModelProfile` config integration via layered config | `test_model_profile_loaded_from_layered_config` | **Gated: ADR-022 Phase 1 must be complete** |
 | EL-09 | `scripts/check_forbidden_names.sh` — CI coverage of `src/prompts/` and `models/` | `check_forbidden_names_sh_blocks_proprietary_name_in_prompts_dir` | Must pass for EL-06 onward |
-| EL-10 | `/review` — flag parsing, ref validation error paths, PendingPatch drop, diff assembly | `test_tui_review_default_assembles_head_diff`; `test_tui_review_base_flag_validates_ref`; `test_tui_review_invalid_ref_emits_error_no_turn`; `test_tui_review_mutual_exclusion_base_and_files`; `test_tui_review_drops_pending_patch_silently`; `test_tui_review_files_flag_uses_context_assembler` | Must be green after EL-05; template requires EL-06 |
+| EL-10 | `/review` — option parsing, ref validation error paths, PendingPatch drop, diff assembly | `test_tui_review_default_assembles_head_diff`; `test_tui_review_base_flag_validates_ref`; `test_tui_review_invalid_ref_emits_error_no_turn`; `test_tui_review_mutual_exclusion_base_and_files`; `test_tui_review_drops_pending_patch_silently`; `test_tui_review_files_flag_uses_context_assembler` | Must be green after EL-05; template requires EL-06 |
 | EL-11 | `/plan` — `plan_template.txt`; `{{scope}}` via `ContextAssembler`; PendingPatch drop; no EditLoop | `test_tui_plan_starts_single_turn_no_loop`; `test_tui_plan_drops_pending_patch_silently`; `test_tui_plan_scope_populated_from_assembler` | Must be green after EL-05; template requires EL-06 |
 | EL-12 | `/context` — zero-turn status output; token estimate annotation; no `ctx.start_turn` call | `test_tui_context_renders_without_model_turn`; `test_tui_context_shows_tilde_token_estimate`; `test_tui_context_shows_active_grants_count` | Must be green after EL-05 |
 | EL-13 | `/commands` and `/help` — runtime-generated from dispatch table; description per entry; compile error for missing description | `test_tui_commands_renders_all_registered_commands`; `test_tui_help_is_alias_for_commands`; `test_commands_output_does_not_call_start_turn`; `test_missing_command_description_is_compile_error` | Must be green after EL-04 |

--- a/adr/ADR-024-zero-licensing-cost-agent-parity-gaps.md
+++ b/adr/ADR-024-zero-licensing-cost-agent-parity-gaps.md
@@ -63,9 +63,9 @@ Every direct dependency of `vexcoder` must be licensed under a permissive, royal
 | 27 | No environment health check sub-command (`vex doctor`) | Proposed |
 | 28 | No session-level token counter | Proposed |
 | 29 | No conversation and task export sub-command (`vex export`) | Proposed |
-| 30 | No `--resume` CLI startup flag | Proposed |
+| 30 | No `--resume` CLI startup option | Proposed |
 | 31 | No MCP HTTP server authentication headers | Active (extends Gap 5) |
-| 32 | No `-p`/`--print` one-shot plain-text flag | Proposed |
+| 32 | No `-p`/`--print` one-shot plain-text option | Proposed |
 | 35 | No model-callable workspace exploration tools (`search_files`, `list_dir`, `glob_files`) | Complete |
 
 ### Gaps intentionally deferred by this ADR
@@ -989,20 +989,20 @@ vex export <task-id> [--format jsonl|markdown] [--output <path>] [--force]
 
 ---
 
-### Gap 30 — `--resume` CLI Startup Flag
+### Gap 30 — `--resume` CLI Startup Option
 
-Gap 14 adds `/resume` as a TUI slash command for resuming a saved task from within a running session. This gap is distinct: `--resume [<task-id>]` is a CLI startup flag that loads a `TaskState` before `TuiMode` initialises, so operators who exited entirely can resume their last task without first landing in a blank session.
+Gap 14 adds `/resume` as a TUI slash command for resuming a saved task from within a running session. This gap is distinct: `--resume [<task-id>]` is a CLI startup option that loads a `TaskState` before `TuiMode` initialises, so operators who exited entirely can resume their last task without first landing in a blank session.
 
 ```bash
 vex --resume                 # loads the most recently modified TaskState in VEX_STATE_DIR
 vex --resume <task-id>       # loads the named TaskState
 ```
 
-**Behaviour:** The flag is handled in `src/bin/vex.rs` before `TuiMode` starts. `TaskState::load` is called for the specified or most-recent task-id. On success, `TuiMode` is initialised with `active_grants` and `changed_files` restored from the saved state, and an informational line `[resumed: <task-id> status=<status>]` is prepended to the transcript. On failure (task-id not found, state file unreadable), the process exits non-zero with a clear diagnostic before any TUI initialisation occurs. Conversation history is not restored — this matches the behaviour of `/resume` (Gap 14): `TaskState` does not persist message content.
+**Behaviour:** The option is handled in `src/bin/vex.rs` before `TuiMode` starts. `TaskState::load` is called for the specified or most-recent task-id. On success, `TuiMode` is initialised with `active_grants` and `changed_files` restored from the saved state, and an informational line `[resumed: <task-id> status=<status>]` is prepended to the transcript. On failure (task-id not found, state file unreadable), the process exits non-zero with a clear diagnostic before any TUI initialisation occurs. Conversation history is not restored — this matches the behaviour of `/resume` (Gap 14): `TaskState` does not persist message content.
 
 **Implementation scope:** `src/bin/vex.rs` only. No changes to `src/runtime/`, `src/state/`, or `src/tools/`. `TaskState::load` already exists; this is routing only.
 
-**Relationship to `-p`/`--print` (Gap 32):** `--resume` and `--print` are independent startup flags. `--resume --print "continue"` is a valid combination: load the saved task context, run one turn non-interactively, and print the result to stdout.
+**Relationship to `-p`/`--print` (Gap 32):** `--resume` and `--print` are independent startup options. `--resume --print "continue"` is a valid combination: load the saved task context, run one turn non-interactively, and print the result to stdout.
 
 **Anchor tests:** `test_cli_resume_flag_loads_task_state`; `test_cli_resume_flag_restores_active_grants`; `test_cli_resume_flag_unknown_task_id_exits_nonzero`; `test_cli_resume_flag_most_recent_when_no_id_given`.
 
@@ -1037,9 +1037,9 @@ X-Client-Id   = "vexcoder"
 
 ---
 
-### Gap 32 — `-p`/`--print` One-Shot Plain-Text Flag
+### Gap 32 — `-p`/`--print` One-Shot Plain-Text Option
 
-Reference CLI agents expose a `-p`/`--print` flag for pipe-friendly one-shot queries: the agent runs a single turn, prints the plain assistant response to stdout, and exits. This is distinct from `vex exec` (`BatchMode`): `BatchMode` is designed for multi-turn automation with full JSONL evidence output; `--print` is designed for scripting that needs only a plain text answer. Both are headless; their output formats and use cases do not overlap.
+Reference CLI agents expose a `-p`/`--print` option for pipe-friendly one-shot queries: the agent runs a single turn, prints the plain assistant response to stdout, and exits. This is distinct from `vex exec` (`BatchMode`): `BatchMode` is designed for multi-turn automation with full JSONL evidence output; `--print` is designed for scripting that needs only a plain text answer. Both are headless; their output formats and use cases do not overlap.
 
 ```bash
 # pipe input
@@ -1055,7 +1055,7 @@ vex --resume <task-id> --print "what files did you change?"
 
 **Behaviour:** `-p`/`--print` is a `BatchMode` invocation with the following fixed parameters: `--max-turns 1`, `--format text`, no JSONL evidence output, no changed-file tracking appended to `TaskState`. Stdin is read and prepended to the prompt if stdin is not a TTY (pipe mode). Output is the assistant's final response text only, written to stdout. Exit code: 0 on a completed turn; non-zero on model error or approval denial.
 
-**Implementation:** `-p`/`--print <prompt>` is a `clap` flag pair (short `-p`, long `--print`) in `src/bin/vex.rs` that routes to `BatchMode` with the parameters above. It does not introduce a new runtime mode. `BatchMode` must already exist (Gap 2) for this flag to be implemented; Gap 32 is therefore gated on Gap 2 completion.
+**Implementation:** `-p`/`--print <prompt>` is a `clap` option pair (short `-p`, long `--print`) in `src/bin/vex.rs` that routes to `BatchMode` with the parameters above. It does not introduce a new runtime mode. `BatchMode` must already exist (Gap 2) for this option to be implemented; Gap 32 is therefore gated on Gap 2 completion.
 
 **No `ratatui` or `crossterm` in the execution path.** The existing `BatchMode` CI check covers this.
 
@@ -1597,7 +1597,7 @@ Rejected. The migration command exists for operators running vexcoder before ADR
 | **PB-03** | `vex skills list\|install\|remove` + `registry.toml` | [x] |
 | **PC-01** | `/model <name>` runtime model switching | [x] |
 | **PD-01** | `SandboxDriver` trait + `PassthroughSandbox` | [x] |
-| **PD-02** | `MacosSandboxExec` driver (best-effort + require flag) | [x] |
+| **PD-02** | `MacosSandboxExec` driver (best-effort + require option) | [x] |
 | **PD-03** | `ContainerSandbox` driver | [x] |
 | **PE-01** | `BatchMode: RuntimeMode + FrontendAdapter` | [x] |
 | **PE-02** | `vex exec` sub-command with JSONL/text output | [x] |
@@ -1639,14 +1639,14 @@ Rejected. The migration command exists for operators running vexcoder before ADR
 | **PK-06** | `/tools [desc]` — current dispatch table enumeration; MCP-namespaced tools | [x] |
 | **PK-07** | `/diff [--staged]` — spawn_blocking git diff; truncation; no model turn | [x] |
 | **PK-08** | `vex branch` and `vex pr-summary` — thin git wrappers; stdout output; no platform API | [x] |
-| **PK-09** | `/generate-tests` — generate_tests_template.txt; non-test patch filter; framework flag | [x] |
+| **PK-09** | `/generate-tests` — generate_tests_template.txt; non-test patch filter; framework option | [x] |
 | **PL-01** | Pre/post-tool-call hooks — `[[hooks]]` config; `Capability`-triggered; `SandboxDriver`-wrapped; user-layer only | [x] |
 | **PL-02** | `vex doctor` — config probe, endpoint reachability, sandbox probe, MCP connectivity, `--json` output | [x] |
 | **PL-03** | Session token counter — turn accumulator; `/usage` command; `BatchMode` JSONL `tokens` field | [x] |
-| **PL-04** | `vex export <task-id>` — JSONL and Markdown formats; read-only; `--output`/`--force` flags | [x] |
-| **PM-01** | `--resume [<task-id>]` startup flag — `TaskState::load` before TUI init; non-zero exit on failure | [x] |
+| **PL-04** | `vex export <task-id>` — JSONL and Markdown formats; read-only; `--output`/`--force` options | [x] |
+| **PM-01** | `--resume [<task-id>]` startup option — `TaskState::load` before TUI init; non-zero exit on failure | [x] |
 | **PM-02** | MCP HTTP `[mcp_servers.headers]` — env-var substitution; STDIO rejection; startup failure on unset var | [x] |
-| **PM-03** | `-p`/`--print` flag — `BatchMode` single-turn; stdin pipe; plain-text stdout; gated on Gap 2 | [x] |
+| **PM-03** | `-p`/`--print` option — `BatchMode` single-turn; stdin pipe; plain-text stdout; gated on Gap 2 | [x] |
 | **PP-01** | `search_files`, `list_dir`, `glob_files` — workspace-confined; `.gitignore`-aware; bounded results; registered in dispatch table; gated on workspace ignore mechanism being available | [x] |
 
 ## Implementation reporting contract (mandatory per checklist item)
@@ -1717,7 +1717,7 @@ When checking a box above, append an evidence block under this section:
 | Do not add a dependency licensed under a commercial, copyleft, or conditionally-paid license | All direct dependencies must carry MIT, Apache 2.0, or dual MIT/Apache 2.0 licensing; exceptions require a dedicated ADR with explicit legal basis |
 | Do not use provider-branded names or proprietary product references in runtime code, config keys, or default values | Documentation may reference external tools by name for operator clarity; runtime behaviour must remain neutral. **Migration tooling exception (Gap 11):** `vex migrate config` is the sole permitted context in which pre-ADR-022 branded variable values (for example, the legacy messages token behind `VEX_API_PROTOCOL`) may be read at runtime — exclusively to map them to neutral equivalents. No other code path may read or emit branded values. |
 | MCP HTTP header values containing secrets must use `${ENV_VAR_NAME}` substitution; literal secrets must never appear in config files | Enforced at config load time: values without `${}` syntax are used verbatim and are assumed non-secret; values with `${}` are resolved from environment only |
-| `-p`/`--print` must not be implemented before Gap 2 (`BatchMode`) is complete | `--print` is a routing flag over `BatchMode`; implementing it without `BatchMode` requires duplicating runtime logic, which is prohibited |
+| `-p`/`--print` must not be implemented before Gap 2 (`BatchMode`) is complete | `--print` is a routing option over `BatchMode`; implementing it without `BatchMode` requires duplicating runtime logic, which is prohibited |
 | Do not implement a minimal/simple execution mode env var (`VEX_SIMPLE` or equivalent) without a dedicated ADR | The exact feature-disable set must be decided deliberately; disabling MCP, hooks, or skills piecemeal without a specification creates inconsistent operator expectations |
 | Do not implement `vex remote-control` or any remote environment serving surface without a dedicated ADR | This is distinct from `LocalApiServer` (Phase I) and requires its own network exposure, authentication, and security boundary decisions |
 
@@ -1898,7 +1898,7 @@ The current command-execution amendment is recorded in `adr/ADR-022-amendment-20
   - Trait and default driver scaffolded during PL-01 hooks work.
   - PD-02 (`MacosSandboxExec`) and PD-03 (`ContainerSandbox`) merged in this branch.
 
-### [PD-02] - MacosSandboxExec driver (best-effort + require flag)
+### [PD-02] - MacosSandboxExec driver (best-effort + require option)
 - Operator: this branch (`work/vexcoder-adr024-sandbox-drivers`)
 - Commit: `3090d1c8202cce785ddc765284154cfd97fabd45`
 - Files:
@@ -1929,7 +1929,7 @@ The current command-execution amendment is recorded in `adr/ADR-022-amendment-20
 - Notes:
   - `sandbox.sandbox_profile` must name the container image; driver rejects empty values.
   - A short `run --rm <image> true` probe is executed at session open to validate image availability.
-  - Network isolation depends on the container image and host configuration; no additional flags are injected.
+  - Network isolation depends on the container image and host configuration; no additional options are injected.
 
 ### [PA-03 / PA-04] - vex migrate config + migration doc
 - Operator: reconciliation on a prior integration branch; implementation merged earlier

--- a/adr/ADR-029-stream-parser-completeness-and-session-persistence.md
+++ b/adr/ADR-029-stream-parser-completeness-and-session-persistence.md
@@ -344,7 +344,7 @@ reading state files written before this ADR, preserving backward compatibility.
 
 State files written after this ADR include all four new fields.
 
-The `--resume` flag path in `src/bin/vex.rs` is unchanged. It calls
+The `--resume` option path in `src/bin/vex.rs` is unchanged. It calls
 `TaskState::load()` which reads the JSON document and populates all fields
 including the new ones. The resumed session has access to the plan, notes,
 compaction history, and cache stats immediately after load.

--- a/adr/ADR-031-operator-surface-ui-overhaul.md
+++ b/adr/ADR-031-operator-surface-ui-overhaul.md
@@ -186,7 +186,7 @@ assumptions that have not been merged into `main`, such as:
 - temporary event names
 - temporary pending-step trackers
 - temporary output buffers
-- temporary command lifecycle flags
+- temporary command lifecycle settings
 - temporary approval state derived only in the UI layer
 
 If such state is required for the UI, it must first exist in the runtime or

--- a/adr/ADR-040-real-time-local-turn-telemetry.md
+++ b/adr/ADR-040-real-time-local-turn-telemetry.md
@@ -22,7 +22,7 @@ emit useful stream metadata such as:
 2. `timings` snapshots that distinguish prompt-eval time from generation time.
 
 On endpoints that support the messages/v1 protocol, the same telemetry is
-carried natively inside event metadata without requiring opt-in request flags.
+carried natively inside event metadata without requiring opt-in request options.
 
 The operator-facing problem was not one bug but one broken feedback loop:
 
@@ -64,7 +64,7 @@ streaming protocols.
 
 ### Request contract — messages/v1 protocol
 
-8. Messages/v1 streaming requests do not require opt-in flags for telemetry.
+8. Messages/v1 streaming requests do not require opt-in options for telemetry.
    Prompt progress and timing data arrive as metadata on standard stream
    events when the backend supports them.
 9. The system prompt is passed as a top-level `system` field, not embedded in
@@ -165,7 +165,7 @@ streaming protocols.
 ### Negative
 
 - The local chat-compatible path now knowingly depends on backend-specific
-  progress fields and opt-in request flags.
+  progress fields and opt-in request options.
 - The messages/v1 path carries telemetry natively but depends on per-backend
   support for populating `prompt_progress` and `timings` metadata.
 - Tests must cover metadata-only chunks because they are now semantically
@@ -178,7 +178,7 @@ streaming protocols.
 Candidate implementation areas:
 
 - `src/api/client/mod.rs` — request payload construction for both protocols;
-  `apply_local_chat_compat_stream_flags()` inserts telemetry opt-in flags.
+  `apply_local_chat_compat_stream_flags()` inserts telemetry opt-in options.
 - `src/api/stream.rs` — `StreamParser` with messages/v1-first fallback chain;
   `ChatCompatChunk` intermediate struct for chat-compatible conversion.
 - `src/types/api_types.rs` — shared `StreamEvent` enum, `StreamChunkMetadata`,

--- a/adr/ADR-042-tool-registration-and-approval-layer.md
+++ b/adr/ADR-042-tool-registration-and-approval-layer.md
@@ -176,8 +176,8 @@ exposed to the model for a session:
   the dispatch layer as a defense-in-depth guard.
 - **Chat**: no tools. The model operates in plain conversation mode.
 
-The policy is set via `--plan` or `--chat` CLI flags (mutually exclusive), or
-via `tool_policy` in `config.toml`. The CLI flags override the config value.
+The policy is set via `--plan` or `--chat` CLI options (mutually exclusive), or
+via `tool_policy` in `config.toml`. The CLI options override the config value.
 
 The policy flows through `Config.tool_policy` → `ApiClient.tool_policy` →
 `tool_definitions_for_policy()` which filters the tool schema, and a
@@ -188,7 +188,7 @@ rejects mutating tools even if the model hallucinates them.
 
 - Local sessions automatically adapt `max_tokens` to the server's context
   window, preventing wasted generation budget on servers with large contexts.
-- The operator can tune batch size and context via server flags
+- The operator can tune batch size and context via server options
   (`--ctx-size`, `--batch-size`) and the client respects those settings
   without per-session env-var overrides.
 - The telemetry line provides actionable capacity data for tuning.
@@ -205,7 +205,7 @@ rejects mutating tools even if the model hallucinates them.
 - Registering `run_command` in the schema increases the likelihood that
   local models attempt shell calls in contexts where they are not needed.
   Mitigated: the approval gate requires explicit user confirmation at the
-  `once` scope by default; auto-approve requires an explicit operator flag
+  `once` scope by default; auto-approve requires an explicit operator option
   (`--auto-approve task`).
 - Dispatch aliases for unregistered names (`bash`, `run_shell_command`,
   etc.) broaden the execution surface beyond what the schema alone implies.

--- a/adr/ADR-044-test-suite-scalability-and-fixture-patterns.md
+++ b/adr/ADR-044-test-suite-scalability-and-fixture-patterns.md
@@ -36,7 +36,7 @@ fixtures and builder helpers, and a standard async runtime declaration for
 streaming-heavy tests. The current branch carries roughly 50-70 focused tests
 across `src/app/tests/`, `src/state/conversation/tests/`, and `tests/`; the
 series target is to grow past 100 focused tests without reintroducing fixture
-duplication or oversized generic test buckets.
+duplication or oversized generic test groups.
 
 As the `TaskDocumentCondenser` expands its event coverage (ADR-045), the
 number of scenarios exercised in each of these files will grow. Without a
@@ -72,7 +72,7 @@ The shared support surface owns reusable SSE fixtures, tagged tool-call
 round-trip helpers, and any future builder types needed by renderer and
 runtime tests. New helper modules must use descriptive domain names such as
 `tool_rendering.rs`, `session_runtime.rs`, or `transcript_projection.rs`.
-Generic buckets such as `misc.rs`, `helpers2.rs`, or `more_tests.rs` are not
+Generic groups such as `misc.rs`, `helpers2.rs`, or `more_tests.rs` are not
 permitted.
 
 ### Rule 3 — Single builder for RuntimeContext fixtures

--- a/adr/ADR-044-test-suite-scalability-and-fixture-patterns.md
+++ b/adr/ADR-044-test-suite-scalability-and-fixture-patterns.md
@@ -126,7 +126,7 @@ migrated to `TempEnv` before the `slash_commands.rs` file is split
 ### Rule 5 — Parameterised scenarios via `#[test_case]`
 
 When three or more tests share the same assertion structure and differ only
-in input values or setup flags, they must be collapsed into a single
+in input values or setup options, they must be collapsed into a single
 `#[test_case]` parameterised test. This applies immediately to new tests.
 A retroactive cleanup of existing repeated scenarios is
 deferred to the split phase for the relevant file.

--- a/adr/completed/ADR-001-tdm-agentic-manifest-strategy.md
+++ b/adr/completed/ADR-001-tdm-agentic-manifest-strategy.md
@@ -109,5 +109,5 @@ When executing any task in this repository:
 1. Read `CONTRIBUTING.md` first. It is the TDM law, not a suggestion.
 2. Your success criterion is `cargo test <anchor_name>`, not the absence of compiler errors.
 3. Do not modify files outside the `Target File` specified in the task manifest unless the task explicitly lists additional files.
-4. Do not add new CLI flags, modes, or environment variables unless the task manifest explicitly calls for them.
+4. Do not add new CLI options, modes, or environment variables unless the task manifest explicitly calls for them.
 5. Run `cargo test --all` before declaring the task complete to verify no regressions.

--- a/adr/completed/ADR-004-runtime-seam-headless-first.md
+++ b/adr/completed/ADR-004-runtime-seam-headless-first.md
@@ -87,7 +87,7 @@ pub trait RuntimeMode {
 ### Scope discipline
 
 During the REF track (REF-02 through REF-06):
-- No new CLI flags or environment variables.
+- No new CLI options or environment variables.
 - No new tools.
 - No changes to the `messages-v1` or chat-completions protocol paths.
 - `cargo test --all` must pass after every task.

--- a/adr/completed/ADR-005-cfg-test-mock-injection.md
+++ b/adr/completed/ADR-005-cfg-test-mock-injection.md
@@ -98,4 +98,4 @@ When the REF track reaches REF-05 (generic runtime loop), extract `ApiStream` as
 **Constraints imposed on future work:**
 - Do not add additional `#[cfg(test)]` fields to `ApiClient`. If a second injectable dependency is needed, that is the signal to do the trait extraction instead.
 - `src/api/mock_client.rs` must remain gated behind `#[cfg(test)]`. It must never be compiled into release builds.
-- Any new test that uses `ConversationManager` with network calls must use `ApiClient::new_mock()`. Tests that reach the real hosted `messages-v1` API are integration tests and must be gated behind a feature flag or ignored by default.
+- Any new test that uses `ConversationManager` with network calls must use `ApiClient::new_mock()`. Tests that reach the real hosted `messages-v1` API are integration tests and must be gated behind a feature gate or ignored by default.

--- a/adr/completed/ADR-006-runtime-mode-contracts.md
+++ b/adr/completed/ADR-006-runtime-mode-contracts.md
@@ -200,9 +200,9 @@ CORE-09 Decision Record (2026-02-18): *"Do not add a new global `src/state.rs`; 
 
 ## Alternatives considered
 
-### Keep everything in `App`, add `--mode` flag when needed
+### Keep everything in `App`, add `--mode` option when needed
 
-Deferred by ADR-004. Adding a flag without the seam requires duplicating or wrapping the entire event loop. The blast radius of a mistake during that rewrite is the full application.
+Deferred by ADR-004. Adding an option without the seam requires duplicating or wrapping the entire event loop. The blast radius of a mistake during that rewrite is the full application.
 
 ### Use `tokio::sync::watch` instead of `mpsc` for `update_rx`
 
@@ -251,6 +251,6 @@ to depend on runtime-layer update signaling.
 
 1. Do not implement `run()` on `Runtime<M>` until REF-05. The stub in `loop.rs` is intentional.
 2. Do not move the `ratatui` draw loop out of `App` until REF-06. That is REF-06's job.
-3. Do not add CLI flags, environment variables, or new tool definitions during the REF track.
+3. Do not add CLI options, environment variables, or new tool definitions during the REF track.
 4. `cargo test --all-targets` must pass after every task. Anchor tests from completed tasks must stay green.
 5. The only files in scope per task are listed in that task's manifest. Do not edit adjacent files to make a test compile.

--- a/adr/completed/ADR-013-tui-completion-deployment-plan.md
+++ b/adr/completed/ADR-013-tui-completion-deployment-plan.md
@@ -125,7 +125,7 @@ in code review and CI:
    field after CORE-09) MUST NOT exceed `MAX_HISTORY_LINES` at the end of any
    `on_model_update` or `on_user_input` call.
 
-4. **Dirty flag:** `TuiFrontend::render` MUST NOT call `terminal.draw(...)` when
+4. **Dirty indicator:** `TuiFrontend::render` MUST NOT call `terminal.draw(...)` when
    `dirty` is false and the tick interval has not elapsed.
 
 5. **Panic hook:** `crate::terminal::restore()` MUST be registered in the panic hook

--- a/adr/completed/ADR-025-runtime-json-handoff-contract.md
+++ b/adr/completed/ADR-025-runtime-json-handoff-contract.md
@@ -308,7 +308,7 @@ However, ADR-025 imposes a new internal rule:
 - command-history evidence recorded in BatchMode must be traceable to the canonical tool/validation event stream for that turn; PI-12 tests must prove that replaying canonical envelopes reconstructs the existing summarized JSONL shape.
 - When `MaxTurnsReached` is emitted, `SummaryRecord.status` is `"failed"` and a `max_turns_reached: true` field is added to the summary record. This is additive and does not break existing tooling that reads only `status`.
 
-A future additive format such as `--format json-events` may emit one `RuntimeEnvelope` per line, but this ADR does not require that flag to exist now.
+A future additive format such as `--format json-events` may emit one `RuntimeEnvelope` per line, but this ADR does not require that option to exist now.
 
 ### 7. Schema v1 is required
 

--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -76,9 +76,9 @@ Manages the OS credential-store entries used by the runtime token fallback.
 - `vex credentials delete <account>` removes the stored secret.
 - `vex credentials list` prints the known account identifiers for the `vexcoder` service.
 
-The current build uses macOS Keychain on macOS, Windows Credential Manager on
-Windows, and Linux keyutils on Linux. `set` intentionally refuses to read the
-secret from argv so the value does not leak into shell history or process lists.
+The current build uses platform-native credential stores. `set` intentionally
+refuses to read the secret from argv so the value does not leak into shell
+history or process lists.
 
 ### `vex export <task-id> [--format jsonl|markdown] [--output PATH] [--force]`
 

--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -1,6 +1,6 @@
 # CLI and TUI Commands
 
-This page documents the commands and flags implemented in the current binary.
+This page documents the commands and options implemented in the current binary.
 
 ## CLI
 
@@ -23,9 +23,9 @@ repo-overview prompts, the runtime now steers the model
 toward `list_files` at the workspace root or `codebase_search` before any
 targeted `read_file`; `read_file` itself requires an explicit non-empty path.
 
-#### Top-level flags
+#### Top-level options
 
-| Flag | Effect |
+| Option | Effect |
 |------|--------|
 | `--chat-compat` | Use the `chat/completions` API format instead of the default `messages/v1` format. Required for endpoints that only expose the chat completions schema. |
 | `--plan` | Restrict tools to read-only operations (search, read, list, git read ops, `codebase_search`, MCP). Mutating and shell tools are excluded from the model schema and rejected at dispatch. Cannot be combined with `--chat`. |
@@ -45,7 +45,7 @@ stdin content is prepended to the prompt.
 
 Runs a non-interactive batch task.
 
-Useful flags:
+Useful options:
 
 - `--task-file PATH`
 - `--max-turns N`
@@ -185,7 +185,7 @@ Commands entered inside the interactive UI start with `/`.
   - Accepts either a plain workspace-relative path or `@path`; `@path` is normalized to the requested file target before context assembly runs.
 - `/review [--base <git-ref>] [--files <glob>] [<instruction>]`
   - Starts a single review turn without entering the edit loop.
-  - With no flags, reviews `git diff HEAD`.
+  - With no options, reviews `git diff HEAD`.
   - `--base <git-ref>` reviews `git diff <git-ref>` after validating the ref.
   - `--files <glob>` assembles matching workspace files instead of a diff and cannot be combined with `--base`.
   - Expands `@path` mentions inside the free-form review instruction before the review turn starts. When `--files` receives `@glob`, the leading `@` is stripped before file matching.

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -210,8 +210,7 @@ Lookup order for authenticated endpoints:
 2. OS credential store entry `service = "vexcoder"`, `account = "model-token"`
 
 The credential-store fallback is disabled when `VEX_KEYRING_DISABLED=1`.
-The current build uses macOS Keychain on macOS, Windows Credential Manager on
-Windows, and Linux keyutils on Linux.
+The current build uses platform-native credential stores.
 
 Store the token without placing it on argv:
 
@@ -348,8 +347,8 @@ Selects the command sandbox driver. Accepted values: `passthrough`,
   `VEX_SANDBOX_PROFILE` to name the container image.
 - `bubblewrap` wraps commands with `bwrap`, mounts the workspace read-write,
   mounts core system directories read-only, adds read-only mounts for common
-  host toolchain roots derived from `PATH`, `CARGO_HOME`, `RUSTUP_HOME`, and
-  `/nix/store`, and disables network by default.
+  host toolchain roots derived from `PATH`, `CARGO_HOME`, and `RUSTUP_HOME`,
+  and disables network by default.
 - The built-in `macos-exec` default is intentionally compatibility-first: it
   allows broad file access, network access, process spawning, IPC lookups, and
   signals so common development tools continue to work. Use a custom profile if

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -79,7 +79,7 @@ for live tool-call parsing.
 
 `tool_policy` controls which tools are exposed to the model for a session.
 
-| Policy | Tools exposed | CLI flag |
+| Policy | Tools exposed | CLI option |
 | :--- | :--- | :--- |
 | `full` | All registered tools including mutating and shell tools | (default) |
 | `plan` | Read-only tools only: `read_file`, `list_files`, `list_directory`, `list_dir`, `glob_files`, `search_files`, `search`, `git_status`, `git_diff`, `git_log`, `git_show`, `search_content`, `find_files`, `codebase_search`, plus any configured MCP tools | `--plan` |
@@ -315,7 +315,7 @@ Opt in to automatic git status and diff injection during context assembly.
 
 - Accepts `true`, `false`, `1`, `0`, `yes`, `no`, `on`, or `off`.
 - Default: `false`.
-- Explicit git tools and review flows still call git directly; this flag only
+- Explicit git tools and review flows still call git directly; this option only
   controls the automatic context path used before a normal model turn.
 
 ### `VEX_CONTEXT_GIT_TIMEOUT_MS`

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -11,6 +11,6 @@ This book focuses on the public user surface:
 - understanding the current runtime, application, and transport layout
 - creating a workspace with `vex init`
 - configuring the model endpoint and token
-- using the current CLI flags and interactive commands
+- using the current CLI options and interactive commands
 
 The shortest path to a running session is in [Quick Start](quick-start.md). For the current code layout, see [Architecture Overview](architecture.md).

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -3,7 +3,7 @@
 VexCoder is a local coding assistant you run as a binary. It connects to the
 model endpoint you configure, supports interactive CLI sessions and
 non-interactive batch runs, and keeps its setup lightweight enough to build
-from source on macOS, Linux, and Windows.
+from source on supported platforms.
 
 This book focuses on the public user surface:
 

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -64,7 +64,7 @@ latency or scale profile:
   avoid parsing the full JSON document during cold start, but it must also
   solve invalidation and crash-consistency so the sidecar cannot drift from the
   task-state JSON.
-- Directory sharding by time bucket or prefix can reduce `read_dir` and
+- Directory sharding by time slice or prefix can reduce `read_dir` and
   metadata pressure when the task-state surface grows large enough that one
   flat directory dominates cold-start cost.
 - A single-writer event log paired with periodic summary checkpoints can make

--- a/scripts/check_forbidden_names.sh
+++ b/scripts/check_forbidden_names.sh
@@ -204,6 +204,7 @@ brand_words=(
   $'\x6c\x6c\x61\x6d\x61'
   $'\x76\x6c\x6c\x6d'
   $'\x6d\x65\x74\x61'
+  $'\x6e\x69\x78'
 )
 brand_regex="$(printf '%s|' "${brand_words[@]}")"
 brand_regex="${brand_regex%|}"

--- a/src/app.rs
+++ b/src/app.rs
@@ -428,7 +428,7 @@ pub struct TuiMode {
     /// assistant block, so that flat `StreamDelta` events are skipped to
     /// avoid double-counting the same content.
     stream_uses_block_deltas: bool,
-    // ── Turn lifecycle flags ───────────────────────────────────────────────
+    // ── Turn lifecycle settings ────────────────────────────────────────────
     read_only_turn_active: bool,
     active_edit_loop: Option<EditLoop>,
     // ── Timeline viewport ─────────────────────────────────────────────────

--- a/src/app/tests/model_turn/slash_commands.rs
+++ b/src/app/tests/model_turn/slash_commands.rs
@@ -407,7 +407,7 @@ async fn test_read_only_turn_flag_clears_after_turn_completion() {
     mode.on_model_update(UiUpdate::TurnComplete, &mut ctx);
     assert!(
         !mode.read_only_turn_active,
-        "turn completion must clear the read-only turn flag"
+        "turn completion must clear the read-only turn indicator"
     );
 
     let (response_tx, response_rx) = tokio::sync::oneshot::channel::<bool>();

--- a/src/batch_mode.rs
+++ b/src/batch_mode.rs
@@ -425,7 +425,7 @@ impl FrontendAdapter<BatchMode> for BatchFrontend {
 }
 
 /// Wraps `BatchFrontend` and quits once the mode signals done via a shared
-/// flag. In practice `run_batch` drives the update loop directly, so this
+/// option. In practice `run_batch` drives the update loop directly, so this
 /// wrapper is provided for callers that want to use `Runtime::run`.
 pub struct BatchFrontendQuit {
     inner: BatchFrontend,

--- a/src/batch_mode/tests.rs
+++ b/src/batch_mode/tests.rs
@@ -187,7 +187,7 @@ async fn test_batch_mode_memory_clear_with_max_turns_emits_single_summary() {
         .filter(|line| {
             serde_json::from_str::<serde_json::Value>(line)
                 .ok()
-                .and_then(|value| value.get("summary").and_then(|flag| flag.as_bool()))
+                .and_then(|value| value.get("summary").and_then(|entry| entry.as_bool()))
                 == Some(true)
         })
         .count();
@@ -207,7 +207,7 @@ async fn test_batch_mode_jsonl_output_includes_required_fields() {
         .find(|value| {
             !value
                 .get("summary")
-                .and_then(|flag| flag.as_bool())
+                .and_then(|entry| entry.as_bool())
                 .unwrap_or(false)
         })
         .expect("expected a turn record before the final summary");
@@ -219,7 +219,7 @@ async fn test_batch_mode_jsonl_output_includes_required_fields() {
 
     let summary = records
         .iter()
-        .find(|value| value.get("summary").and_then(|flag| flag.as_bool()) == Some(true))
+        .find(|value| value.get("summary").and_then(|entry| entry.as_bool()) == Some(true))
         .expect("expected a final summary record");
     assert_eq!(summary["status"], "Completed");
 }

--- a/src/bin/vex.rs
+++ b/src/bin/vex.rs
@@ -463,7 +463,7 @@ async fn main() -> Result<ExitCode> {
     config.validate()?;
     emit_model_endpoint_warnings(&config);
 
-    // PM-01: --resume startup flag.
+    // PM-01: --resume startup option.
     if let Some(state) = resume_state {
         let mut frontend = ManagedTuiFrontend::new()?;
         run_tui_session(config, Some(state), &mut frontend).await?;
@@ -476,9 +476,9 @@ async fn main() -> Result<ExitCode> {
     Ok(ExitCode::SUCCESS)
 }
 
-/// Apply top-level CLI flag overrides to a loaded config.
+/// Apply top-level CLI option overrides to a loaded config.
 ///
-/// This is called once per code path after `Config::load()` so that flags such
+/// This is called once per code path after `Config::load()` so that options such
 /// as `--chat-compat`, `--plan`, and `--chat` take effect regardless of which
 /// subcommand is active.
 fn apply_cli_overrides(chat_compat: bool, tool_policy: ToolPolicy, config: &mut Config) {

--- a/src/bin/vex/cli.rs
+++ b/src/bin/vex/cli.rs
@@ -117,8 +117,7 @@ pub(super) enum Commands {
     },
     /// Manage OS-native credential store entries (ADR-024 Gap 38).
     ///
-    /// Credentials are stored in the OS keyring (macOS Keychain, Linux
-    /// keyutils, Windows Credential Manager) under the service name
+    /// Credentials are stored in the platform keyring under the service name
     /// "vexcoder".
     /// Set VEX_KEYRING_DISABLED=1 to bypass the keyring and use only
     /// VEX_MODEL_TOKEN for token lookup.

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1026,7 +1026,7 @@ fn test_mcp_http_with_args_is_rejected() {
     std::fs::create_dir_all(cwd.join(".git")).unwrap();
     std::fs::write(
         &user_cfg,
-        "[[mcp_servers]]\nname = \"badhttp\"\ntransport = \"http\"\nurl = \"http://example.com\"\nargs = [\"--flag\"]\n",
+        "[[mcp_servers]]\nname = \"badhttp\"\ntransport = \"http\"\nurl = \"http://example.com\"\nargs = [\"--option\"]\n",
     )
     .unwrap();
 

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -1,7 +1,7 @@
 //! OS-native credential store access (ADR-024 Gap 38).
 //!
 //! Wraps the `keyring` crate to provide a uniform read/write/delete surface
-//! over macOS Keychain, Linux keyutils, and Windows Credential Manager.
+//! over platform-native credential stores.
 //! All operations are fallible: callers must handle errors and fall back to
 //! environment variables when the OS credential store is unavailable.
 //!

--- a/src/runtime/sandbox.rs
+++ b/src/runtime/sandbox.rs
@@ -558,10 +558,10 @@ mod tests {
             .expect("wrap request");
         assert_eq!(wrapped.program, "sandbox-exec");
         let args = &wrapped.args;
-        // First flag must be -p (inline profile), not -f (profile file).
+        // First option must be -p (inline profile), not -f (profile file).
         assert_eq!(
             args[0], "-p",
-            "expected -p flag for inline profile, got: {args:?}"
+            "expected -p option for inline profile, got: {args:?}"
         );
         // The original command and its argument must follow the profile value.
         assert!(
@@ -590,7 +590,7 @@ mod tests {
         let args = &wrapped.args;
         assert_eq!(
             args[0], "-f",
-            "expected -f flag for profile file, got: {args:?}"
+            "expected -f option for profile file, got: {args:?}"
         );
         assert_eq!(args[1], profile_path, "expected profile path as second arg");
         assert!(
@@ -666,7 +666,7 @@ mod tests {
 
     #[test]
     fn bubblewrap_places_separator_before_command() {
-        // `--` must separate bwrap flags from the sandboxed command.
+        // `--` must separate bwrap options from the sandboxed command.
         let sandbox = super::BubblewrapSandbox::new(None);
         let wrapped = sandbox
             .wrap(CommandRequest {

--- a/src/runtime/sandbox.rs
+++ b/src/runtime/sandbox.rs
@@ -212,9 +212,9 @@ impl SandboxDriver for ContainerSandbox {
 /// read-write; `/usr`, `/lib`, `/lib64`, `/bin`, `/sbin`, `/etc` are
 /// bind-mounted read-only; `/proc`, `/dev`, and `/tmp` are mounted as
 /// pseudo-filesystems so that standard toolchains can function. Common host
-/// toolchain roots derived from `CARGO_HOME`, `RUSTUP_HOME`, `/nix/store`,
-/// and absolute `PATH` entries are also bind-mounted read-only so Rustup- and
-/// Nix-managed toolchains stay available inside the sandbox.
+/// toolchain roots derived from `CARGO_HOME`, `RUSTUP_HOME`, and absolute
+/// `PATH` entries are also bind-mounted read-only so installed toolchains stay
+/// available inside the sandbox.
 ///
 /// `profile` is an optional whitespace-separated list of additional `bwrap`
 /// arguments. The string is split with `split_whitespace()` (no shell quoting
@@ -295,12 +295,6 @@ impl BubblewrapSandbox {
                 .map(PathBuf::from)
                 .or_else(|| home_dir.as_ref().map(|home| home.join(".rustup"))),
         );
-        maybe_add(
-            &mut extra_roots,
-            working_dir,
-            Some(PathBuf::from("/nix/store")),
-        );
-
         if let Some(path_var) = std::env::var_os("PATH") {
             for path_entry in std::env::split_paths(&path_var) {
                 maybe_add(&mut extra_roots, working_dir, Some(path_entry));

--- a/src/runtime/task_document/condenser.rs
+++ b/src/runtime/task_document/condenser.rs
@@ -359,7 +359,7 @@ impl TaskDocumentCondenser {
             return summary;
         };
 
-        // Clear streaming flags so completed turn entries render without a
+        // Clear streaming markers so completed turn entries render without a
         // live-typing cursor.
         for entry in &mut active.entries {
             if let TurnEntry::AssistantBlock { block, .. } = entry {

--- a/src/runtime/text_util.rs
+++ b/src/runtime/text_util.rs
@@ -1,6 +1,6 @@
 /// Truncate `text` to at most `max_bytes` bytes from the **start**,
 /// respecting UTF-8 char boundaries. Returns the possibly shortened
-/// string and a flag indicating whether any bytes were omitted.
+/// string and a boolean indicating whether any bytes were omitted.
 ///
 /// Used by `ContextAssembler` for file-snapshot content.
 pub fn truncate_head_bytes(text: &str, max_bytes: usize) -> (String, bool) {
@@ -16,7 +16,7 @@ pub fn truncate_head_bytes(text: &str, max_bytes: usize) -> (String, bool) {
 
 /// Truncate `text` to at most `max_bytes` bytes from the **end**,
 /// respecting UTF-8 char boundaries. Returns the possibly shortened
-/// string and a flag indicating whether any bytes were omitted.
+/// string and a boolean indicating whether any bytes were omitted.
 ///
 /// Used by `ValidationSuite` for stdout/stderr trailing-output capture.
 pub fn truncate_tail_bytes(text: &str, max_bytes: usize) -> (String, bool) {


### PR DESCRIPTION
## Summary
This change normalizes repository prose to use neutral wording and updates the naming gate to reject the remaining brand-specific store reference.

## Motivation
The repository still contained a small set of branded and overly specific terms in docs and comments, which left the naming gate incomplete and some user-facing references non-neutral.

## Approach
I updated the documentation and source comments that described sandbox toolchain roots, credential-store backends, and generic grouping language so they use neutral terms. I also added the remaining brand string to `scripts/check_forbidden_names.sh` so the gate now enforces the cleanup.

## Validation
`cargo fmt --check`
`cargo build`
`./target/debug/vex --help`
`bash scripts/check_forbidden_names.sh`
`cargo clippy --all-targets -- -D warnings`
`cargo nextest run -j 2`

## Risks
Duplication / missed shared-code opportunity: none identified; this is a wording-and-gate cleanup only.
Unused code: none identified.
Bugs / regression risk: removing the explicit store-root reference changes sandbox behavior for environments that depended on that hard-coded path; the existing build, smoke, lint, and test passes reduce the risk.
Inconsistency with ADRs: none identified; the edits stay within the existing neutral-language and sandbox boundaries.
Test coverage gaps: there is no dedicated regression test for the removed store-root path, so the behavior change is covered indirectly by the build and suite rather than a focused assertion.
Follow-up work deferred: broader platform-specific wording was left in place where it still describes actual compile-time or runtime behavior.
