### PR TITLE
Implement first-stage tool delta accumulator

### DIFF
--- a/TASKS/completed/REPO-RAW-URL-MAP.md
+++ b/TASKS/completed/REPO-RAW-URL-MAP.md
@@ -5,7 +5,7 @@ Canonical raw URL index for every tracked file in this repository.
 - Branch: main
 - Base: <https://raw.githubusercontent.com/aistar-au/vexcoder/main/>
 - Source: git ls-files
-- Total tracked files: 367
+- Total tracked files: 369
 
 | # | Path | Approx. lines | Raw URL |
 | :--- | :--- | :--- | :--- |
@@ -73,6 +73,7 @@ Canonical raw URL index for every tracked file in this repository.
 | 62 | `adr/ADR-044-test-suite-scalability-and-fixture-patterns.md` | ~227 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/adr/ADR-044-test-suite-scalability-and-fixture-patterns.md> |
 | 63 | `adr/ADR-045-replay-first-task-document-and-single-writer-state.md` | ~604 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/adr/ADR-045-replay-first-task-document-and-single-writer-state.md> |
 | 64 | `adr/ADR-046-agent-peer-message-channel.md` | ~270 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/adr/ADR-046-agent-peer-message-channel.md> |
+| 65 | `adr/ADR-047-block-delta-protocol-discovery-dual-protocol-support.md` | ~126 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/adr/ADR-047-block-delta-protocol-discovery-dual-protocol-support.md> |
 | 65 | `adr/ADR-README.md` | ~104 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/adr/ADR-README.md> |
 | 66 | `adr/completed/ADR-001-tdm-agentic-manifest-strategy.md` | ~113 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/adr/completed/ADR-001-tdm-agentic-manifest-strategy.md> |
 | 67 | `adr/completed/ADR-002-lexical-path-normalization.md` | ~77 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/adr/completed/ADR-002-lexical-path-normalization.md> |
@@ -138,7 +139,8 @@ Canonical raw URL index for every tracked file in this repository.
 | 127 | `src/agents.rs` | ~733 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/src/agents.rs> |
 | 128 | `src/api.rs` | ~6 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/src/api.rs> |
 | 129 | `src/api/client/mod.rs` | ~1030 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/src/api/client/mod.rs> |
-| 130 | `src/api/client/tests.rs` | ~976 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/src/api/client/tests.rs> |
+| 130 | `src/api/client/protocol_discovery.rs` | ~218 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/src/api/client/protocol_discovery.rs> |
+| 131 | `src/api/client/tests.rs` | ~976 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/src/api/client/tests.rs> |
 | 131 | `src/api/client/tools.rs` | ~394 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/src/api/client/tools.rs> |
 | 132 | `src/api/logging.rs` | ~85 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/src/api/logging.rs> |
 | 133 | `src/api/mock_client.rs` | ~47 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/src/api/mock_client.rs> |

--- a/TASKS/completed/REPO-RAW-URL-MAP.md
+++ b/TASKS/completed/REPO-RAW-URL-MAP.md
@@ -5,7 +5,7 @@ Canonical raw URL index for every tracked file in this repository.
 - Branch: main
 - Base: <https://raw.githubusercontent.com/aistar-au/vexcoder/main/>
 - Source: git ls-files
-- Total tracked files: 366
+- Total tracked files: 367
 
 | # | Path | Approx. lines | Raw URL |
 | :--- | :--- | :--- | :--- |
@@ -372,3 +372,4 @@ Canonical raw URL index for every tracked file in this repository.
 | 361 | `clippy.toml` | ~12 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/clippy.toml> |
 | 362 | `docs/src/linting.md` | ~95 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/docs/src/linting.md> |
 | 363 | `docs/src/msrv.md` | ~70 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/docs/src/msrv.md> |
+| 364 | `src/runtime/delta_accumulator.rs` | ~384 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/src/runtime/delta_accumulator.rs> |

--- a/adr/ADR-047-block-delta-protocol-discovery-dual-protocol-support.md
+++ b/adr/ADR-047-block-delta-protocol-discovery-dual-protocol-support.md
@@ -1,0 +1,126 @@
+# ADR-047: Pivot messages/v1 to Block-Delta Default + Protocol Discovery + Dual-Protocol Support via Normalised Internal API
+
+- **Status:** Accepted
+- **Date:** 2026-04-16
+- **Deciders:** Core maintainer
+- **Related ADRs:** ADR-015 (local endpoint text-protocol default), ADR-003 (dual-protocol API auto-detection), ADR-029 (stream-parser completeness), ADR-043 (structured-output parser gates), ADR-046 (agent peer message channel)
+- **Related tasks:** PM-05 (crate boundaries and tool calls), TASKS/PM-01-conversation-compaction, ADR-034 (multi-agent parallel task execution)
+
+## Context
+
+The current `messages/v1` endpoint emits full runtime envelopes. To enable small-portion SSE parsing (only the relevant delta for a given `tx_` ID), we pivot the default to Block-Delta format while preserving dual-protocol support via one canonical accumulator and two thin mappers. This amendment removes legacy backwards compatibility requirements and introduces client-side protocol discovery, simplifying user configuration to `host:port` only.
+
+## Why Backwards Compatibility Is Not Required
+
+1. **Controlled deployment surface.** Vexcoder is a local-first tool deployed via package managers or source builds. Users update through defined channels. There is no uncontrolled third-party API surface requiring indefinite legacy support.
+
+2. **Early adopter expectations.** The user base consists of developers and agent builders who expect iterative evolution. Breaking changes are communicated via `CHANGELOG.md` and migration guides. The `tx_` ID scheme is a documented, intentional evolution.
+
+3. **Memory-first architecture benefits.** ADR-038 and ADR-045 benefit from a clean protocol boundary. Legacy `call_` IDs and full-envelope parsing create unnecessary complexity in the streaming pipeline.
+
+4. **Dual-protocol normaliser already exists.** The `CanonicalToolDeltaAccumulator` + thin mappers pattern means the server can emit either format from the same internal state. There is no runtime cost to supporting both; the question is client configuration complexity.
+
+5. **Discovery solves the real problem.** Users do not want to remember endpoint suffixes. Protocol discovery moves the complexity to a one-time probe at connection time, caching the result for the session.
+
+## Core Architectural Decisions
+
+### 1. Normalised Internal API Pattern
+
+`DeltaAccumulator` lives in `src/runtime/delta_accumulator.rs`. The API layer (`src/api/stream/`) receives a read-only `Arc<Mutex<>>` snapshot via `snapshot()`. No trait handoff; direct struct access with interior mutability. Integration with `RuntimeEnvelopeNormalizer` in `json_handoff.rs` is synchronous within the runtime event loop.
+
+### 2. Single Source of Truth for IDs
+
+`generate_tool_call_id()` is exported as a public free function from `src/runtime/json_handoff.rs` using `AtomicU32` + 4-hex entropy. The accumulator receives pre-generated `tx_` IDs only and never creates its own.
+
+### 3. Generic Protocol Terminology
+
+- **Block-Delta Format** (default for `messages/v1`): explicit `content_block_start` / `content_block_delta` (`input_json_delta` partial JSON) / `content_block_stop`.
+- **Choices-Delta Format** (for `chat/completions` compatibility): index-based `choices[].delta.tool_calls[]` with partial argument strings.
+
+### 4. Integration with Existing Peer Channel Infrastructure
+
+The `DeltaAccumulator` exposes an optional `mpsc::Sender<PeerDeltaEvent>` for in-process cross-agent delta propagation. Each `tx_` ID is scoped to a `task_id`, enabling parallel tool execution across agents without ID collision. A facade-level bridge from `PeerDeltaEvent` to `PeerMessage` for file-backed cross-process propagation is deferred per ADR-028 and the dependency-direction gate.
+
+### 5. Robust Memory Management for Multi-Agent Scenarios
+
+- Bounded per-ID delta queues (`VecDeque`, capacity 32) with oldest-entry eviction on overflow
+- TTL-based cleanup: `cleanup_finished(older_than)` and `cleanup_task(task_id)` for per-task removal
+- Memory watermark monitoring with graceful degradation: `start_tool` returns `AccumulationError::MemoryPressure` when the map is still above watermark after eviction
+- Watermark configurable via `ApiClientConfig::delta_accumulator_memory_watermark_mb` (default 256 MiB)
+
+### 6. Client-Side Protocol Discovery
+
+- Users configure only `base_url` (e.g., `http://127.0.0.1:8000`)
+- `discover_protocol()` runs a one-time probe at connection time:
+  1. Attempt `GET /v1/messages` with `Accept: application/vnd.block-delta+sse`
+  2. If `200 OK` + `text/event-stream` content-type → `ProtocolVariant::BlockDelta`
+  3. Else attempt `GET /v1/chat/completions` with `Accept: application/vnd.choices-delta+sse`
+  4. If `200 OK` + `text/event-stream` → `ProtocolVariant::ChoicesDelta`
+  5. Else return `DiscoveryError::AllProbesFailed` with probe diagnostics
+- Discovery result cached for session duration
+- Optional override: `explicit_protocol = "block_delta"` or `"choices_delta"` bypasses discovery
+- Probe timeout: 500 ms per attempt, 1.5 s total max
+
+## Resolution of Debug Points
+
+| Issue | Resolution |
+|-------|-----------|
+| Accumulator boundary | `DeltaAccumulator` in `src/runtime/delta_accumulator.rs`; API layer receives `Arc<Mutex<>>` snapshot |
+| `tx_` ID source of truth | `generate_tool_call_id()` as `pub fn` in `json_handoff.rs`; accumulator receives pre-generated IDs |
+| Thread safety | `std::sync::Mutex<HashMap<>>>`; `DashMap` rejected (single module, no cross-thread contention) |
+| SSE frame ordering | `VecDeque<String>` FIFO per tool; mappers drain in insertion order |
+| Config propagation | `ApiClientConfig` in `src/config.rs`; handlers read via `State<Config>` |
+| Error propagation | `AccumulationError::MemoryPressure`; SSE emitter maps to `{"type":"error",...}` per spec |
+| Memory lifecycle | `cleanup_finished(ttl)`, `cleanup_task(task_id)`, bounded queues, watermark enforcement |
+| ADR-003 alignment | Accept-header probe is primary; explicit override available for debugging |
+
+## Implementation Phases
+
+### Phase 0 — Foundation (merged in PR #388)
+
+- New `src/runtime/delta_accumulator.rs` with full lifecycle, peer events, memory management
+- `RuntimeEnvelopeNormalizer` wired to accumulator; `tx_` ID format; schema updated
+- `generate_tool_call_id(&AtomicU32, u16)` exported as public free function
+- `AccumulationError::MemoryPressure` added; `LocalApiTaskShared::new` constructor
+- `ApiClientConfig` struct in `src/config.rs` with `base_url`, `explicit_protocol`, `delta_accumulator_memory_watermark_mb`
+- `src/api/client/protocol_discovery.rs` with `discover_protocol()`, `ProtocolVariant`, `DiscoveryResult`, `DiscoveryError`
+- Legacy `legacy_messages_protocol_value` / `legacy_chat_protocol_value` migration functions removed
+
+### Phase 1 — Protocol Mappers
+
+- New `src/api/stream/mappers.rs` with `BlockDeltaMapper` and `ChoicesDeltaMapper` implementing `ProtocolMapper` trait
+- Mappers are thin stateless serialisers over `ToolState` snapshots
+
+### Phase 2 — Server Handler Simplification
+
+- `messages_handler` selects mapper via discovered `ProtocolVariant`; streams `content_block_start/delta/stop` from accumulator snapshot
+- No server-side protocol detection code; selection is driven by the cached discovery result
+
+### Phase 3 — Testing
+
+Seven named integration tests: `dual_protocol_parity`, `interleaved_text_and_tool_deltas`, `truncated_stream_recovery`, `malformed_partial_rejection`, `peer_channel_propagation`, `memory_watermark_enforcement`, `task_cleanup_on_completion`.
+
+### Phase 4 — Schema + Docs
+
+- `schemas/runtime_envelope_v1.json` locked to `tx_` pattern only (completed in Phase 0)
+- `docs/src/configuration.md` updated with `ApiClientConfig` table and TOML example
+
+## Consequences
+
+- Simplified user configuration: only `host:port` required
+- Faster iteration: server can evolve protocols without breaking clients
+- Cleaner codebase: removed legacy ID patterns and migration shims
+- Robust discovery: cached result, timeout protection, explicit override
+- Memory safety: bounded queues, watermark monitoring, graceful degradation
+- Peer channel integration: live delta propagation across parallel agent sessions (phase 1)
+
+## Migration Path
+
+1. Update `schemas/runtime_envelope_v1.json` to `tx_` pattern — **done (Phase 0)**
+2. Remove legacy `call_` ID generation — **done (Phase 0)**
+3. Add `protocol_discovery.rs` — **done (Phase 0)**
+4. Update `ApiClient::connect` to run discovery on first connect — phase 1
+5. Add protocol mapper tests — phase 3
+6. Update docs + CHANGELOG — phase 4
+
+This ADR supersedes all previous draft versions and is fully aligned with the repository as of 2026-04-16.

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -554,3 +554,30 @@ Token for authenticated endpoints:
 ```bash
 export VEX_MODEL_TOKEN="your-token"
 ```
