### PR TITLE
CLI polish: panic reports and task listings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,17 @@ jobs:
             exit 1
           fi
 
+      - name: Resolve release version
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            release_version="${GITHUB_REF_NAME}"
+          else
+            release_version="$(git rev-parse --short=7 HEAD)"
+          fi
+          echo "RELEASE_VERSION=${release_version}" >> "$GITHUB_ENV"
+
       - name: Run gate (non-Windows)
         if: runner.os != 'Windows'
         shell: bash
@@ -139,8 +150,7 @@ jobs:
           TARGET: ${{ matrix.target }}
           OUT_DIR: dist
           BUILD_TOOL: ${{ matrix.build_tool }}
-          VERSION: ${{ github.ref_name }}
-        run: bash scripts/release.sh
+        run: VERSION="${RELEASE_VERSION}" bash scripts/release.sh
 
       - name: Package release archive (Windows)
         if: runner.os == 'Windows'
@@ -149,7 +159,7 @@ jobs:
           TARGET: ${{ matrix.target }}
           OUT_DIR: dist
         run: |
-          .\scripts\release.ps1 -Version $env:GITHUB_REF_NAME -Target $env:TARGET -OutDir $env:OUT_DIR
+          .\scripts\release.ps1 -Version $env:RELEASE_VERSION -Target $env:TARGET -OutDir $env:OUT_DIR
 
       - name: Upload dist artifact
         uses: actions/upload-artifact@v6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,6 +481,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2653,6 +2659,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "human-panic"
+version = "2.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2815d0c49773c6e0a9753960b3d0e50b822e48e08c77bcb4780be8474c9cc3d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "backtrace",
+ "serde",
+ "serde_derive",
+ "sysinfo",
+ "toml 1.1.2+spec-1.1.0",
+ "uuid",
+]
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3568,6 +3590,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3715,6 +3746,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-io-surface"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3792,6 +3833,17 @@ name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
+name = "papergrid"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6978128c8b51d8f4080631ceb2302ab51e32cc6e8615f735ee2f83fd269ae3f1"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width",
+]
 
 [[package]]
 name = "parking_lot"
@@ -4094,6 +4146,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -4868,6 +4942,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5194,6 +5277,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
+]
+
+[[package]]
+name = "tabled"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e39a2ee1fbcd360805a771e1b300f78cc88fec7b8d3e2f71cd37bbf23e725c7d"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+ "testing_table",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846"
+dependencies = [
+ "heck",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5283,6 +5404,15 @@ dependencies = [
  "wezterm-dynamic",
  "wezterm-input-types",
  "winapi",
+]
+
+[[package]]
+name = "testing_table"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -5482,9 +5612,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_writer",
 ]
 
 [[package]]
@@ -5497,6 +5639,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5504,8 +5655,8 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
  "winnow",
 ]
