### PR TITLE
chore: centralize workspace metadata, lints, and MSRV policy

### DIFF
--- a/.github/instructions/rust.instructions.md
+++ b/.github/instructions/rust.instructions.md
@@ -26,7 +26,10 @@ applyTo: "**/*.rs,**/Cargo.toml,**/Cargo.lock"
 ### Safety and correctness
 
 - Avoid `unsafe` unless the task explicitly requires it. When `unsafe` is
-  necessary, document the safety invariant in a `// SAFETY:` comment.
+  necessary, document the safety invariant in a `// SAFETY:` comment **and**
+  annotate the enclosing item with `#[allow(unsafe_code)]` plus a one-line
+  rationale. The workspace lint `unsafe_code = "warn"` (enforced as an error by
+  `make lint`) requires this annotation for any new unsafe block.
 - Validate all indices, lengths, and type conversions at trust boundaries.
 - Prefer `TryFrom`/`TryInto` over `as` casts for numeric conversions that may
   lose precision or sign.
@@ -37,6 +40,13 @@ applyTo: "**/*.rs,**/Cargo.toml,**/Cargo.lock"
 - Prefer deterministic tests. Avoid timing-dependent assertions without
   explicit tolerance or retry logic.
 - Keep test helpers minimal and co-located with the tests that use them.
+
+### Lints
+
+Workspace lint rules live in `[workspace.lints]` in the root `Cargo.toml`
+(stable since Rust 1.74). Every member crate opts in via `[lints] workspace = true`.
+Reproduce the CI lint gate locally with `make lint`.
+Full policy and progressive-adoption guide: `docs/src/linting.md`.
 
 ### Dependencies
 
@@ -89,5 +99,7 @@ Before submitting Rust changes, verify:
 - [ ] Error propagation — errors surface with enough context to diagnose
 - [ ] Lifetimes and ownership — no unnecessary cloning or leaking
 - [ ] Test coverage — changed behavior has at least one covering test
-- [ ] Formatting and lint cleanliness — `cargo fmt` and `cargo clippy` pass
+- [ ] Formatting and lint cleanliness — `make fmt-check` and `make lint` pass
+- [ ] Unsafe code — any new `unsafe` block carries `// SAFETY:` + `#[allow(unsafe_code)]`
 - [ ] Dependency changes — new crates justified, `make deps-deny` passes
+- [ ] MSRV — no API used that was stabilised after `rust-version` in `Cargo.toml`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4344,9 +4344,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,16 @@
 [workspace]
 members = [".", "crates/*"]
-resolver = "2"
+# resolver = "3" is the default for edition = "2024" workspaces (Rust 1.84+).
+# It activates the MSRV-aware dependency resolver, which prefers crate versions
+# compatible with the declared rust-version instead of always picking the latest.
+# See docs/src/msrv.md and the Rust 2024 Edition Guide §cargo-resolver.
+resolver = "3"
 
 [workspace.package]
+version = "0.1.0-rc.9"
 edition = "2024"
+rust-version = "1.91"
+license = "MIT"
 
 [workspace.dependencies]
 # Direct third-party version requirements live here so `cargo upgrade` only
@@ -171,18 +178,41 @@ serde = [
   "derive and #[serde(...)] attributes stay next to their types in src/** and crates/vexcoder-api-types/src/lib.rs",
 ]
 arboard = ["src/clipboard.rs", "src/app/commands/session.rs"]