+
+## API Client Configuration (ADR-047)
+
+The `[api_client]` section configures the local inference client. Only
+`base_url` is required; protocol is auto-discovered at connection time.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `base_url` | string | `""` | Server address — `scheme://host:port` only (e.g. `http://127.0.0.1:8000`). Endpoint path and protocol are discovered automatically. |
+| `explicit_protocol` | `"block_delta"` \| `"choices_delta"` | unset | Bypass discovery and use this protocol for the session. Use only for debugging or non-standard servers. |
+| `delta_accumulator_memory_watermark_mb` | integer | `256` | Memory ceiling (MiB) for in-flight streaming tool-argument deltas. When exceeded, the oldest pending entry is evicted. |
+
+Example:
+
+```toml
+[api_client]
+base_url = "http://127.0.0.1:8000"
+delta_accumulator_memory_watermark_mb = 512
+```
+
+Override protocol (debugging only):
+
+```toml
+[api_client]
+base_url = "http://127.0.0.1:8000"
+explicit_protocol = "choices_delta"
+```

--- a/schemas/runtime_envelope_v1.json
+++ b/schemas/runtime_envelope_v1.json
@@ -166,7 +166,7 @@
       "required": ["type", "id", "name", "arguments"],
       "properties": {
         "type": { "const": "tool_call" },
-        "id": { "type": "string", "pattern": "^call_[0-9]+_[0-9a-f]{4}$" },
+        "id": { "type": "string", "pattern": "^tx_[0-9]+_[0-9a-f]{4}$" },
         "name": { "$ref": "#/$defs/tool_name" },
         "arguments": { "type": "object" }
       }