@@ -5515,6 +5666,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -5874,6 +6031,7 @@ dependencies = [
  "hickory-resolver",
  "http 1.4.0",
  "httpdate",
+ "human-panic",
  "hyper",
  "hyper-util",
  "ignore",
@@ -5905,6 +6063,7 @@ dependencies = [
  "similar",
  "strip-ansi-escapes",
  "syntect",
+ "tabled",
  "tempfile",
  "textwrap",
  "thiserror 2.0.18",
@@ -5912,7 +6071,7 @@ dependencies = [
  "tokio-rustls 0.26.4",
  "tokio-stream",
  "tokio-util",
- "toml",
+ "toml 0.8.23",
  "tower",
  "tower-http",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ tree-sitter-rust = "0.24"
 x509-parser = "0.18"
 arboard = { version = "3", default-features = false }
 color-eyre = "0.6"
+human-panic = "2"
 dirs = "6"
 tracing-appender = "0.2"
 similar = "2"
@@ -118,6 +119,7 @@ syntect = { version = "5", default-features = false, features = [
 ] }
 indicatif = "0.17"
 console = "0.15"
+tabled = "0.20"
 ignore = "0.4"
 globset = "0.4"
 pathdiff = "0.2"
@@ -214,6 +216,9 @@ arboard = ["src/clipboard.rs", "src/app/commands/session.rs"]
 # Markdown rendering stack — both crates are consumed together at one site.
 pulldown-cmark = ["src/ui/render/markdown.rs"]
 syntect = ["src/ui/render/markdown.rs"]
+# CLI panic/reporting polish — release panic hook and interactive task table.
+human-panic = ["src/bin/vex.rs"]
+tabled = ["src/bin/vex.rs"]
 # TUI text bridge — converts ANSI escape sequences to ratatui spans.
 ansi-to-tui = ["src/ui/tui.rs"]
 # Network wrappers — focused seams for transport-related helper crates.
@@ -257,6 +262,8 @@ jsonwebtoken = "JWT/JWS helpers stay localized in src/net/jwt.rs; keep RFC 7519 
 oauth2 = "Native-app PKCE generation, authorization URL assembly, and the custom async token-exchange adapter stay localized in src/net/oauth.rs."
 open = "Browser-launch helpers for RFC 8252 native-app authorization stay localized in src/net/oauth.rs."
 reqwest = "Core HTTP client seams remain in src/api/client/mod.rs, src/net/http_client.rs, and src/server/, with proxy-specific URL handling isolated in src/net/proxy.rs."
+human-panic = "The release-build panic path stays localized in src/bin/vex.rs so panic-hook ownership remains explicit alongside color-eyre's eyre hook."
+tabled = "Interactive task-list rendering stays localized in src/bin/vex.rs; non-TTY and --json output remain separate compatibility paths."
 
 [package]
 name = "vexcoder"
@@ -326,6 +333,7 @@ arboard.workspace = true
 
 # --- diagnostics, path utilities, diff rendering ---
 color-eyre.workspace = true
+human-panic.workspace = true
 dirs.workspace = true
 tracing-appender.workspace = true
 similar.workspace = true
@@ -336,6 +344,7 @@ pulldown-cmark.workspace = true
 syntect.workspace = true
 indicatif.workspace = true
 console.workspace = true
+tabled.workspace = true
 
 # --- workspace navigation and path normalization ---
 ignore.workspace = true

--- a/TASKS/ACTIVE-ROADMAP.md
+++ b/TASKS/ACTIVE-ROADMAP.md
@@ -207,7 +207,7 @@ without changing machine-facing lifecycle values or diff color semantics.
   display-only.
 - Do not rename code symbols, persisted schema fields, or JSON payload keys.
 
-Concrete targets (7 display-facing strings across 4 files):
+Concrete targets (6 display-facing strings across 3 files):
 
 | File | Count | Terms to normalize |
 | :--- | :--- | :--- |

--- a/TASKS/ACTIVE-ROADMAP.md
+++ b/TASKS/ACTIVE-ROADMAP.md
@@ -207,12 +207,11 @@ without changing machine-facing lifecycle values or diff color semantics.
   display-only.
 - Do not rename code symbols, persisted schema fields, or JSON payload keys.
 
-Concrete targets (9 display-facing strings across 5 files):
+Concrete targets (7 display-facing strings across 4 files):
 
 | File | Count | Terms to normalize |
 | :--- | :--- | :--- |
 | `src/app/commands/mod.rs` | 3 | `parent=` -> `origin=` in watch lines; `branched from` -> `derived from`; `fork aborted` -> `fork halted` |
-| `src/bin/vex.rs` | 2 | `parent=` -> `origin=` in session-task status lines |
 | `src/app/model_update.rs` | 1 | `aborted` -> `halted` in edit loop approval denial |
 | `src/app/input.rs` | 2 | `busy` -> `occupied` in turn-in-progress status lines |
 

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -281,7 +281,7 @@ adopt only when there is a live code path and a focused verification seam.
 | `console-subscriber` | **Deferred** | Useful for local runtime diagnostics, but it is debug-only instrumentation and not part of the shipping transport, auth, or CLI contract. |
 | `tui-textarea`, `tui-input`, `ratatui-image`, `tui-tree-widget`, `tui-logger`, `throbber-widgets-tui`, `ratatui-splash-screen` | **Deferred** | The current editor, transcript, and task-surface code already own these concerns.  A widget-crate swap would be a UI-architecture lane, not a transport follow-up. |
 | `directories`, `config`, `strum`, `bytesize` | **Deferred** | Current config loading, XDG path resolution, enum handling, and byte-count formatting already stay localized in existing repo seams.  Adding alternate helpers now would duplicate working code. |
-| `human-panic`, `dialoguer`, `tabled`, `palette` | **Deferred** | These are reasonable polish crates, but they do not close a current RFC or transport gap and would broaden the PR beyond the active follow-up lane. |
+| `dialoguer`, `palette` | **Deferred** | These remain plausible polish crates, but there is still no live prompt/theme seam that requires them in the current tree. |
 
 ### Vexcoder-specific crates
 
@@ -293,9 +293,11 @@ a design need specific to vexcoder's architecture.
 | `axum` | HTTP routing and handler composition for the local API server surface | Comparable CLIs may use a thinner direct HTTP surface or a different server seam. | `axum` is already the active server foundation in vexcoder; `tower-http` sits on top of it for request tracing, not in place of it. |
 | `tower-http` | `TraceLayer` HTTP middleware for the local API server (`src/server/http.rs`) | Comparable CLIs use axum directly without tower middleware.  vexcoder's `LocalApiServer` (ADR-026) requires request/response tracing for debugging multi-agent sessions. | Conventional for axum-based servers needing observability. |
 | `fs2` | File-locking for `.vex/state/` durable writes | Comparable CLIs use a different persistence model. | Prevents concurrent vexcoder sessions from corrupting task-state files.  `write_json_safe` uses temp+fsync+rename; `fs2` adds advisory locking as a second safety layer. |
+| `human-panic` | Release-build crash reports for unexpected CLI panics | Comparable CLIs often rely on raw panic output or a single issue-url hook. | `vex` keeps `color-eyre` for recoverable `Result` errors and uses `human-panic` only for unrecoverable release crashes so operators get a stable report path without replacing the normal error-reporting surface. |
 | `portable-pty` | Pseudo-TTY allocation for sandboxed command execution | Comparable CLIs use platform-specific PTY code directly. | vexcoder's command runner needs PTY for interactive tool output (e.g., `git commit` with editor).  `portable-pty` provides cross-platform PTY without platform-specific FFI. |
 | `rmcp` (workspace-managed 1.x requirement) | MCP (Model Context Protocol) client for external tool providers | Comparable CLIs implement MCP transport directly using earlier transport library versions (e.g., pre-1.0). | vexcoder supports `[[mcp_servers]]` config for connecting to external tool providers (ADR-024 PM-01). The root workspace manifest owns the `rmcp` requirement so upgrades stay in one place while the MCP wire contract remains on the stable 1.x line. |
 | `quick-xml` | XML tool-call tag parsing from model output | Comparable CLIs use string-based parsing for tool calls. | vexcoder's stream parser delegates structured XML extraction to `quick-xml` rather than hand-rolling an XML parser.  Conventional for XML processing in Rust. |
+| `tabled` | Interactive task inventory tables in `vex tasks list` | Comparable CLIs often keep ad-hoc line output or JSON-only task listings. | vexcoder keeps `--json` and non-TTY line output stable while giving TTY operators aligned task/session-task columns through one localized renderer in `src/bin/vex.rs`. |
 
 ## Ongoing boundary work
 

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -281,7 +281,7 @@ adopt only when there is a live code path and a focused verification seam.
 | `console-subscriber` | **Deferred** | Useful for local runtime diagnostics, but it is debug-only instrumentation and not part of the shipping transport, auth, or CLI contract. |
 | `tui-textarea`, `tui-input`, `ratatui-image`, `tui-tree-widget`, `tui-logger`, `throbber-widgets-tui`, `ratatui-splash-screen` | **Deferred** | The current editor, transcript, and task-surface code already own these concerns.  A widget-crate swap would be a UI-architecture lane, not a transport follow-up. |
 | `directories`, `config`, `strum`, `bytesize` | **Deferred** | Current config loading, XDG path resolution, enum handling, and byte-count formatting already stay localized in existing repo seams.  Adding alternate helpers now would duplicate working code. |
-| `dialoguer`, `palette` | **Deferred** | These remain plausible polish crates, but there is still no live prompt/theme seam that requires them in the current tree. |
+| `dialoguer`, `palette` | **Deferred** | These remain plausible polish crates, but the current tree still lacks a concrete prompt or theme seam that would justify them without speculative churn. |
 
 ### Vexcoder-specific crates
 

--- a/src/bin/vex.rs
+++ b/src/bin/vex.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 use std::io::{IsTerminal, Read};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
+use tabled::{Table, Tabled};
 use vexcoder::app::{
     run_tui_session, task_graph_rollup_path, todos_rollup_path, write_projection_rollup,
 };
@@ -175,6 +176,15 @@ struct TaskListEntry {
     agent_id: Option<String>,
 }
 
+#[derive(Tabled)]
+struct TaskListTableRow {
+    kind: &'static str,
+    id: String,
+    status: String,
+    origin: String,
+    agent: String,
+}
+
 fn collect_task_entries(working_dir: &Path) -> Result<Vec<TaskListEntry>> {
     let mut entries = Vec::new();
     for file in TaskState::state_files_from(working_dir) {
@@ -199,23 +209,62 @@ fn collect_task_entries(working_dir: &Path) -> Result<Vec<TaskListEntry>> {
     Ok(entries)
 }
 
+fn render_task_entries(entries: &[TaskListEntry], interactive: bool) -> String {
+    if entries.is_empty() {
+        return "[tasks] no saved tasks found".to_string();
+    }
+
+    if interactive {
+        return format_task_entries_table(entries);
+    }
+
+    entries
+        .iter()
+        .map(|entry| {
+            match (
+                entry.kind,
+                entry.parent_task_id.as_deref(),
+                entry.agent_id.as_deref(),
+            ) {
+                ("task", _, _) => format!("task {} status={}", entry.id, entry.status),
+                (_, Some(origin), Some(agent)) => format!(
+                    "session-task {} origin={} agent={} status={}",
+                    entry.id, origin, agent, entry.status
+                ),
+                _ => format!("{} {} status={}", entry.kind, entry.id, entry.status),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn format_task_entries_table(entries: &[TaskListEntry]) -> String {
+    let rows = entries
+        .iter()
+        .map(|entry| TaskListTableRow {
+            kind: entry.kind,
+            id: entry.id.clone(),
+            status: entry.status.clone(),
+            origin: entry
+                .parent_task_id
+                .clone()
+                .unwrap_or_else(|| "-".to_string()),
+            agent: entry.agent_id.clone().unwrap_or_else(|| "-".to_string()),
+        })
+        .collect::<Vec<_>>();
+
+    Table::new(rows).to_string()
+}
+
 fn run_tasks_list(working_dir: &Path, json: bool) -> Result<ExitCode> {
     let entries = collect_task_entries(working_dir)?;
     if json {
         println!("{}", serde_json::to_string_pretty(&entries)?);
-    } else if entries.is_empty() {
-        println!("[tasks] no saved tasks found");
     } else {
-        for entry in entries {
-            match (entry.kind, entry.parent_task_id, entry.agent_id) {
-                ("task", _, _) => println!("task {} status={}", entry.id, entry.status),
-                (_, Some(parent), Some(agent)) => println!(
-                    "session-task {} parent={} agent={} status={}",
-                    entry.id, parent, agent, entry.status
-                ),
-                _ => println!("{} {} status={}", entry.kind, entry.id, entry.status),
-            }
-        }
+        println!(
+            "{}",
+            render_task_entries(&entries, std::io::stdout().is_terminal())
+        );
     }
     Ok(ExitCode::SUCCESS)
 }
@@ -249,7 +298,7 @@ fn run_tasks_watch(working_dir: &Path, id: &str, json: bool) -> Result<ExitCode>
             );
         } else {
             println!(
-                "session-task {} parent={} agent={} status={}",
+                "session-task {} origin={} agent={} status={}",
                 session_task.id, state.id, session_task.agent_id, session_task.lifecycle_state
             );
         }
@@ -276,9 +325,11 @@ fn run_tasks_export_todos(working_dir: &Path) -> Result<ExitCode> {
 
 #[tokio::main]
 async fn main() -> Result<ExitCode> {
-    // Install color-eyre panic hook for pretty backtraces/suggestions.
-    // Errors are ignored here because the handler is optional diagnostic sugar.
-    let _ = color_eyre::install();
+    // Keep human-panic for unexpected release crashes while color-eyre formats
+    // recoverable Result-based failures.
+    human_panic::setup_panic!();
+    let (_, eyre_hook) = color_eyre::config::HookBuilder::default().into_hooks();
+    let _ = eyre_hook.install();
 
     let _log_guard = if std::env::var_os("RUST_LOG").is_some() {
         let file_appender = tracing_appender::rolling::daily(

--- a/src/bin/vex/tests.rs
+++ b/src/bin/vex/tests.rs
@@ -4,8 +4,8 @@
 
 use super::{
     Cli, Commands, CredentialsCommands, MigrateCommands, SkillsCommands,
-    credentials_action_from_cli, emit_migrate_config_output, read_secret_from_env_var,
-    read_secret_from_reader, resolve_resume_state,
+    credentials_action_from_cli, emit_migrate_config_output, format_task_entries_table,
+    read_secret_from_env_var, read_secret_from_reader, render_task_entries, resolve_resume_state,
 };
 use clap::Parser;
 use clap_complete::Shell;
@@ -934,6 +934,51 @@ fn test_resolve_resume_state_explicit_id_falls_back_to_legacy_subdir() {
     assert_eq!(loaded.id, "task-legacy");
 
     std::env::set_current_dir(old_cwd).unwrap();
+}
+
+#[test]
+fn task_list_interactive_render_uses_columns() {
+    let entries = vec![
+        super::TaskListEntry {
+            id: "task-parent".to_string(),
+            status: "Ready".to_string(),
+            kind: "task",
+            parent_task_id: None,
+            agent_id: None,
+        },
+        super::TaskListEntry {
+            id: "task-parent-reviewer-123".to_string(),
+            status: "Running".to_string(),
+            kind: "session-task",
+            parent_task_id: Some("task-parent".to_string()),
+            agent_id: Some("reviewer".to_string()),
+        },
+    ];
+
+    let rendered = format_task_entries_table(&entries);
+
+    assert!(rendered.contains("kind"), "table output: {rendered}");
+    assert!(rendered.contains("origin"), "table output: {rendered}");
+    assert!(rendered.contains("reviewer"), "table output: {rendered}");
+    assert!(rendered.contains("task-parent"), "table output: {rendered}");
+}
+
+#[test]
+fn task_list_noninteractive_render_keeps_line_mode_and_origin_copy() {
+    let entries = vec![super::TaskListEntry {
+        id: "task-parent-reviewer-123".to_string(),
+        status: "Running".to_string(),
+        kind: "session-task",
+        parent_task_id: Some("task-parent".to_string()),
+        agent_id: Some("reviewer".to_string()),
+    }];
+
+    let rendered = render_task_entries(&entries, false);
+
+    assert_eq!(
+        rendered,
+        "session-task task-parent-reviewer-123 origin=task-parent agent=reviewer status=Running"
+    );
 }
 
 // -- PM-03 ----------------------------------------------------------------


### PR DESCRIPTION
## Summary
This PR implements the operator-facing CLI polish lane and fixes manual release packaging for non-tag workflow dispatches.

It adds release-build panic reporting through human-panic, renders vex tasks list as an interactive table when stdout is a TTY, completes the remaining session-task copy normalization from parent to origin on this CLI surface, and makes release.yml derive a valid package version when the workflow is dispatched from a branch.

## Motivation
The current CLI already had concrete seams for two narrowly scoped polish changes:
- release panic reporting at the binary entrypoint
- operator-readable task inventory rendering in vex tasks list

The current tree still lacks a concrete prompt or theme seam that would justify dialoguer or palette without speculative churn, so this PR keeps that dependency lane limited to the parts that are already grounded in the current implementation.

The release workflow also had a concrete manual-dispatch defect: workflow_dispatch on a branch passed GITHUB_REF_NAME such as main into the packaging scripts even though those scripts correctly accept only semver tags, nightly, or 7-character short SHAs.

## Approach
- install human-panic for unrecoverable release panics while keeping color-eyre as the recoverable Result error hook
- render vex tasks list through tabled in interactive terminals while preserving --json output and non-TTY plain-text compatibility
- normalize operator-facing session-task copy from parent= to origin= where this CLI surface exposed lineage text
- add focused CLI tests for interactive table rendering and non-interactive fallback output
- update architecture and roadmap docs so the checked-in rationale matches the implemented tree
- add a Resolve release version step in release.yml so non-tag dispatches use git rev-parse --short=7 HEAD, while tag-triggered runs continue using the actual tag name
- route both the non-Windows and Windows packaging steps through that resolved version value

## Validation
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings
- cargo nextest run -j 2
- inspected the failing manual release.yml run and traced the failure to scripts/release.sh rejecting branch-name versions such as main
- validated the workflow patch for schema and editor errors before push
- confirmed the workflow fix end to end with a fresh workflow_dispatch run on work/vexcoder-cli-polish: release run 24549698572 completed successfully across the packaging matrix

## Risks
- Duplication / missed shared-code opportunity: None identified. The new task-list rendering stays localized in src/bin/vex.rs, and the release-version resolution is centralized in one workflow step instead of duplicating branch/tag logic across packaging calls.
- Unused code: None identified. The new rendering helpers are exercised through focused CLI tests, and the workflow environment value is consumed immediately by the packaging steps.
- Bugs / regression risk: Interactive vex tasks list now renders as a table in TTY mode. Any operator workflow that scrapes the human-readable TTY output should use --json or non-TTY execution instead. The release workflow now changes naming behavior for branch-dispatched packaging runs from branch names to short SHAs.
- Inconsistency with ADRs: None identified. The CLI changes stay within the binary seam, and the workflow change does not alter runtime, transport, or task-state contracts.
- Coverage gaps deferred: dialoguer and palette remain deferred because the current tree still lacks a concrete prompt or theme seam that would justify those crates without speculative churn.
- Build / compile-time impact: Adds human-panic and tabled to the workspace dependency set, increasing compile surface modestly in exchange for localized CLI-only functionality. The workflow fix does not change crate build inputs.