+# Markdown rendering stack — both crates are consumed together at one site.
+pulldown-cmark = ["src/ui/render/markdown.rs"]
+syntect = ["src/ui/render/markdown.rs"]
+# TUI text bridge — converts ANSI escape sequences to ratatui spans.
+ansi-to-tui = ["src/ui/tui.rs"]
+# XML tool-call parser — the only call site for quick-xml's reader API.
+quick-xml = ["src/state/conversation/tool_call_parser.rs"]
+# tree-sitter grammar loading and query API — one indexing module.
+tree-sitter = ["src/tools/index.rs"]
+tree-sitter-rust = ["src/tools/index.rs"]
+tree-sitter-python = ["src/tools/index.rs"]
+tree-sitter-typescript = ["src/tools/index.rs"]
+tree-sitter-javascript = ["src/tools/index.rs"]
+# gitoxide family — pure-Rust git operations, all wired through git_rollup.
+gix = ["src/runtime/git_rollup.rs"]
+gix-discover = ["src/runtime/git_rollup.rs"]
+gix-config = ["src/runtime/git_rollup.rs"]
+gix-index = ["src/runtime/git_rollup.rs"]
+# libgit2 bindings — lower-level git tasks (commit-graph, repo discovery).
+git2 = ["src/tools/operator/git_ops.rs"]
 
 [workspace.metadata.upgrade-notes]
-rust = "Update package.rust-version and the CI toolchain declarations together when the MSRV changes."
+rust = "Update workspace.package.rust-version and CI toolchain declarations together; also update clippy.toml msrv field."
 serde = "Derive and field/container attributes are compile-time only; a facade does not reduce churn here."
 tokio = "Runtime helpers are localized in src/runtime/tokio.rs; attribute macros like #[tokio::test] remain direct in tests and binaries."
+tree-sitter = "All five grammar crates share the same seam (src/tools/index.rs); bump them together."
+gix = "The four gix-* sub-crates share the same seam (src/runtime/git_rollup.rs); coordinate their bumps."
+pulldown-cmark = "pulldown-cmark and syntect share src/ui/render/markdown.rs; check both when either changes."
 
 [package]
 name = "vexcoder"
-version = "0.1.0-rc.9"
-edition = "2024"
-rust-version = "1.91"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
 autobins = false
 
 [features]
@@ -362,5 +392,21 @@ tower.workspace = true
 pretty_assertions.workspace = true
 assert_cmd.workspace = true
 
+[lints]
+workspace = true
+
+# ---------------------------------------------------------------------------
+# Workspace-wide lint policy (Rust 1.74+, RFC 3389).
+# All member crates inherit these via `[lints] workspace = true`.
+# See docs/src/linting.md for the rationale and progressive-adoption guide.
+# ---------------------------------------------------------------------------
+
+[workspace.lints.rust]
+# Any new unsafe block must carry a // SAFETY: comment.
+# Existing sites annotate with #[allow(unsafe_code)] + a rationale comment.
+unsafe_code = "warn"
+
 [workspace.lints.clippy]
+# Allow MSRV-gated API calls to compile on the declared minimum toolchain (1.91).
+# Remove this entry when rust-version advances past any previously-gated API.
 incompatible_msrv = "allow"

--- a/TASKS/completed/REPO-RAW-URL-MAP.md
+++ b/TASKS/completed/REPO-RAW-URL-MAP.md
@@ -5,7 +5,7 @@ Canonical raw URL index for every tracked file in this repository.
 - Branch: main
 - Base: <https://raw.githubusercontent.com/aistar-au/vexcoder/main/>
 - Source: git ls-files
-- Total tracked files: 363
+- Total tracked files: 366
 
 | # | Path | Approx. lines | Raw URL |
 | :--- | :--- | :--- | :--- |
@@ -369,3 +369,6 @@ Canonical raw URL index for every tracked file in this repository.
 | 358 | `tests/tool_operator_tests.rs` | ~382 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/tests/tool_operator_tests.rs> |
 | 359 | `.github/workflows/deny.yml` | ~63 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/.github/workflows/deny.yml> |
 | 360 | `deny.toml` | ~154 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/deny.toml> |