@@ -177,7 +177,7 @@
       "required": ["type", "tool_call_id", "is_error", "output"],
       "properties": {
         "type": { "const": "tool_result" },
-        "tool_call_id": { "type": "string", "pattern": "^call_[0-9]+_[0-9a-f]{4}$" },
+        "tool_call_id": { "type": "string", "pattern": "^tx_[0-9]+_[0-9a-f]{4}$" },
         "tool_name": {
           "oneOf": [
             { "$ref": "#/$defs/tool_name" },

--- a/src/api/client/mod.rs
+++ b/src/api/client/mod.rs
@@ -1012,6 +1012,8 @@ fn tool_input_to_json_string(value: &Value) -> String {
     }
 }
 
+pub mod protocol_discovery;
+
 mod tools;
 pub(crate) use tools::{builtin_tool_summaries, is_readonly_tool};
 #[cfg(test)]

--- a/src/api/client/protocol_discovery.rs
+++ b/src/api/client/protocol_discovery.rs
@@ -67,11 +67,7 @@ pub enum DiscoveryError {
 ///
 /// A probe is considered successful when the server returns `200 OK` and
 /// a `Content-Type` that contains `text/event-stream`.
-async fn probe_endpoint(
-    url: &str,
-    accept_header: &str,
-    client: &reqwest::Client,
-) -> ProbeAttempt {
+async fn probe_endpoint(url: &str, accept_header: &str, client: &reqwest::Client) -> ProbeAttempt {
     let start = Instant::now();
 
     let response = client

--- a/src/api/client/protocol_discovery.rs
+++ b/src/api/client/protocol_discovery.rs
@@ -1,0 +1,218 @@
+//! Client-side protocol discovery for local inference endpoints.
+//!
+//! Users configure only `base_url` (e.g. `http://127.0.0.1:8000`).
+//! [`discover_protocol`] probes the server once at connection time and
+//! returns a cached [`ProtocolVariant`] for the session.
+//!
+//! Two probes are attempted in order:
+//! 1. `GET /v1/messages` with `Accept: application/vnd.block-delta+sse`
+//! 2. `GET /v1/chat/completions` with `Accept: application/vnd.choices-delta+sse`
+//!
+//! The first probe that returns `200 OK` with a `text/event-stream`
+//! `Content-Type` wins. If both fail, [`DiscoveryError::AllProbesFailed`]
+//! is returned with per-probe diagnostics for debugging.
+//!
+//! ADR-047 §6 — Client-Side Protocol Discovery.
+
+use crate::config::ProtocolVariant;
+use std::time::{Duration, Instant};
+
+/// Result of a successful protocol probe.
+#[derive(Debug, Clone)]
+pub struct DiscoveryResult {
+    /// The protocol variant confirmed by the probe.
+    pub protocol: ProtocolVariant,
+    /// The full endpoint URL that responded (e.g. `http://…/v1/messages`).
+    pub endpoint: String,
+    /// Round-trip latency of the winning probe in milliseconds.
+    pub probe_latency_ms: u64,
+}
+
+/// Diagnostic record for a single probe attempt.
+///
+/// Included in [`DiscoveryError::AllProbesFailed`] so callers can surface
+/// meaningful error messages without re-running the probes.
+#[derive(Debug, Clone)]
+pub struct ProbeAttempt {
+    /// The URL that was probed.
+    pub endpoint: String,
+    /// The `Accept` header sent in the probe request.
+    pub accept_header: String,
+    /// HTTP status code, or `None` if the request could not be sent.
+    pub status: Option<u16>,
+    /// Error description if the probe failed.
+    pub error: Option<String>,
+    /// Round-trip latency in milliseconds.
+    pub latency_ms: u64,
+}
+
+/// Errors returned by [`discover_protocol`].
+#[derive(Debug, thiserror::Error)]
+pub enum DiscoveryError {
+    /// Neither the Block-Delta nor the Choices-Delta probe succeeded.
+    ///
+    /// `attempts` contains one entry per probe with status and error details.
+    #[error("all protocol probes failed; see attempts for details")]
+    AllProbesFailed {
+        /// Ordered list of probe attempts (Block-Delta first, then
+        /// Choices-Delta).
+        attempts: Vec<ProbeAttempt>,
+    },
+    /// A network-level error prevented the probe from completing.
+    #[error("network error during protocol probe: {0}")]
+    NetworkError(String),
+}
+
+/// Probe a single endpoint and return a [`ProbeAttempt`].
+///
+/// A probe is considered successful when the server returns `200 OK` and
+/// a `Content-Type` that contains `text/event-stream`.
+async fn probe_endpoint(
+    url: &str,
+    accept_header: &str,
+    client: &reqwest::Client,
+) -> ProbeAttempt {
+    let start = Instant::now();
+
+    let response = client
+        .get(url)
+        .header("Accept", accept_header)
+        .header("Accept-Encoding", "identity")
+        .timeout(Duration::from_millis(500))
+        .send()
+        .await;
+
+    let latency_ms = start.elapsed().as_millis() as u64;
+
+    match response {
+        Ok(resp) => {
+            let status = resp.status().as_u16();
+            if status == 200 {
+                let is_sse = resp
+                    .headers()
+                    .get("content-type")
+                    .and_then(|v| v.to_str().ok())
+                    .map(|ct| ct.contains("text/event-stream"))
+                    .unwrap_or(false);
+
+                if is_sse {
+                    return ProbeAttempt {
+                        endpoint: url.to_string(),
+                        accept_header: accept_header.to_string(),
+                        status: Some(status),
+                        error: None,
+                        latency_ms,
+                    };
+                }
+            }
+
+            ProbeAttempt {
+                endpoint: url.to_string(),
+                accept_header: accept_header.to_string(),
+                status: Some(status),
+                error: Some("server did not return text/event-stream".to_string()),
+                latency_ms,
+            }
+        }
+        Err(e) => ProbeAttempt {
+            endpoint: url.to_string(),
+            accept_header: accept_header.to_string(),
+            status: None,
+            error: Some(e.to_string()),
+            latency_ms,
+        },
+    }
+}
+
+/// Discover the streaming protocol variant supported by a local inference
+/// server at `base_url`.
+///
+/// Probes are performed in order: Block-Delta first, then Choices-Delta.
+/// The first successful probe terminates the sequence.
+///
+/// # Errors
+///
+/// Returns [`DiscoveryError::AllProbesFailed`] with per-probe diagnostics
+/// when neither endpoint responds as expected.
+pub async fn discover_protocol(
+    base_url: &str,
+    client: &reqwest::Client,
+) -> Result<DiscoveryResult, DiscoveryError> {
+    let base = base_url.trim_end_matches('/');
+    let mut attempts = Vec::with_capacity(2);
+
+    let block_probe = probe_endpoint(
+        &format!("{base}/v1/messages"),
+        "application/vnd.block-delta+sse",
+        client,
+    )
+    .await;
+
+    let block_ok = block_probe.status == Some(200) && block_probe.error.is_none();
+    let block_endpoint = block_probe.endpoint.clone();
+    let block_latency = block_probe.latency_ms;
+    attempts.push(block_probe);
+
+    if block_ok {
+        return Ok(DiscoveryResult {
+            protocol: ProtocolVariant::BlockDelta,
+            endpoint: block_endpoint,
+            probe_latency_ms: block_latency,
+        });
+    }
+
+    let choices_probe = probe_endpoint(
+        &format!("{base}/v1/chat/completions"),
+        "application/vnd.choices-delta+sse",
+        client,
+    )
+    .await;
+
+    let choices_ok = choices_probe.status == Some(200) && choices_probe.error.is_none();
+    let choices_endpoint = choices_probe.endpoint.clone();
+    let choices_latency = choices_probe.latency_ms;
+    attempts.push(choices_probe);
+
+    if choices_ok {
+        return Ok(DiscoveryResult {
+            protocol: ProtocolVariant::ChoicesDelta,
+            endpoint: choices_endpoint,
+            probe_latency_ms: choices_latency,
+        });
+    }
+
+    Err(DiscoveryError::AllProbesFailed { attempts })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn protocol_variant_eq() {
+        assert_eq!(ProtocolVariant::BlockDelta, ProtocolVariant::BlockDelta);
+        assert_ne!(ProtocolVariant::BlockDelta, ProtocolVariant::ChoicesDelta);
+    }
+
+    #[test]
+    fn discovery_error_display() {
+        let err = DiscoveryError::AllProbesFailed { attempts: vec![] };
+        assert!(err.to_string().contains("all protocol probes failed"));
+
+        let err = DiscoveryError::NetworkError("connection refused".to_string());
+        assert!(err.to_string().contains("connection refused"));
+    }
+
+    #[test]
+    fn probe_attempt_fields() {
+        let attempt = ProbeAttempt {
+            endpoint: "http://127.0.0.1:8000/v1/messages".to_string(),
+            accept_header: "application/vnd.block-delta+sse".to_string(),
+            status: Some(200),
+            error: None,
+            latency_ms: 12,
+        };
+        assert_eq!(attempt.status, Some(200));
+        assert!(attempt.error.is_none());
+    }
+}

--- a/src/api/client/tests.rs
+++ b/src/api/client/tests.rs
@@ -56,6 +56,7 @@ fn test_local_messages_endpoint_keeps_messages_v1_wire_protocol() {
         api: crate::config::ApiConfig::default(),
         hooks: Vec::new(),
         auto_memory: crate::config::AutoMemoryConfig::default(),
+        api_client: crate::config::ApiClientConfig::default(),
     };
 
     let client = ApiClient::new(&config).expect("client should build");
@@ -92,6 +93,7 @@ fn test_local_bare_v1_endpoint_resolves_messages_v1_url() {
         api: crate::config::ApiConfig::default(),
         hooks: Vec::new(),
         auto_memory: crate::config::AutoMemoryConfig::default(),
+        api_client: crate::config::ApiClientConfig::default(),
     };
 
     let client = ApiClient::new(&config).expect("client should build");
@@ -128,6 +130,7 @@ fn test_local_bare_v1_endpoint_resolves_chat_compat_url() {
         api: crate::config::ApiConfig::default(),
         hooks: Vec::new(),
         auto_memory: crate::config::AutoMemoryConfig::default(),
+        api_client: crate::config::ApiClientConfig::default(),
     };
 
     let client = ApiClient::new(&config).expect("client should build");
@@ -165,6 +168,7 @@ fn test_remote_messages_endpoint_preserves_messages_wire_protocol() {
         api: crate::config::ApiConfig::default(),
         hooks: Vec::new(),
         auto_memory: crate::config::AutoMemoryConfig::default(),
+        api_client: crate::config::ApiClientConfig::default(),
     };
 
     let client = ApiClient::new(&config).expect("client should build");
@@ -201,6 +205,7 @@ fn test_https_localhost_messages_endpoint_preserves_full_request_url() {
         api: crate::config::ApiConfig::default(),
         hooks: Vec::new(),
         auto_memory: crate::config::AutoMemoryConfig::default(),
+        api_client: crate::config::ApiClientConfig::default(),
     };
 
     let client = ApiClient::new(&config).expect("client should build");
@@ -341,6 +346,7 @@ fn test_structured_tool_protocol_env_off_disables_protocol() {
         api: crate::config::ApiConfig::default(),
         hooks: Vec::new(),
         auto_memory: crate::config::AutoMemoryConfig::default(),
+        api_client: crate::config::ApiClientConfig::default(),
     };
 
     let client = ApiClient::new(&config).expect("client should build");
@@ -378,6 +384,7 @@ fn test_structured_tool_protocol_defaults_off_for_local_endpoint() {
         api: crate::config::ApiConfig::default(),
         hooks: Vec::new(),
         auto_memory: crate::config::AutoMemoryConfig::default(),
+        api_client: crate::config::ApiClientConfig::default(),
     };
 
     let client = ApiClient::new(&config).expect("client should build");
@@ -412,6 +419,7 @@ fn test_structured_tool_protocol_defaults_on_for_remote_endpoint() {
         api: crate::config::ApiConfig::default(),
         hooks: Vec::new(),
         auto_memory: crate::config::AutoMemoryConfig::default(),
+        api_client: crate::config::ApiClientConfig::default(),
     };
 
     let client = ApiClient::new(&config).expect("client should build");

--- a/src/app/tests/memory.rs
+++ b/src/app/tests/memory.rs
@@ -259,6 +259,7 @@ fn test_memory_injection_over_budget_emits_startup_warning() {
         api: crate::config::ApiConfig::default(),
         hooks: Vec::new(),
         auto_memory: crate::config::AutoMemoryConfig::default(),
+        api_client: crate::config::ApiClientConfig::default(),
     };
 
     let (runtime, _ctx) = build_runtime(config).expect("runtime should build");

--- a/src/app/tests/session/runtime.rs
+++ b/src/app/tests/session/runtime.rs
@@ -42,6 +42,7 @@ fn test_build_runtime_with_resume_restores_task() {
         api: crate::config::ApiConfig::default(),
         hooks: Vec::new(),
         auto_memory: crate::config::AutoMemoryConfig::default(),
+        api_client: crate::config::ApiClientConfig::default(),
     };
 
     let (runtime, _ctx) =

--- a/src/batch_mode/tests.rs
+++ b/src/batch_mode/tests.rs
@@ -139,6 +139,7 @@ async fn test_batch_mode_memory_clear_with_auto_approve_clears_notes() {
         api: crate::config::ApiConfig::default(),
         hooks: Vec::new(),
         auto_memory: crate::config::AutoMemoryConfig::default(),
+        api_client: crate::config::ApiClientConfig::default(),
     };
 
     let result = run_batch(
@@ -428,6 +429,7 @@ async fn test_build_batch_runtime_injects_memory_notes_into_system_prompt() {
         api: crate::config::ApiConfig::default(),
         hooks: Vec::new(),
         auto_memory: crate::config::AutoMemoryConfig::default(),
+        api_client: crate::config::ApiClientConfig::default(),
     };
 
     let (_runtime, ctx, _task_id) = build_batch_runtime(
@@ -478,6 +480,7 @@ async fn test_build_batch_runtime_injects_project_instructions_into_system_promp
         api: crate::config::ApiConfig::default(),
         hooks: Vec::new(),
         auto_memory: crate::config::AutoMemoryConfig::default(),
+        api_client: crate::config::ApiClientConfig::default(),
     };
 
     let (_runtime, ctx, _task_id) = build_batch_runtime(
@@ -551,6 +554,7 @@ fn test_build_batch_runtime_uses_resumed_task_id() {
         api: crate::config::ApiConfig::default(),
         hooks: Vec::new(),
         auto_memory: crate::config::AutoMemoryConfig::default(),
+        api_client: crate::config::ApiClientConfig::default(),
     };
     let resume_state = TaskState::new("task-batch-resume".to_string());
 

--- a/src/bin/vex/tests.rs
+++ b/src/bin/vex/tests.rs
@@ -100,18 +100,6 @@ fn init_pr_summary_repo() -> tempfile::TempDir {
 }
 
 #[test]
-fn test_migrate_config_maps_legacy_messages_value() {
-    let out = vexcoder::config::migrate_config_from_env(&[(
-        "VEX_API_PROTOCOL",
-        concat!("anth", "ropic"),
-    )]);
-    assert!(
-        out.contains("model_protocol = \"messages-v1\""),
-        "migrate output: {out}"
-    );
-}
-
-#[test]
 fn test_migrate_config_maps_structured_tool_protocol_on() {
     let out = vexcoder::config::migrate_config_from_env(&[("VEX_STRUCTURED_TOOL_PROTOCOL", "on")]);
     assert!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -476,6 +476,7 @@ impl Config {
             undo: UndoConfig::default(),
             search: SearchConfig::default(),
             auto_memory: AutoMemoryConfig::default(),
+            api_client: ApiClientConfig::default(),
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,7 +21,6 @@ mod tests;
 #[cfg(test)]
 use self::load::{
     default_model_backend, default_tool_call_mode, infer_model_protocol,
-    legacy_chat_protocol_value, legacy_messages_protocol_value,
     model_token_from_env_or_keyring_with, parse_model_headers_json, read_env_layer,
     user_config_path,
 };
@@ -218,6 +217,73 @@ pub(crate) struct AutoMemoryConfigLayer {
     pub(crate) max_notes_per_turn: Option<usize>,
 }
 
+/// Wire protocol variant for streaming tool-call deltas.
+///
+/// Stored in [`ApiClientConfig::explicit_protocol`] as an optional override
+/// for client-side protocol discovery (ADR-047 §6).  When `None`, the client
+/// probes the server at connection time via
+/// [`crate::api::client::protocol_discovery::discover_protocol`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ProtocolVariant {
+    /// `messages/v1` Block-Delta format (default).
+    ///
+    /// Emits `content_block_start` / `content_block_delta` (`input_json_delta`)
+    /// / `content_block_stop` events.  Preferred for all new local-inference
+    /// deployments.
+    #[default]
+    BlockDelta,
+    /// `chat/completions` Choices-Delta format.
+    ///
+    /// Emits `choices[].delta.tool_calls[]` with partial `arguments` strings.
+    /// Used when the server exposes only the chat-compat completions endpoint.
+    ChoicesDelta,
+}
+
+/// Client-side configuration for the local inference API.
+///
+/// Simplifies user configuration to `base_url` only; protocol is discovered
+/// automatically unless `explicit_protocol` is set (ADR-047 Phase 0).
+///
+/// Example TOML fragment:
+/// ```toml
+/// [api_client]
+/// base_url = "http://127.0.0.1:8000"
+/// delta_accumulator_memory_watermark_mb = 512
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ApiClientConfig {
+    /// Server address. Protocol and endpoint path are discovered automatically.
+    /// Only `scheme://host:port` is required (e.g. `http://127.0.0.1:8000`).
+    pub base_url: String,
+    /// Optional explicit protocol override. When set, protocol discovery is
+    /// skipped and this variant is used for the entire session.
+    pub explicit_protocol: Option<ProtocolVariant>,
+    /// Memory ceiling for the delta accumulator in mebibytes (default: 256).
+    /// When the in-flight tool-delta map exceeds this threshold, the oldest
+    /// pending entry is evicted to stay within the bound.
+    pub delta_accumulator_memory_watermark_mb: usize,
+}
+
+impl Default for ApiClientConfig {
+    fn default() -> Self {
+        Self {
+            base_url: String::new(),
+            explicit_protocol: None,
+            delta_accumulator_memory_watermark_mb: 256,
+        }
+    }
+}
+
+impl ApiClientConfig {
+    /// Returns the watermark in bytes for use with [`DeltaAccumulator`](crate::runtime::delta_accumulator::DeltaAccumulator).
+    pub fn delta_accumulator_memory_watermark_bytes(&self) -> usize {
+        self.delta_accumulator_memory_watermark_mb
+            .saturating_mul(1024 * 1024)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     pub model_token: Option<String>,
@@ -252,6 +318,11 @@ pub struct Config {
     pub undo: UndoConfig,
     pub search: SearchConfig,
     pub auto_memory: AutoMemoryConfig,
+    /// Client-side API configuration: `base_url`, optional protocol override,
+    /// and delta-accumulator memory watermark.  Discovery runs automatically
+    /// when `explicit_protocol` is not set (ADR-047 Phase 0).
+    #[serde(default)]
+    pub api_client: ApiClientConfig,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -298,6 +369,7 @@ struct ConfigLayer {
     undo: Option<UndoConfigLayer>,
     search: Option<SearchConfigLayer>,
     auto_memory: Option<AutoMemoryConfigLayer>,
+    api_client: Option<ApiClientConfig>,
 }
 
 #[derive(Debug, Deserialize, Default)]

--- a/src/config/load/merge.rs
+++ b/src/config/load/merge.rs
@@ -33,6 +33,7 @@ pub(super) fn apply_over(base: ConfigLayer, over: ConfigLayer) -> ConfigLayer {
         undo: apply_undo_over(base.undo, over.undo),
         search: apply_search_over(base.search, over.search),
         auto_memory: apply_auto_memory_over(base.auto_memory, over.auto_memory),
+        api_client: over.api_client.or(base.api_client),
     }
 }
 

--- a/src/config/load/mod.rs
+++ b/src/config/load/mod.rs
@@ -19,9 +19,7 @@ use paths::*;
 // Re-exports for parent module (config.rs test-only imports)
 pub(super) use parse::infer_model_protocol;
 #[cfg(test)]
-pub(super) use parse::{
-    legacy_chat_protocol_value, legacy_messages_protocol_value, parse_model_headers_json,
-};
+pub(super) use parse::parse_model_headers_json;
 pub(super) use paths::user_config_path;
 
 pub(super) fn load() -> Result<Config> {

--- a/src/config/load/mod.rs
+++ b/src/config/load/mod.rs
@@ -460,6 +460,7 @@ pub(super) fn read_env_layer() -> Result<(ConfigLayer, Option<String>)> {
         http_hooks: None,
         search: None,
         auto_memory: None,
+        api_client: None,
     };
 
     Ok((layer, env_token))

--- a/src/config/load/parse.rs
+++ b/src/config/load/parse.rs
@@ -83,10 +83,3 @@ pub(crate) fn parse_model_headers_json() -> Result<HeaderMap> {
     Ok(headers)
 }
 
-pub(crate) fn legacy_messages_protocol_value() -> &'static str {
-    concat!("anth", "ropic")
-}
-
-pub(crate) fn legacy_chat_protocol_value() -> &'static str {
-    concat!("open", "ai")
-}

--- a/src/config/load/parse.rs
+++ b/src/config/load/parse.rs
@@ -82,4 +82,3 @@ pub(crate) fn parse_model_headers_json() -> Result<HeaderMap> {
     }
     Ok(headers)
 }
-

--- a/src/config/load/resolve.rs
+++ b/src/config/load/resolve.rs
@@ -181,6 +181,7 @@ pub(super) fn resolve_config(
         undo: resolve_undo_config(merged.undo),
         search: resolve_search_config(merged.search),
         auto_memory: resolve_auto_memory_config(merged.auto_memory),
+        api_client: merged.api_client.unwrap_or_default(),
     })
 }
 
@@ -434,19 +435,10 @@ pub(crate) fn migrate_config_from_env(envs: &[(&str, &str)]) -> String {
     lines
         .push("# apply this fragment to .vex/config.toml or ~/.config/vex/config.toml".to_string());
 
-    if let Some(value) = get("VEX_API_PROTOCOL") {
-        match value.trim().to_ascii_lowercase().as_str() {
-            value if value == legacy_messages_protocol_value() => {
-                lines.push(r#"model_protocol = "messages-v1""#.to_string())
-            }
-            value if value == legacy_chat_protocol_value() => {
-                lines.push(r#"model_protocol = "chat-compat""#.to_string())
-            }
-            other => lines.push(format!(
-                "# WARNING: unknown VEX_API_PROTOCOL value {other:?}; no mapping generated"
-            )),
-        }
-    }
+    // VEX_API_PROTOCOL (legacy env var) migration removed in ADR-047 Phase 0.
+    // The env var previously accepted short string aliases for "messages-v1"
+    // and "chat-compat". Protocol is now discovered automatically at connection
+    // time or set via `api_client.explicit_protocol` in config.
 
     if let Some(value) = get("VEX_STRUCTURED_TOOL_PROTOCOL") {
         match value.trim().to_ascii_lowercase().as_str() {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -517,24 +517,6 @@ fn test_model_profile_loaded_from_layered_config() {
 }
 
 #[test]
-fn test_migrate_maps_legacy_messages_protocol() {
-    let out = super::migrate_config_from_env(&[(
-        "VEX_API_PROTOCOL",
-        super::legacy_messages_protocol_value(),
-    )]);
-    assert!(out.contains("model_protocol = \"messages-v1\""), "{out}");
-}
-
-#[test]
-fn test_migrate_maps_legacy_chat_protocol() {
-    let out = super::migrate_config_from_env(&[(
-        "VEX_API_PROTOCOL",
-        super::legacy_chat_protocol_value(),
-    )]);
-    assert!(out.contains("model_protocol = \"chat-compat\""), "{out}");
-}
-
-#[test]
 fn test_migrate_maps_structured_tool_protocol_on() {
     let out = super::migrate_config_from_env(&[("VEX_STRUCTURED_TOOL_PROTOCOL", "on")]);
     assert!(out.contains("tool_call_mode = \"structured\""), "{out}");

--- a/src/local_api.rs
+++ b/src/local_api.rs
@@ -13,6 +13,9 @@ use crate::app::FacadeSessionTaskRollup;
 use crate::config::Config;
 use crate::runtime::UiUpdate;
 use crate::runtime::context::RuntimeContext;
+use crate::runtime::delta_accumulator::{
+    DEFAULT_DELTA_ACCUMULATOR_MEMORY_WATERMARK_BYTES, DeltaAccumulator,
+};
 use crate::runtime::frontend::{FrontendAdapter, UserInputEvent};
 use crate::runtime::json_handoff::{
     RuntimeEnvelope, RuntimeEnvelopeNormalizer, RuntimeEvent, TurnEndContext,
@@ -52,6 +55,32 @@ pub(crate) struct LocalApiTaskShared {
     pub interrupted: bool,
     pub active_command_sessions: BTreeSet<u64>,
     pub turn_completion_pending: bool,
+}
+
+impl LocalApiTaskShared {
+    pub fn new(
+        task_id: String,
+        envelope_tx: mpsc::UnboundedSender<String>,
+        quit: Arc<AtomicBool>,
+    ) -> Self {
+        let delta_accumulator = Arc::new(DeltaAccumulator::new(
+            DEFAULT_DELTA_ACCUMULATOR_MEMORY_WATERMARK_BYTES,
+        ));
+
+        Self {
+            normalizer: RuntimeEnvelopeNormalizer::new_with_delta_accumulator(
+                task_id,
+                delta_accumulator,
+            ),
+            envelope_tx,
+            pending_approval: None,
+            quit,
+            turn_in_progress: false,
+            interrupted: false,
+            active_command_sessions: BTreeSet::new(),
+            turn_completion_pending: false,
+        }
+    }
 }
 
 pub(crate) struct PendingApproval {

--- a/src/local_api.rs
+++ b/src/local_api.rs
@@ -13,9 +13,7 @@ use crate::app::FacadeSessionTaskRollup;
 use crate::config::Config;
 use crate::runtime::UiUpdate;
 use crate::runtime::context::RuntimeContext;
-use crate::runtime::delta_accumulator::{
-    DEFAULT_DELTA_ACCUMULATOR_MEMORY_WATERMARK_BYTES, DeltaAccumulator,
-};
+use crate::runtime::delta_accumulator::DeltaAccumulator;
 use crate::runtime::frontend::{FrontendAdapter, UserInputEvent};
 use crate::runtime::json_handoff::{
     RuntimeEnvelope, RuntimeEnvelopeNormalizer, RuntimeEvent, TurnEndContext,
@@ -58,14 +56,20 @@ pub(crate) struct LocalApiTaskShared {
 }
 
 impl LocalApiTaskShared {
+    /// Constructs a new `LocalApiTaskShared` with a fresh delta accumulator.
+    ///
+    /// `memory_watermark_bytes` should be read from
+    /// [`crate::config::ApiClientConfig::delta_accumulator_memory_watermark_bytes`]
+    /// by the server handler.  Pass
+    /// `crate::runtime::delta_accumulator::DEFAULT_DELTA_ACCUMULATOR_MEMORY_WATERMARK_BYTES`
+    /// from paths that do not have access to the full config.
     pub fn new(
         task_id: String,
         envelope_tx: mpsc::UnboundedSender<String>,
         quit: Arc<AtomicBool>,
+        memory_watermark_bytes: usize,
     ) -> Self {
-        let delta_accumulator = Arc::new(DeltaAccumulator::new(
-            DEFAULT_DELTA_ACCUMULATOR_MEMORY_WATERMARK_BYTES,
-        ));
+        let delta_accumulator = Arc::new(DeltaAccumulator::new(memory_watermark_bytes));
 
         Self {
             normalizer: RuntimeEnvelopeNormalizer::new_with_delta_accumulator(

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -4,6 +4,7 @@ pub mod command;
 pub mod context;
 pub mod context_assembler;
 pub mod context_cache;
+pub mod delta_accumulator;
 pub mod edit_loop;
 pub mod frontend;
 pub mod git_parse;

--- a/src/runtime/delta_accumulator.rs
+++ b/src/runtime/delta_accumulator.rs
@@ -73,6 +73,13 @@ impl DeltaAccumulator {
 
             if self.estimate_memory_usage(&map) > self.memory_watermark_bytes {
                 self.drop_oldest_pending(&mut map);
+                // Second check: if still over watermark after eviction (e.g. all
+                // entries are finished and nothing was removed), surface the error
+                // so callers can observe memory pressure rather than silently losing
+                // the new entry.
+                if self.estimate_memory_usage(&map) > self.memory_watermark_bytes {
+                    return Err(AccumulationError::MemoryPressure);
+                }
             }
 
             map.insert(
@@ -230,6 +237,13 @@ pub enum AccumulationError {
     DuplicateId(ToolCallId),
     #[error("malformed partial json")]
     MalformedPartial,
+    /// Returned when the memory watermark is exceeded and no eligible pending
+    /// entry can be evicted (for example, all in-flight entries are already
+    /// finished). Callers should treat this as a best-effort degradation signal;
+    /// the accumulator will not panic and the caller may continue without the
+    /// new entry.
+    #[error("memory watermark exceeded")]
+    MemoryPressure,
 }
 
 fn is_valid_json_prefix(existing: &str, incoming: &str) -> bool {
@@ -380,5 +394,28 @@ mod tests {
         let map = snapshot.lock().unwrap_or_else(|e| e.into_inner());
         assert!(!map.contains_key("tx_1_aaaa"));
         assert!(map.contains_key("tx_2_bbbb"));
+    }
+
+    #[test]
+    fn memory_pressure_returned_when_no_pending_entry_can_be_evicted() {
+        // A 1-byte watermark ensures any single entry exceeds the limit.
+        let accumulator = DeltaAccumulator::new(1);
+
+        // Insert and immediately finish one entry so it becomes ineligible for
+        // eviction (drop_oldest_pending skips finished entries).
+        let id = "tx_1_aaaa".to_string();
+        accumulator
+            .start_tool(id.clone(), "task-wp".to_string(), "read_file".to_string())
+            .unwrap();
+        accumulator.finish(&id);
+
+        // A second start must observe MemoryPressure: the watermark is still
+        // exceeded after the eviction pass because no pending entry exists.
+        let result = accumulator.start_tool(
+            "tx_2_bbbb".to_string(),
+            "task-wp".to_string(),
+            "apply_patch".to_string(),
+        );
+        assert_eq!(result.unwrap_err(), AccumulationError::MemoryPressure);
     }
 }

--- a/src/runtime/delta_accumulator.rs
+++ b/src/runtime/delta_accumulator.rs
@@ -1,0 +1,384 @@
+use crate::runtime::json_handoff::ToolCallId;
+use crate::runtime::tokio::sync::mpsc;
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+pub const DEFAULT_DELTA_ACCUMULATOR_MEMORY_WATERMARK_BYTES: usize = 256 * 1024 * 1024;
+const MAX_STORED_PARTIAL_BYTES: usize = 65_536;
+const MAX_TOOL_DELTA_QUEUE_DEPTH: usize = 32;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PeerDeltaEvent {
+    ToolStart {
+        tool_call_id: ToolCallId,
+        task_id: String,
+        name: String,
+    },
+    ToolDelta {
+        tool_call_id: ToolCallId,
+        task_id: String,
+        partial_json: String,
+    },
+    ToolFinish {
+        tool_call_id: ToolCallId,
+        task_id: String,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct ToolState {
+    pub id: ToolCallId,
+    pub task_id: String,
+    pub name: String,
+    pub partial_args: String,
+    pub finished: bool,
+    pub delta_queue: VecDeque<String>,
+    pub last_activity: Instant,
+}
+
+pub struct DeltaAccumulator {
+    state: Arc<Mutex<HashMap<ToolCallId, ToolState>>>,
+    peer_events: Option<mpsc::Sender<PeerDeltaEvent>>,
+    memory_watermark_bytes: usize,
+}
+
+impl DeltaAccumulator {
+    pub fn new(memory_watermark_bytes: usize) -> Self {
+        Self::new_with_peer_events(memory_watermark_bytes, None)
+    }
+
+    pub fn new_with_peer_events(
+        memory_watermark_bytes: usize,
+        peer_events: Option<mpsc::Sender<PeerDeltaEvent>>,
+    ) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(HashMap::new())),
+            peer_events,
+            memory_watermark_bytes,
+        }
+    }
+
+    pub fn start_tool(
+        &self,
+        id: ToolCallId,
+        task_id: String,
+        name: String,
+    ) -> Result<(), AccumulationError> {
+        {
+            let mut map = self.state.lock().unwrap_or_else(|e| e.into_inner());
+            if map.contains_key(&id) {
+                return Err(AccumulationError::DuplicateId(id));
+            }
+
+            if self.estimate_memory_usage(&map) > self.memory_watermark_bytes {
+                self.drop_oldest_pending(&mut map);
+            }
+
+            map.insert(
+                id.clone(),
+                ToolState {
+                    id: id.clone(),
+                    task_id: task_id.clone(),
+                    name: name.clone(),
+                    partial_args: String::new(),
+                    finished: false,
+                    delta_queue: VecDeque::new(),
+                    last_activity: Instant::now(),
+                },
+            );
+        }
+
+        self.publish_event(PeerDeltaEvent::ToolStart {
+            tool_call_id: id,
+            task_id,
+            name,
+        });
+
+        Ok(())
+    }
+
+    pub fn accumulate(&self, id: &ToolCallId, partial_json: &str) -> Result<(), AccumulationError> {
+        let task_id = {
+            let mut map = self.state.lock().unwrap_or_else(|e| e.into_inner());
+
+            {
+                let entry = map
+                    .get_mut(id)
+                    .ok_or_else(|| AccumulationError::UnknownId(id.clone()))?;
+
+                if !is_valid_json_prefix(&entry.partial_args, partial_json) {
+                    return Err(AccumulationError::MalformedPartial);
+                }
+
+                entry.last_activity = Instant::now();
+                if entry.delta_queue.len() == MAX_TOOL_DELTA_QUEUE_DEPTH {
+                    entry.delta_queue.pop_front();
+                }
+                entry.delta_queue.push_back(partial_json.to_string());
+
+                for ch in partial_json.chars() {
+                    let next_len = entry.partial_args.len().saturating_add(ch.len_utf8());
+                    if next_len > MAX_STORED_PARTIAL_BYTES {
+                        break;
+                    }
+                    entry.partial_args.push(ch);
+                }
+            }
+
+            if self.estimate_memory_usage(&map) > self.memory_watermark_bytes {
+                self.drop_oldest_pending(&mut map);
+            }
+
+            map.get(id)
+                .map(|state| state.task_id.clone())
+                .unwrap_or_default()
+        };
+
+        self.publish_event(PeerDeltaEvent::ToolDelta {
+            tool_call_id: id.clone(),
+            task_id,
+            partial_json: partial_json.to_string(),
+        });
+
+        Ok(())
+    }
+
+    pub fn finish(&self, id: &ToolCallId) {
+        let task_id = {
+            let mut map = self.state.lock().unwrap_or_else(|e| e.into_inner());
+            map.get_mut(id).map(|entry| {
+                entry.finished = true;
+                entry.last_activity = Instant::now();
+                entry.task_id.clone()
+            })
+        };
+
+        if let Some(task_id) = task_id {
+            self.publish_event(PeerDeltaEvent::ToolFinish {
+                tool_call_id: id.clone(),
+                task_id,
+            });
+        }
+    }
+
+    pub fn snapshot(&self) -> Arc<Mutex<HashMap<ToolCallId, ToolState>>> {
+        Arc::clone(&self.state)
+    }
+
+    pub fn cleanup_finished(&self, older_than: Duration) -> usize {
+        let mut map = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let cutoff = Instant::now() - older_than;
+        let before = map.len();
+        map.retain(|_, state| !state.finished || state.last_activity > cutoff);
+        before.saturating_sub(map.len())
+    }
+
+    pub fn cleanup_task(&self, task_id: &str) -> usize {
+        let mut map = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let before = map.len();
+        map.retain(|_, state| state.task_id != task_id);
+        before.saturating_sub(map.len())
+    }
+
+    fn estimate_memory_usage(&self, map: &HashMap<ToolCallId, ToolState>) -> usize {
+        map.iter()
+            .map(|(id, state)| {
+                id.len()
+                    + state.task_id.len()
+                    + state.name.len()
+                    + state.partial_args.len()
+                    + state
+                        .delta_queue
+                        .iter()
+                        .map(|delta| delta.len())
+                        .sum::<usize>()
+                    + 128
+            })
+            .sum()
+    }
+
+    fn drop_oldest_pending(&self, map: &mut HashMap<ToolCallId, ToolState>) {
+        let Some(oldest_id) = map
+            .iter()
+            .filter(|(_, state)| !state.finished)
+            .min_by_key(|(_, state)| state.last_activity)
+            .map(|(id, _)| id.clone())
+        else {
+            return;
+        };
+
+        map.remove(&oldest_id);
+    }
+
+    fn publish_event(&self, event: PeerDeltaEvent) {
+        let Some(peer_events) = &self.peer_events else {
+            return;
+        };
+
+        if let Err(error) = peer_events.try_send(event) {
+            tracing::debug!(%error, "dropped delta accumulator peer event");
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum AccumulationError {
+    #[error("unknown tool call id: {0}")]
+    UnknownId(ToolCallId),
+    #[error("duplicate tool call id: {0}")]
+    DuplicateId(ToolCallId),
+    #[error("malformed partial json")]
+    MalformedPartial,
+}
+
+fn is_valid_json_prefix(existing: &str, incoming: &str) -> bool {
+    let mut brace_depth = 0i32;
+    let mut bracket_depth = 0i32;
+    let mut in_string = false;
+    let mut escaped = false;
+
+    for ch in existing.chars().chain(incoming.chars()) {
+        if in_string {
+            if escaped {
+                escaped = false;
+                continue;
+            }
+
+            match ch {
+                '\\' => escaped = true,
+                '"' => in_string = false,
+                _ => {}
+            }
+            continue;
+        }
+
+        match ch {
+            '"' => in_string = true,
+            '{' => brace_depth += 1,
+            '}' => {
+                brace_depth -= 1;
+                if brace_depth < 0 {
+                    return false;
+                }
+            }
+            '[' => bracket_depth += 1,
+            ']' => {
+                bracket_depth -= 1;
+                if bracket_depth < 0 {
+                    return false;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn start_accumulate_finish_tracks_state_and_peer_events() {
+        let (tx, mut rx) = mpsc::channel(8);
+        let accumulator = DeltaAccumulator::new_with_peer_events(1_024, Some(tx));
+        let tool_call_id = "tx_1_abcd".to_string();
+
+        accumulator
+            .start_tool(
+                tool_call_id.clone(),
+                "task-1".to_string(),
+                "read_file".to_string(),
+            )
+            .unwrap();
+        accumulator
+            .accumulate(&tool_call_id, r#"{"path":"src/"#)
+            .unwrap();
+        accumulator
+            .accumulate(&tool_call_id, r#"main.rs"}"#)
+            .unwrap();
+        accumulator.finish(&tool_call_id);
+
+        let snapshot = accumulator.snapshot();
+        let map = snapshot.lock().unwrap_or_else(|e| e.into_inner());
+        let state = map.get(&tool_call_id).expect("tool state present");
+        assert_eq!(state.partial_args, r#"{"path":"src/main.rs"}"#);
+        assert_eq!(state.delta_queue.len(), 2);
+        assert!(state.finished);
+
+        assert_eq!(
+            rx.blocking_recv().unwrap(),
+            PeerDeltaEvent::ToolStart {
+                tool_call_id: tool_call_id.clone(),
+                task_id: "task-1".to_string(),
+                name: "read_file".to_string(),
+            }
+        );
+        assert_eq!(
+            rx.blocking_recv().unwrap(),
+            PeerDeltaEvent::ToolDelta {
+                tool_call_id: tool_call_id.clone(),
+                task_id: "task-1".to_string(),
+                partial_json: r#"{"path":"src/"#.to_string(),
+            }
+        );
+        assert_eq!(
+            rx.blocking_recv().unwrap(),
+            PeerDeltaEvent::ToolDelta {
+                tool_call_id: tool_call_id.clone(),
+                task_id: "task-1".to_string(),
+                partial_json: r#"main.rs"}"#.to_string(),
+            }
+        );
+        assert_eq!(
+            rx.blocking_recv().unwrap(),
+            PeerDeltaEvent::ToolFinish {
+                tool_call_id,
+                task_id: "task-1".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_partial_json() {
+        let accumulator = DeltaAccumulator::new(1_024);
+        let tool_call_id = "tx_2_dcba".to_string();
+        accumulator
+            .start_tool(
+                tool_call_id.clone(),
+                "task-2".to_string(),
+                "apply_patch".to_string(),
+            )
+            .unwrap();
+
+        let error = accumulator.accumulate(&tool_call_id, "}").unwrap_err();
+        assert_eq!(error, AccumulationError::MalformedPartial);
+    }
+
+    #[test]
+    fn memory_watermark_evicts_oldest_pending_tool() {
+        let accumulator = DeltaAccumulator::new(1);
+
+        accumulator
+            .start_tool(
+                "tx_1_aaaa".to_string(),
+                "task-3".to_string(),
+                "read_file".to_string(),
+            )
+            .unwrap();
+        accumulator
+            .start_tool(
+                "tx_2_bbbb".to_string(),
+                "task-3".to_string(),
+                "apply_patch".to_string(),
+            )
+            .unwrap();
+
+        let snapshot = accumulator.snapshot();
+        let map = snapshot.lock().unwrap_or_else(|e| e.into_inner());
+        assert!(!map.contains_key("tx_1_aaaa"));
+        assert!(map.contains_key("tx_2_bbbb"));
+    }
+}

--- a/src/runtime/json_handoff.rs
+++ b/src/runtime/json_handoff.rs
@@ -12,7 +12,8 @@ use chrono::{Timelike, Utc};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeSet, HashMap};
-use std::sync::{Arc, atomic::{AtomicU32, Ordering}};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
 
 mod derived;
 

--- a/src/runtime/json_handoff.rs
+++ b/src/runtime/json_handoff.rs
@@ -12,7 +12,7 @@ use chrono::{Timelike, Utc};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeSet, HashMap};
-use std::sync::Arc;
+use std::sync::{Arc, atomic::{AtomicU32, Ordering}};
 
 mod derived;
 
@@ -161,6 +161,25 @@ pub struct DerivedBatchRecords {
 }
 
 pub type ToolCallId = String;
+
+/// Generates a `tx_`-prefixed tool call ID suitable for use as a
+/// [`ToolCallId`] anywhere in the runtime pipeline.
+///
+/// `counter` must be an [`AtomicU32`] owned or shared by the caller and
+/// monotonically incremented per call. `entropy` is a 16-bit time- or
+/// task-derived salt that reduces collision risk across counter resets.
+///
+/// The resulting format is `tx_{counter}_{entropy:04x}` — a decimal monotonic
+/// counter followed by a 4-hex-digit entropy field — matching the pattern
+/// `^tx_[0-9]+_[0-9a-f]{4}$` enforced by `schemas/runtime_envelope_v1.json`.
+///
+/// IDs are generated once in `src/runtime/json_handoff.rs` and passed
+/// pre-generated to [`super::delta_accumulator::DeltaAccumulator`] — the
+/// accumulator never creates its own IDs.
+pub fn generate_tool_call_id(counter: &AtomicU32, entropy: u16) -> ToolCallId {
+    let count = counter.fetch_add(1, Ordering::SeqCst);
+    format!("tx_{}_{:04x}", count, entropy & 0xffff)
+}
 
 #[derive(Debug, Clone)]
 struct PendingToolCall {

--- a/src/runtime/json_handoff.rs
+++ b/src/runtime/json_handoff.rs
@@ -1,5 +1,6 @@
 use super::UiUpdate;
 use crate::runtime::AssistantPhase;
+use crate::runtime::delta_accumulator::DeltaAccumulator;
 use crate::state::{StreamBlock, ToolStatus};
 use crate::turn_evidence::{
     SummaryRecord, TurnEvidenceRecord, command_evidence_from_tool_result,
@@ -10,7 +11,8 @@ use crate::usage::TurnTokens;
 use chrono::{Timelike, Utc};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
+use std::sync::Arc;
 
 mod derived;
 
@@ -158,9 +160,11 @@ pub struct DerivedBatchRecords {
     pub max_turns_reached: bool,
 }
 
+pub type ToolCallId = String;
+
 #[derive(Debug, Clone)]
 struct PendingToolCall {
-    runtime_id: String,
+    runtime_id: ToolCallId,
     name: String,
     arguments: serde_json::Value,
 }
@@ -170,23 +174,42 @@ pub struct RuntimeEnvelopeNormalizer {
     turn: u32,
     next_seq: u64,
     pending_tool_calls: IndexMap<String, PendingToolCall>,
+    streaming_tool_call_blocks: HashMap<usize, ToolCallId>,
     turn_changed_files: BTreeSet<String>,
     tool_id_counter: u64,
     open_final_text_block: Option<usize>,
     next_synthetic_block_index: usize,
+    delta_accumulator: Option<Arc<DeltaAccumulator>>,
 }
 
 impl RuntimeEnvelopeNormalizer {
     pub fn new(task_id: impl Into<String>) -> Self {
+        Self::new_inner(task_id.into(), None)
+    }
+
+    pub fn new_with_delta_accumulator(
+        task_id: impl Into<String>,
+        delta_accumulator: Arc<DeltaAccumulator>,
+    ) -> Self {
+        Self::new_inner(task_id.into(), Some(delta_accumulator))
+    }
+
+    pub fn delta_accumulator(&self) -> Option<Arc<DeltaAccumulator>> {
+        self.delta_accumulator.clone()
+    }
+
+    fn new_inner(task_id: String, delta_accumulator: Option<Arc<DeltaAccumulator>>) -> Self {
         Self {
-            task_id: task_id.into(),
+            task_id,
             turn: 0,
             next_seq: 1,
             pending_tool_calls: IndexMap::new(),
+            streaming_tool_call_blocks: HashMap::new(),
             turn_changed_files: BTreeSet::new(),
             tool_id_counter: 0,
             open_final_text_block: None,
             next_synthetic_block_index: SYNTHETIC_FINAL_TEXT_BLOCK_START,
+            delta_accumulator,
         }
     }
 
@@ -194,6 +217,7 @@ impl RuntimeEnvelopeNormalizer {
         self.turn = turn;
         self.next_seq = 1;
         self.pending_tool_calls.clear();
+        self.streaming_tool_call_blocks.clear();
         self.turn_changed_files.clear();
         self.open_final_text_block = None;
         self.next_synthetic_block_index = SYNTHETIC_FINAL_TEXT_BLOCK_START;
@@ -207,7 +231,9 @@ impl RuntimeEnvelopeNormalizer {
                 id, name, input, ..
             }
             | ContentBlock::ServerToolUse { id, name, input } => {
-                vec![self.record_tool_call(id.clone(), name.clone(), input.clone())]
+                let envelope = self.record_tool_call(id.clone(), name.clone(), input.clone());
+                self.seed_tool_accumulator_for_source(id, input);
+                vec![envelope]
             }
             ContentBlock::ToolResult {
                 tool_use_id,
@@ -280,15 +306,27 @@ impl RuntimeEnvelopeNormalizer {
                     block: block.clone(),
                 }));
                 envelopes.extend(self.normalize_stream_block(block));
+                if let StreamBlock::ToolCall { id, .. } = block
+                    && let Some(pending) = self.pending_tool_calls.get(id)
+                {
+                    self.streaming_tool_call_blocks
+                        .insert(*index, pending.runtime_id.clone());
+                }
                 envelopes
             }
             UiUpdate::StreamBlockDelta { index, delta } => {
+                if let Some(runtime_id) = self.streaming_tool_call_blocks.get(index).cloned() {
+                    self.accumulate_tool_delta(&runtime_id, delta);
+                }
                 vec![self.next_envelope(RuntimeEvent::TranscriptBlockDelta {
                     index: *index,
                     delta: delta.clone(),
                 })]
             }
             UiUpdate::StreamBlockComplete { index } => {
+                if let Some(runtime_id) = self.streaming_tool_call_blocks.remove(index) {
+                    self.finish_tool_accumulator(&runtime_id);
+                }
                 vec![self.next_envelope(RuntimeEvent::TranscriptBlockComplete { index: *index })]
             }
             UiUpdate::TurnComplete => self.complete_turn(turn_end.unwrap_or_default()),
@@ -333,10 +371,14 @@ impl RuntimeEnvelopeNormalizer {
         }));
 
         if !recoverable {
+            let changed_files = self.resolve_changed_files(turn_end.changed_files);
+            self.finish_pending_tool_accumulations();
+            self.pending_tool_calls.clear();
+            self.streaming_tool_call_blocks.clear();
             envelopes.push(self.next_envelope(RuntimeEvent::TurnEnd {
                 status: "failed".to_string(),
                 usage: turn_end.usage,
-                changed_files: self.resolve_changed_files(turn_end.changed_files),
+                changed_files,
             }));
         }
 
@@ -349,11 +391,15 @@ impl RuntimeEnvelopeNormalizer {
         turn_end: TurnEndContext,
     ) -> Vec<RuntimeEnvelope> {
         let mut envelopes = self.close_open_final_text_block();
+        let changed_files = self.resolve_changed_files(turn_end.changed_files);
+        self.finish_pending_tool_accumulations();
+        self.pending_tool_calls.clear();
+        self.streaming_tool_call_blocks.clear();
         envelopes.push(self.next_envelope(RuntimeEvent::MaxTurnsReached { max_turns }));
         envelopes.push(self.next_envelope(RuntimeEvent::TurnEnd {
             status: "failed".to_string(),
             usage: turn_end.usage,
-            changed_files: self.resolve_changed_files(turn_end.changed_files),
+            changed_files,
         }));
         envelopes
     }
@@ -375,11 +421,15 @@ impl RuntimeEnvelopeNormalizer {
         status: &str,
         turn_end: TurnEndContext,
     ) -> Vec<RuntimeEnvelope> {
+        let changed_files = self.resolve_changed_files(turn_end.changed_files);
+        self.finish_pending_tool_accumulations();
+        self.pending_tool_calls.clear();
+        self.streaming_tool_call_blocks.clear();
         let mut envelopes = self.close_open_final_text_block();
         envelopes.push(self.next_envelope(RuntimeEvent::TurnEnd {
             status: status.to_string(),
             usage: turn_end.usage,
-            changed_files: self.resolve_changed_files(turn_end.changed_files),
+            changed_files,
         }));
         envelopes
     }
@@ -431,6 +481,8 @@ impl RuntimeEnvelopeNormalizer {
                 arguments: arguments.clone(),
             },
         );
+        self.start_tool_accumulator(&runtime_id, &name);
+        self.seed_tool_accumulator(&runtime_id, &arguments);
 
         Some(self.next_envelope(RuntimeEvent::ToolCall {
             id: runtime_id,
@@ -454,6 +506,7 @@ impl RuntimeEnvelopeNormalizer {
                 arguments: arguments.clone(),
             },
         );
+        self.start_tool_accumulator(&runtime_id, &name);
 
         self.next_envelope(RuntimeEvent::ToolCall {
             id: runtime_id,
@@ -469,6 +522,7 @@ impl RuntimeEnvelopeNormalizer {
         is_error: bool,
     ) -> RuntimeEnvelope {
         if let Some(pending) = self.pending_tool_calls.shift_remove(source_id) {
+            self.finish_tool_accumulator(&pending.runtime_id);
             if !is_error {
                 note_changed_files_from_tool_call(
                     &mut self.turn_changed_files,
@@ -500,12 +554,74 @@ impl RuntimeEnvelopeNormalizer {
         }
     }
 
-    fn generate_tool_call_id(&mut self) -> String {
+    fn start_tool_accumulator(&self, tool_call_id: &ToolCallId, name: &str) {
+        let Some(delta_accumulator) = &self.delta_accumulator else {
+            return;
+        };
+
+        if let Err(error) = delta_accumulator.start_tool(
+            tool_call_id.clone(),
+            self.task_id.clone(),
+            name.to_string(),
+        ) {
+            tracing::debug!(%error, tool_call_id = %tool_call_id, "failed to start tool delta accumulation");
+        }
+    }
+
+    fn seed_tool_accumulator_for_source(&self, source_id: &str, arguments: &serde_json::Value) {
+        let Some(pending) = self.pending_tool_calls.get(source_id) else {
+            return;
+        };
+
+        self.seed_tool_accumulator(&pending.runtime_id, arguments);
+    }
+
+    fn seed_tool_accumulator(&self, tool_call_id: &ToolCallId, arguments: &serde_json::Value) {
+        let Some(delta_accumulator) = &self.delta_accumulator else {
+            return;
+        };
+
+        let Ok(serialized) = serde_json::to_string(arguments) else {
+            return;
+        };
+        if serialized == "{}" {
+            return;
+        }
+
+        if let Err(error) = delta_accumulator.accumulate(tool_call_id, &serialized) {
+            tracing::debug!(%error, tool_call_id = %tool_call_id, "failed to seed tool delta accumulation");
+        }
+    }
+
+    fn accumulate_tool_delta(&self, tool_call_id: &ToolCallId, delta: &str) {
+        let Some(delta_accumulator) = &self.delta_accumulator else {
+            return;
+        };
+
+        if let Err(error) = delta_accumulator.accumulate(tool_call_id, delta) {
+            tracing::debug!(%error, tool_call_id = %tool_call_id, "failed to accumulate tool delta");
+        }
+    }
+
+    fn finish_tool_accumulator(&self, tool_call_id: &ToolCallId) {
+        let Some(delta_accumulator) = &self.delta_accumulator else {
+            return;
+        };
+
+        delta_accumulator.finish(tool_call_id);
+    }
+
+    fn finish_pending_tool_accumulations(&self) {
+        for pending in self.pending_tool_calls.values() {
+            self.finish_tool_accumulator(&pending.runtime_id);
+        }
+    }
+
+    fn generate_tool_call_id(&mut self) -> ToolCallId {
         self.tool_id_counter = self.tool_id_counter.saturating_add(1);
         let now = Utc::now();
-        let millis = now.timestamp_millis() as u128;
         let entropy = ((now.nanosecond() as u128 ^ self.tool_id_counter as u128) & 0xffff) as u16;
-        format!("call_{millis}_{entropy:04x}")
+        format!("tx_{}_{entropy:04x}", self.tool_id_counter)
     }
 
     fn next_envelope(&mut self, event: RuntimeEvent) -> RuntimeEnvelope {

--- a/src/runtime/json_handoff.rs
+++ b/src/runtime/json_handoff.rs
@@ -179,7 +179,7 @@ pub type ToolCallId = String;
 /// accumulator never creates its own IDs.
 pub fn generate_tool_call_id(counter: &AtomicU32, entropy: u16) -> ToolCallId {
     let count = counter.fetch_add(1, Ordering::SeqCst);
-    format!("tx_{}_{:04x}", count, entropy & 0xffff)
+    format!("tx_{}_{entropy:04x}", count)
 }
 
 #[derive(Debug, Clone)]

--- a/src/runtime/json_handoff/tests.rs
+++ b/src/runtime/json_handoff/tests.rs
@@ -1,6 +1,8 @@
 use super::*;
+use crate::runtime::delta_accumulator::DeltaAccumulator;
 use crate::state::ToolApprovalRequest;
 use serde_json::json;
+use std::sync::Arc;
 use tokio::sync::oneshot;
 
 #[test]
@@ -11,7 +13,7 @@ fn test_pi_09_anchor_runtime_envelope_serde_shape() {
         turn: 1,
         seq: 3,
         event: RuntimeEvent::ToolCall {
-            id: "call_1741700123456_9a2f".to_string(),
+            id: "tx_1_9a2f".to_string(),
             name: "read_file".to_string(),
             arguments: json!({
                 "path": "src/app.rs"
@@ -25,7 +27,7 @@ fn test_pi_09_anchor_runtime_envelope_serde_shape() {
     assert_eq!(value["turn"], 1);
     assert_eq!(value["seq"], 3);
     assert_eq!(value["event"]["type"], "tool_call");
-    assert_eq!(value["event"]["id"], "call_1741700123456_9a2f");
+    assert_eq!(value["event"]["id"], "tx_1_9a2f");
     assert_eq!(value["event"]["name"], "read_file");
     assert_eq!(value["event"]["arguments"]["path"], "src/app.rs");
 }
@@ -310,6 +312,59 @@ fn test_pi_10_normalization_projects_ui_updates_and_approval_events() {
 }
 
 #[test]
+fn test_pi_10_stream_block_deltas_feed_delta_accumulator() {
+    let accumulator = Arc::new(DeltaAccumulator::new(8 * 1_024));
+    let mut normalizer = RuntimeEnvelopeNormalizer::new_with_delta_accumulator(
+        "task-delta",
+        Arc::clone(&accumulator),
+    );
+    let _ = normalizer.start_turn(1, Some("stream tool".to_string()));
+
+    let start = normalizer.normalize_ui_update(
+        &UiUpdate::StreamBlockStart {
+            index: 0,
+            block: StreamBlock::ToolCall {
+                id: "provider-call-1".to_string(),
+                name: "read_file".to_string(),
+                input: json!({}),
+                status: crate::state::ToolStatus::Pending,
+            },
+        },
+        None,
+    );
+    let runtime_call_id = match &start[1].event {
+        RuntimeEvent::ToolCall { id, .. } => id.clone(),
+        other => panic!("expected tool_call event, got {other:?}"),
+    };
+
+    normalizer.normalize_ui_update(
+        &UiUpdate::StreamBlockDelta {
+            index: 0,
+            delta: r#"{"path":"src/"#.to_string(),
+        },
+        None,
+    );
+    normalizer.normalize_ui_update(
+        &UiUpdate::StreamBlockDelta {
+            index: 0,
+            delta: r#"lib.rs"}"#.to_string(),
+        },
+        None,
+    );
+    normalizer.normalize_ui_update(&UiUpdate::StreamBlockComplete { index: 0 }, None);
+
+    let snapshot = accumulator.snapshot();
+    let map = snapshot.lock().unwrap_or_else(|e| e.into_inner());
+    let tool_state = map.get(&runtime_call_id).expect("tool state present");
+    assert_eq!(tool_state.partial_args, r#"{"path":"src/lib.rs"}"#);
+    assert_eq!(
+        tool_state.delta_queue.iter().cloned().collect::<Vec<_>>(),
+        vec![r#"{"path":"src/"#.to_string(), r#"lib.rs"}"#.to_string()]
+    );
+    assert!(tool_state.finished);
+}
+
+#[test]
 fn test_pi_12_runtime_handoff_round_trips_and_batch_derivation_hold() {
     let mut normalizer = RuntimeEnvelopeNormalizer::new("batch-1741700000000");
     let mut envelopes = Vec::new();
@@ -495,7 +550,7 @@ fn test_pi_12_error_and_max_turn_sequences_follow_contract() {
 fn assert_runtime_tool_id(id: &str) {
     let parts: Vec<_> = id.split('_').collect();
     assert_eq!(parts.len(), 3, "runtime tool id must have three segments");
-    assert_eq!(parts[0], "call");
+    assert_eq!(parts[0], "tx");
     assert!(parts[1].chars().all(|ch| ch.is_ascii_digit()));
     assert_eq!(parts[2].len(), 4);
     assert!(parts[2].chars().all(|ch| ch.is_ascii_hexdigit()));

--- a/src/server/handlers/mod.rs
+++ b/src/server/handlers/mod.rs
@@ -343,7 +343,10 @@ pub async fn turns_handler(
         task_id.clone(),
         envelope_tx,
         Arc::clone(&quit),
-        state.config.api_client.delta_accumulator_memory_watermark_bytes(),
+        state
+            .config
+            .api_client
+            .delta_accumulator_memory_watermark_bytes(),
     )));
 
     {

--- a/src/server/handlers/mod.rs
+++ b/src/server/handlers/mod.rs
@@ -20,7 +20,7 @@ use crate::http_facade::{StatusCode, header};
 use crate::local_api::{
     ActiveTask, FrontendCommand, LocalApiMode, LocalApiState, LocalApiTaskShared,
 };
-use crate::runtime::json_handoff::{RuntimeEnvelopeNormalizer, RuntimeRequest, TurnEndContext};
+use crate::runtime::json_handoff::{RuntimeRequest, TurnEndContext};
 
 use super::ControlResponse;
 
@@ -339,16 +339,11 @@ pub async fn turns_handler(
     let (envelope_tx, envelope_rx) = mpsc::unbounded_channel::<String>();
     let (interrupt_tx, interrupt_rx) = mpsc::unbounded_channel::<FrontendCommand>();
     let quit = Arc::new(AtomicBool::new(false));
-    let shared = Arc::new(Mutex::new(LocalApiTaskShared {
-        normalizer: RuntimeEnvelopeNormalizer::new(task_id.clone()),
+    let shared = Arc::new(Mutex::new(LocalApiTaskShared::new(
+        task_id.clone(),
         envelope_tx,
-        pending_approval: None,
-        quit: Arc::clone(&quit),
-        turn_in_progress: false,
-        interrupted: false,
-        active_command_sessions: std::collections::BTreeSet::new(),
-        turn_completion_pending: false,
-    }));
+        Arc::clone(&quit),
+    )));
 
     {
         let mut tasks = state.tasks.lock().await;

--- a/src/server/handlers/mod.rs
+++ b/src/server/handlers/mod.rs
@@ -343,6 +343,7 @@ pub async fn turns_handler(
         task_id.clone(),
         envelope_tx,
         Arc::clone(&quit),
+        state.config.api_client.delta_accumulator_memory_watermark_bytes(),
     )));
 
     {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -170,6 +170,7 @@ fn test_config_validation_rejects_local_model_for_remote_endpoint() {
         api: vexcoder::config::ApiConfig::default(),
         hooks: Vec::new(),
         auto_memory: vexcoder::config::AutoMemoryConfig::default(),
+        api_client: vexcoder::config::ApiClientConfig::default(),
     };
     assert!(config.validate().is_err());
 }
@@ -200,6 +201,7 @@ fn test_config_validation_allows_local_endpoint_without_token() {
         api: vexcoder::config::ApiConfig::default(),
         hooks: Vec::new(),
         auto_memory: vexcoder::config::AutoMemoryConfig::default(),
+        api_client: vexcoder::config::ApiClientConfig::default(),
     };
     assert!(config.validate().is_ok());
 }
@@ -539,6 +541,7 @@ async fn test_build_batch_runtime_succeeds_with_local_config() {
         api: vexcoder::config::ApiConfig::default(),
         hooks: Vec::new(),
         auto_memory: vexcoder::config::AutoMemoryConfig::default(),
+        api_client: vexcoder::config::ApiClientConfig::default(),
     };
     let result = build_batch_runtime(&config, "test task".to_string(), BatchRunOpts::default());
     assert!(

--- a/tests/live_server_test.rs
+++ b/tests/live_server_test.rs
@@ -104,6 +104,7 @@ fn build_chat_compat_config(base_url: &str, model_name: &str) -> Config {
         api: vexcoder::config::ApiConfig::default(),
         hooks: Vec::new(),
         auto_memory: vexcoder::config::AutoMemoryConfig::default(),
+        api_client: vexcoder::config::ApiClientConfig::default(),
     }
 }
 
@@ -136,6 +137,7 @@ fn build_messages_v1_config(base_url: &str, model_name: &str) -> Config {
         api: vexcoder::config::ApiConfig::default(),
         hooks: Vec::new(),
         auto_memory: vexcoder::config::AutoMemoryConfig::default(),
+        api_client: vexcoder::config::ApiClientConfig::default(),
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `src/runtime/delta_accumulator.rs`: synchronous shared accumulator storing streamed tool-input fragments per `tx_`-prefixed ID, bounded delta queues, TTL cleanup, task-scoped cleanup, optional in-memory peer event sender, and precise memory estimation.
- Switch `RuntimeEnvelopeNormalizer` to `tx_`-prefixed tool call IDs and wire it to the new accumulator so every tool start, streaming delta, and block-complete event flows into the accumulator state.
- Export `generate_tool_call_id(&AtomicU32, u16) -> ToolCallId` as a public free function in `json_handoff.rs` so phase-1 protocol mappers can generate conforming IDs without owning a normalizer.
- Add `AccumulationError::MemoryPressure`: returned from `start_tool` when the watermark is still exceeded after the oldest-pending eviction pass (i.e. every in-flight entry is already finished).
- Route accumulator construction through `LocalApiTaskShared::new` so the server handler never touches the accumulator directly; schema and test suite updated to the new `tx_` ID contract.

## Motivation

The ADR amendment (Phase 0 of the block-delta pivot) requires one runtime-owned canonical store for tool-call IDs and streamed argument fragments. Two gaps remained in the original detached-sandbox draft:

1. `generate_tool_call_id` was a private method on the normalizer instead of the public free function the ADR spec shows. Phase-1 protocol mappers need to produce `tx_` IDs without depending on a live normalizer instance, so the function must be exported from `json_handoff.rs` with an `AtomicU32` counter interface.

2. `AccumulationError::MemoryPressure` was defined in the ADR spec but absent from the enum. The accumulator already silently evicts the oldest pending entry under pressure; without the variant the caller has no way to observe the case where every entry is finished and nothing can be evicted, which is the exact condition that leaves the new start request silently dropped.

The ADR spec also shows `delta_tx: mpsc::Sender<String>` embedded per `ToolState` with the receiver immediately dropped — this is a latent bug (a dropped receiver makes every subsequent `try_send` fail). The implementation substitutes `delta_queue: VecDeque<String>` capped at 32 entries, which preserves insertion order, costs no channel allocation per tool, and is strictly correct. The decision is documented here rather than in the ADR to keep the spec intent clear.

The file-backed `PeerChannel` from `task_state/peer_channel.rs` was not used for delta publication. That channel is JSONL-on-disk with a 256-message depth cap; streaming deltas (dozens to hundreds per tool call) would exhaust it and impose per-delta file I/O. An optional `mpsc::Sender<PeerDeltaEvent>` in the accumulator carries the same semantic as the ADR's peer integration but stays entirely in-memory. A facade-level bridge from `PeerDeltaEvent` to `PeerMessage` for genuine cross-agent propagation is deferred to phase 1 per ADR-028 and the dependency-direction gate.

## Approach

**Accumulator design (`src/runtime/delta_accumulator.rs`)**
`std::sync::Mutex<HashMap<ToolCallId, ToolState>>` provides the shared mutable state. `DashMap` was ruled out (introduces a dependency for a single internal module with no external contention). An async `RwLock` was ruled out (writes arrive on every streaming delta, eliminating the reader-favouring advantage, and would require new `await` seams in the synchronous normalizer path). A pure actor behind a channel was ruled out (later SSE serializers need to snapshot accumulated state, not replay events).

Each `ToolState` carries a `VecDeque<String>` delta queue (capacity 32, FIFO, oldest dropped on overflow) and a `partial_args: String` capped at 64 KiB. Memory estimation sums all string bytes plus 128-byte overhead per entry. When the configured watermark is exceeded, `drop_oldest_pending` removes the entry with the earliest `last_activity` among unfinished tools. If no pending entry exists after eviction, `start_tool` returns `Err(AccumulationError::MemoryPressure)` and the normalizer logs it at `DEBUG` and continues.

**ID generation (`src/runtime/json_handoff.rs`)**
`pub fn generate_tool_call_id(counter: &AtomicU32, entropy: u16) -> ToolCallId` is exported alongside the `ToolCallId` type alias. Format: `tx_{decimal_counter}_{entropy:04x}` matching `^tx_[0-9]+_[0-9a-f]{4}$` in `schemas/runtime_envelope_v1.json`. The normalizer's private `generate_tool_call_id` method delegates to the same format using its own `u64` counter (protected by the outer session mutex) and nanosecond-derived entropy; it is not removed to avoid changing the call sites.

**Normalizer integration (`src/runtime/json_handoff.rs`)**
`RuntimeEnvelopeNormalizer` gains `streaming_tool_call_blocks: HashMap<usize, ToolCallId>` mapping provider block indices to runtime IDs. `StreamBlockStart` with a `ToolCall` block seeds the mapping; `StreamBlockDelta` routes partial JSON through `accumulate`; `StreamBlockComplete` calls `finish` and removes the index. Non-streaming tool calls seed the accumulator from their full `arguments` value. All turn-end paths (`complete_turn`, `max_turns_path`, `failed_turn_path`) call `finish_pending_tool_accumulations` before clearing `pending_tool_calls` so no in-flight accumulation is left open.

**Construction seam (`src/local_api.rs`)**
`LocalApiTaskShared::new` creates the `DeltaAccumulator` and passes it to `RuntimeEnvelopeNormalizer::new_with_delta_accumulator`. The server handler (`src/server/handlers/mod.rs`) now calls `LocalApiTaskShared::new` instead of constructing the struct literal inline; no server-layer code touches the accumulator directly.

## Validation

- `cargo test json_handoff --lib` — ID format and normalizer stream-delta test
- `cargo test delta_accumulator --lib` — unit tests for start/accumulate/finish lifecycle, peer event delivery, malformed-JSON rejection, memory-watermark eviction, and the new `MemoryPressure` case
- `cargo fmt --check` — no formatting drift
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo nextest run -j 2` — full suite green
- `bash scripts/check_forbidden_names.sh` — clean
- `make check-arch` — dependency-direction gate passes; accumulator stays inside `runtime`, server handler stays on the `local_api` seam

## Risks

- **No end-to-end SSE assertion**: there is no HTTP-level test that a live local-api turn emits `tx_`-prefixed IDs over the wire. Coverage is at the normalizer, schema, and unit-test levels. An integration test for the SSE frame format is deferred to phase 1 alongside the protocol mappers.
- **`generate_tool_call_id` free function is unused by production callers**: the function is exported and tested in isolation but no phase-0 caller outside tests invokes it yet. It will be used in phase-1 mapper construction; the unused-public-item lint is suppressed by the existing `lib.rs` export policy.
- **Peer event sender is always `None` in production**: `LocalApiTaskShared::new` wires the accumulator without a peer sender; `PeerDeltaEvent` is emitted only in tests that supply a channel. Cross-agent delta propagation is deferred to phase 1 per ADR-046 and ADR-028.
- **`partial_args` truncation is silent**: the 64 KiB cap on stored partial JSON is not surfaced as an error; callers that need the full argument string must read the live delta queue instead. A `PartialArgsTruncated` diagnostic event is considered for phase 1.