### PR TITLE
fix: preserve XML fallback parameter entities

### DIFF
--- a/scripts/upgrade-deps.sh
+++ b/scripts/upgrade-deps.sh
@@ -58,15 +58,29 @@ print_review_seams() {
   cat <<'EOF'
 
 Review these local seams when an upgraded crate needs source changes:
-  - TUI stack: src/ui/tui.rs, src/tui_handle.rs
-  - XML tool-call parsing: src/state/conversation/tool_call_parser.rs
-  - Structural indexing: src/tools/index.rs
+  - ratatui / crossterm: src/ui/tui.rs, src/tui_handle.rs,
+    src/tui_frontend.rs, src/ui/editor/mod.rs, src/app.rs,
+    src/app/overlay.rs, src/app/tests/mod.rs
+  - rmcp: src/mcp.rs
+  - http: src/http_facade.rs, src/mcp.rs, src/server/http.rs,
+    src/server/util.rs, src/server/handlers/mod.rs,
+    src/server/handlers/session.rs, src/server/tests.rs
+  - tokio: src/runtime/tokio.rs plus the focused runtime, server, and test
+    sites listed under [workspace.metadata.upgrade-seams] in Cargo.toml
+  - arboard: src/clipboard.rs, src/app/commands/session.rs
+  - serde: derives and #[serde(...)] attributes stay next to their owning
+    types; review src/** and crates/vexcoder-api-types/src/lib.rs directly
+  - rust / MSRV: update package.rust-version and CI toolchain declarations
+    together
+  - quick-xml: src/state/conversation/tool_call_parser.rs
+  - tree-sitter: src/tools/index.rs
   - Markdown rendering: src/ui/render/markdown.rs
-  - HTTP and MCP stack: src/api/client/mod.rs, src/mcp.rs, src/server/
 
 Use `cargo tree -i <crate>` to inspect reverse dependencies for one crate.
 Use `cargo tree -d` for investigation only; it is not a hard gate because the
 transitive tree legitimately carries parallel versions in some ecosystems.
+The authoritative seam map lives in [workspace.metadata.upgrade-seams] and
+[workspace.metadata.upgrade-notes] in the root Cargo.toml.
 EOF
 }
 

--- a/src/state/conversation/tool_call_parser.rs
+++ b/src/state/conversation/tool_call_parser.rs
@@ -66,6 +66,20 @@ fn decode_xml_text(text: &quick_xml::events::BytesText<'_>) -> Option<String> {
     text.decode().ok().map(|value| value.into_owned())
 }
 
+fn decode_xml_reference(reference: &quick_xml::events::BytesRef<'_>) -> Option<String> {
+    let raw = std::str::from_utf8(reference.as_ref()).ok()?;
+    let escaped = if raw.starts_with('&') {
+        raw.to_string()
+    } else if raw.ends_with(';') {
+        format!("&{raw}")
+    } else {
+        format!("&{raw};")
+    };
+    quick_xml::escape::unescape(&escaped)
+        .ok()
+        .map(|value| value.into_owned())
+}
+
 impl XmlFallbackParser {
     /// Try to parse tool calls from generic XML patterns:
     ///   `<tool_call>…</tool_call>`  or  `<invoke name="…">…</invoke>`
@@ -125,11 +139,12 @@ impl XmlFallbackParser {
     fn parse_invoke_blocks(text: &str) -> Vec<TaggedToolCall> {
         let mut calls = Vec::new();
         let mut reader = XmlReader::from_str(text);
-        reader.config_mut().trim_text(true);
+        reader.config_mut().trim_text(false);
 
         let mut current_name: Option<String> = None;
         let mut current_params = serde_json::Map::new();
         let mut current_key: Option<String> = None;
+        let mut current_value = String::new();
         let mut depth = 0u32;
         let mut buf = Vec::new();
 
@@ -151,15 +166,30 @@ impl XmlFallbackParser {
                             .filter_map(Result::ok)
                             .find(|a| a.key.as_ref() == b"name" || a.key.as_ref() == b"key")
                             .and_then(|a| String::from_utf8(a.value.to_vec()).ok());
+                        current_value.clear();
                     }
                     _ => {}
                 },
                 Ok(XmlEvent::Text(ref e)) if depth > 0 && current_key.is_some() => {
-                    if let (Some(key), Some(val)) = (current_key.take(), decode_xml_text(e)) {
-                        current_params.insert(key, serde_json::Value::String(val));
+                    if let Some(val) = decode_xml_text(e) {
+                        current_value.push_str(&val);
+                    }
+                }
+                Ok(XmlEvent::GeneralRef(ref e)) if depth > 0 && current_key.is_some() => {
+                    if let Some(val) = decode_xml_reference(e) {
+                        current_value.push_str(&val);
                     }
                 }
                 Ok(XmlEvent::End(ref e)) => match e.name().as_ref() {
+                    b"parameter" | b"argument" if depth > 0 => {
+                        let value = current_value.trim().to_string();
+                        if let Some(key) = current_key.take()
+                            && !value.is_empty()
+                        {
+                            current_params.insert(key, serde_json::Value::String(value));
+                        }
+                        current_value.clear();
+                    }
                     b"invoke" | b"tool_use" if depth > 0 => {
                         depth -= 1;
                         if let Some(name) = current_name.take()
@@ -173,9 +203,7 @@ impl XmlFallbackParser {
                             });
                         }
                     }
-                    _ => {
-                        current_key = None;
-                    }
+                    _ => {}
                 },
                 Ok(XmlEvent::Eof) => break,
                 Err(_) => break,
@@ -313,6 +341,16 @@ mod tests {
         assert_eq!(calls.len(), 2);
         assert_eq!(calls[0].input["path"], "a.rs");
         assert_eq!(calls[1].input["path"], "b.rs");
+    }
+
+    #[test]
+    fn xml_fallback_unescapes_parameter_entities() {
+        let text = r#"<invoke name="search_files">
+<parameter name="query">a&amp;b &lt; c &#x2f; d</parameter>
+</invoke>"#;
+        let calls = XmlFallbackParser::parse_xml_tool_calls(text);
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].input["query"], "a&b < c / d");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This change preserves complete parameter values in the XML fallback parser after the quick-xml update and restores the dependency-upgrade helper so it prints the full seam map from the shared review helper instead of leaving that guidance stranded in one execution path.

## Motivation

The seam-localization lane merged on main, but review exposed one correctness gap in `src/state/conversation/tool_call_parser.rs`: entity-escaped XML parameters could be truncated or left unresolved because quick-xml now emits entity references as separate events. The follow-up also corrects the upgrade helper so the expanded seam guidance remains attached to `print_review_seams()` and is available from the dry-run and apply flows.

## Approach

For the parser fix, the chosen approach keeps the structured XML reader and accumulates `Text` plus `GeneralRef` events until each `<parameter>` or `<argument>` closes, then trims once before insertion. Two alternatives were ruled out: reverting to ad hoc string slicing would duplicate parsing logic and be fragile around malformed XML, and switching to the reader convenience helpers would still leave entity handling unresolved in the current quick-xml release. For the operator helper, the seam list stays in `print_review_seams()` so both `plan` and `apply` reuse one source of truth while the `apply` branch keeps its actual upgrade commands.

## Validation

I ran `cargo fmt`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo nextest run -j 2`, `bash scripts/check_forbidden_names.sh`, `cargo build --bin vex`, and `cargo run --quiet --bin vex -- --help`. The full nextest pass completed with 1378 tests passed and 0 failed, and the CLI help smoke check printed the expected command list.

## Risks

- Duplication / missed shared-code opportunity: the seam map now exists in `Cargo.toml`, `scripts/upgrade-deps.sh`, and the dependency-upgrade guide, so those references still need to move together when upgrade boundaries change.
- Unused code: no unused helper was introduced by this diff.
- Bugs / regression risk: the parser change is limited to the XML fallback path, but mixed-content parameter bodies with nested elements or other uncommon quick-xml event combinations could still need additional coverage.
- Inconsistency with ADRs: no conflict with ADR-028 or ADR-043 was identified; the change keeps the fallback parser optional and continues to concentrate version-sensitive handling near the existing seams.
- Test coverage gaps: entity-escaped parameter text is now covered, but the follow-up does not add new cases for CDATA or nested markup inside parameter bodies.
- Follow-up work deferred: if more XML formats appear in model output, add focused fallback parser cases for those event shapes rather than broadening the parser heuristically.