+| 361 | `clippy.toml` | ~12 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/clippy.toml> |
+| 362 | `docs/src/linting.md` | ~95 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/docs/src/linting.md> |
+| 363 | `docs/src/msrv.md` | ~70 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/docs/src/msrv.md> |

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,11 @@
+# clippy.toml — workspace-wide Clippy configuration
+#
+# This file is picked up by `cargo clippy` (and `make lint`) automatically.
+# See docs/src/linting.md for the workspace lint policy and progressive
+# adoption guide.
+#
+# msrv: tells Clippy which stable APIs are in scope for this codebase.
+# Any API introduced after this version will trigger clippy::msrv lints
+# locally before CI has a chance to catch them.  Keep this in sync with
+# package.rust-version in the root Cargo.toml (workspace.package.rust-version).
+msrv = "1.91"

--- a/crates/vexcoder-api-types/Cargo.toml
+++ b/crates/vexcoder-api-types/Cargo.toml
@@ -1,10 +1,14 @@
 [package]
 name = "vexcoder-api-types"
-version = "0.1.0-rc.9"
+version.workspace = true
 edition.workspace = true
-license = "MIT"
+rust-version.workspace = true
+license.workspace = true
 description = "API wire types for the vexcoder coding agent"
 
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -17,3 +17,5 @@
 # Maintainer Guide
 
 - [Dependency Upgrades](dependency-upgrades.md)
+- [Lint Policy](linting.md)
+- [MSRV Policy](msrv.md)

--- a/docs/src/linting.md
+++ b/docs/src/linting.md
@@ -1,0 +1,94 @@
+# Lint Policy
+
+This repository defines all workspace-wide lint rules in one place and
+members inherit them automatically. The goal is the same as
+[dependency centralization](dependency-upgrades.md): one file to edit,
+consistent enforcement everywhere.
+
+## How it works
+
+`[workspace.lints]` in the root `Cargo.toml` (stable since Rust 1.74,
+[RFC 3389](https://rust-lang.github.io/rfcs/3389-manifest-lint.html)) holds
+the shared rule set. Each member crate opts in with a single stanza:
+
+```toml
+# in any crates/*/Cargo.toml
+[lints]
+workspace = true
+```
+
+Running `cargo clippy --all-targets -- -D warnings` (or `make lint`) applies
+the workspace rules to every crate in one pass. CI enforces the same command
+so local and remote results are identical.
+
+## Current rules
+
+| Table | Lint | Level | Reason |
+| :--- | :--- | :--- | :--- |
+| `[workspace.lints.rust]` | `unsafe_code` | `warn` | New `unsafe` blocks must carry a `// SAFETY:` comment; existing sites carry `#[allow(unsafe_code)]` with rationale. |
+| `[workspace.lints.clippy]` | `incompatible_msrv` | `allow` | Suppresses false positives when a Clippy lint fires for an API that already exists on the declared MSRV. Remove when `rust-version` advances past the gated API. |
+
+### MSRV-aware Clippy
+
+`clippy.toml` at the workspace root sets `msrv = "1.91"`, matching
+`workspace.package.rust-version`. This causes `clippy::msrv` lints to fire
+locally on APIs that were stabilised after 1.91, giving early feedback
+before CI.
+
+## Unsafe code policy
+
+`unsafe_code = "warn"` is the workspace default. The rule is:
+
+1. **New unsafe** — add a `// SAFETY:` comment explaining the invariant that
+   makes the block sound. CI will catch the warning (`-D warnings`).
+2. **Existing unsafe** — annotate the enclosing function or `impl` item with
+   `#[allow(unsafe_code)]` and a short rationale. Sites added so far:
+
+   | File | Reason |
+   | :--- | :--- |
+   | `src/tools/search.rs` `mmap_read_file` | Memory-mapped read; no mutable alias during `Mmap` lifetime. |
+   | `src/test_support.rs` `EnvLockGuard::set_var/remove_var` | `ENV_LOCK` serialises all callers. |
+   | `src/test_support.rs` `EnvRestore::drop` | `EnvRestore` cannot outlive its `EnvLockGuard`. |
+   | `src/bin/vex/tests.rs` (module level) | All `unsafe` env-var calls in this test module go through `ENV_LOCK`. |
+
+## Progressive adoption guide
+
+Adding a new lint or enabling a lint group follows this workflow:
+
+```bash
+# 1. Add the lint at "warn" level in root Cargo.toml [workspace.lints.*].
+# 2. Run lint locally to see current violations.
+make lint 2>&1 | grep "^warning"
+
+# 3. Fix violations or add targeted #[allow(...)] with a rationale comment.
+# 4. Re-run to confirm clean.
+make lint
+
+# 5. Commit the Cargo.toml lint addition + any source fixes together so the
+#    PR diff is self-contained (no separate "fix lint" commits needed).
+```
+
+### Why not add all Clippy groups at once?
+
+CI runs `cargo clippy --all-targets -- -D warnings`. Enabling a broad lint
+group (e.g. `pedantic`) as `"warn"` is equivalent to `"deny"` under `-D
+warnings`. Without first auditing the group for current violations, a single
+`"warn"` entry can block dozens of unrelated PRs.
+
+The recommended path: enable one lint at a time (or one carefully reviewed
+subset), fix violations in the same commit, and document the rationale in
+this file.
+
+### Suggested next lints
+
+These lints are commonly enabled in production Rust CLIs and are likely clean
+or low-violation in this codebase. Each should be audited with `make lint`
+before merging:
+
+```toml
+[workspace.lints.clippy]
+cloned_instead_of_copied   = "warn"   # performance: prefer Copy over Clone for trivial types
+inefficient_to_string      = "warn"   # performance: avoid unnecessary allocations
+manual_string_new          = "warn"   # style: String::new() over "".to_string()
+semicolon_if_nothing_returned = "warn" # style: explicit ; on statement-returning blocks
+```

--- a/docs/src/linting.md
+++ b/docs/src/linting.md
@@ -50,6 +50,8 @@ before CI.
    | `src/test_support.rs` `EnvLockGuard::set_var/remove_var` | `ENV_LOCK` serialises all callers. |
    | `src/test_support.rs` `EnvRestore::drop` | `EnvRestore` cannot outlive its `EnvLockGuard`. |
    | `src/bin/vex/tests.rs` (module level) | All `unsafe` env-var calls in this test module go through `ENV_LOCK`. |
+   | `tests/integration_test.rs` (module level) | All `unsafe` env-var calls go through a module-local `ENV_LOCK`. |
+   | `tests/disk_policy_tests.rs` (module level) | All `unsafe` env-var calls go through a module-local `ENV_LOCK`. |
 
 ## Progressive adoption guide
 

--- a/docs/src/msrv.md
+++ b/docs/src/msrv.md
@@ -1,0 +1,69 @@
+# MSRV Policy
+
+MSRV (Minimum Supported Rust Version) is the oldest `rustc` release this
+codebase is tested and guaranteed to compile with.
+
+## Declared value
+
+`workspace.package.rust-version` in the root `Cargo.toml` is the single
+source of truth:
+
+```toml
+[workspace.package]
+rust-version = "1.91"
+```
+
+Both member crates inherit it with `rust-version.workspace = true`. The
+`clippy.toml` `msrv` field mirrors this value so Clippy lints fire locally
+on MSRV-incompatible API usage.
+
+## Why MSRV matters
+
+Dependency upgrades can silently raise the effective MSRV of the workspace if
+a new crate version requires a newer compiler. The resolver 3 / MSRV-aware
+resolver (enabled by `resolver = "3"` in the workspace since Rust 1.84,
+defaulted for `edition = "2024"`) prefers crate versions compatible with the
+declared `rust-version` instead of always selecting the newest release.
+
+See the [Rust 2024 Edition Guide §cargo-resolver][edition-guide] for the full
+specification.
+
+[edition-guide]: https://doc.rust-lang.org/edition-guide/rust-2024/cargo-resolver.html
+
+## Bumping the MSRV
+
+1. Update `workspace.package.rust-version` in the root `Cargo.toml`.
+2. Update the `msrv` field in `clippy.toml` to match.
+3. Update the CI toolchain wherever a specific Rust version is pinned (search
+   `ci.yml`, `deny.yml`, and any other workflow files for `toolchain` or
+   `rustup toolchain install`).
+4. Note the change in the `[workspace.metadata.upgrade-notes]` `rust` entry
+   as a reminder to update CI together.
+
+Per the upgrade notes:
+> "Update package.rust-version and the CI toolchain declarations together
+> when the MSRV changes."
+
+## MSRV CI gate (future work)
+
+A dedicated MSRV CI job (`cargo +<MSRV> check --workspace`) should be added
+to `ci.yml` to catch transitive MSRV regressions before they reach main.
+This is tracked as item C-1 in the workspace-hygiene improvement backlog.
+Until that job exists, local verification is:
+
+```bash
+rustup toolchain install 1.91
+cargo +1.91 check --workspace --all-targets
+```
+
+## Resolver version
+
+The workspace uses `resolver = "3"` (the default for the 2024 edition).
+Resolver 3 activates `incompatible-rust-versions = "fallback"`, which causes
+Cargo to prefer dependency versions compatible with `rust-version` when
+selecting from a version range. This reduces the risk of a routine
+`cargo update` silently pulling in a crate version that requires a newer
+compiler than the declared MSRV.
+
+Note: resolver 3 requires `rustc` ≥ 1.84. Because the workspace `rust-version`
+is 1.91, this requirement is already satisfied.

--- a/src/bin/vex/tests.rs
+++ b/src/bin/vex/tests.rs
@@ -1,3 +1,7 @@
+// Tests in this module use std::env::set_var/remove_var (unsafe in Rust 2024
+// edition) via EnvLockGuard, which serialises access with ENV_LOCK.
+#![allow(unsafe_code)]
+
 use super::{
     Cli, Commands, CredentialsCommands, MigrateCommands, SkillsCommands,
     credentials_action_from_cli, emit_migrate_config_output, read_secret_from_env_var,

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -33,12 +33,14 @@ pub struct EnvLockGuard<'a> {
 }
 
 impl EnvLockGuard<'_> {
+    #[allow(unsafe_code)] // guarded: ENV_LOCK serialises all callers — see SAFETY comment
     pub fn set_var(&self, key: &str, value: impl AsRef<std::ffi::OsStr>) {
         let _ = &self.guard;
         // SAFETY: the guard proves exclusive ownership of ENV_LOCK.
         unsafe { std::env::set_var(key, value) }
     }
 
+    #[allow(unsafe_code)] // guarded: ENV_LOCK serialises all callers — see SAFETY comment
     pub fn remove_var(&self, key: &str) {
         let _ = &self.guard;
         // SAFETY: the guard proves exclusive ownership of ENV_LOCK.
@@ -70,6 +72,7 @@ impl<'a> EnvRestore<'a> {
 }
 
 impl Drop for EnvRestore<'_> {
+    #[allow(unsafe_code)] // lifetime-bounded: EnvRestore cannot outlive its EnvLockGuard — see SAFETY comment
     fn drop(&mut self) {
         match &self.value {
             // SAFETY: EnvRestore cannot outlive the EnvLockGuard it was created from.

--- a/src/tools/search.rs
+++ b/src/tools/search.rs
@@ -331,6 +331,7 @@ pub fn grep_search_file(path: &Path, pattern: &str) -> Vec<(u64, String)> {
 /// Faster than buffered I/O for large files because the OS page cache is
 /// reused without copying.  Returns `None` when the file cannot be opened or
 /// mapped.
+#[allow(unsafe_code)] // memory-mapped read: no mutable alias during Mmap lifetime; see SAFETY below
 pub fn mmap_read_file(path: &Path) -> Option<Mmap> {
     let file = File::open(path).ok()?;
     // SAFETY: the file is opened read-only; no mutable alias to these pages

--- a/tests/disk_policy_tests.rs
+++ b/tests/disk_policy_tests.rs
@@ -1,3 +1,7 @@
+// Tests in this file use std::env::set_var/remove_var (unsafe in Rust 2024
+// edition). A module-local ENV_LOCK serialises all callers in this binary.
+#![allow(unsafe_code)]
+
 use std::path::Path;
 
 use vexcoder::disk_policy::{

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,3 +1,7 @@
+// Tests in this file use std::env::set_var/remove_var (unsafe in Rust 2024
+// edition). A module-local ENV_LOCK serialises all callers in this binary.
+#![allow(unsafe_code)]
+
 use reqwest::header::HeaderMap;
 use vexcoder::batch_mode::{AutoApproveScope, BatchRunOpts, OutputFormat, build_batch_runtime};
 use vexcoder::config::Config;


### PR DESCRIPTION
## Summary

Three Cargo.toml consolidation items (PR-A from the workspace-hygiene backlog) and their supporting docs in one commit.

### A-1 — `[workspace.lints]` (RFC 3389, Rust 1.74)

Added `[workspace.lints.rust]` and expanded `[workspace.lints.clippy]` in the root manifest. All member crates opt in with `[lints] workspace = true` — one table, zero per-file repetition.

First rule: `unsafe_code = "warn"`. Any new `unsafe` block now fails `make lint` until it carries a `// SAFETY:` comment and `#[allow(unsafe_code)]` with a rationale. Existing sites annotated:

| File | Reason |
| :--- | :--- |
| `src/tools/search.rs::mmap_read_file` | Read-only mmap; no mutable alias during `Mmap` lifetime |
| `src/test_support.rs` `EnvLockGuard::set_var/remove_var`, `EnvRestore::drop` | Serialised by `ENV_LOCK` |
| `src/bin/vex/tests.rs` | Module-level allow for env-var test helpers (Rust 2024 edition made `set_var` unsafe) |

`clippy.toml` added at workspace root with `msrv = "1.91"` so `clippy::msrv` lints fire locally before CI.

### A-2 — `[workspace.package]` (Rust 1.64)

`version`, `rust-version`, and `license` moved to `[workspace.package]`. Both crates inherit with `.workspace = true`. Future version bumps and licence changes touch one line.

### A-3 — `resolver = "3"` (Rust 1.84)

Upgraded from `resolver = "2"`. Resolver 3 is the default for `edition = "2024"` and activates `incompatible-rust-versions = "fallback"`: routine `cargo update` passes now prefer crate versions compatible with the declared `rust-version`. Reference: [Rust 2024 Edition Guide §cargo-resolver](https://doc.rust-lang.org/edition-guide/rust-2024/cargo-resolver.html).

### Polish — upgrade-seams expansion

Added seam entries for `pulldown-cmark`, `syntect`, `ansi-to-tui`, `quick-xml`, tree-sitter family (5 crates), gix family (4 crates), and `git2`. Added coordinated-bump notes for tree-sitter and gix families.

### Docs

- `docs/src/linting.md` — workspace lint policy, unsafe annotation guide, progressive-adoption workflow.
- `docs/src/msrv.md` — MSRV value, resolver 3 rationale, bump procedure, future CI gate placeholder.
- Both wired into `docs/src/SUMMARY.md`.
- `rust.instructions.md` — added Lints section, updated unsafe guidance, expanded review checklist.

## Risks

- `unsafe_code = "warn"` will catch any new `unsafe` block missing an annotation and fail CI. This is the intended behaviour; the annotation requirement is now documented.
- `resolver = "3"` may change which dependency versions `cargo update` selects. No MSRV regressions are expected given the workspace already declares `rust-version = "1.91"` and all current dependencies satisfy it.