### PR TITLE
CLI polish: credential prompts and markdown theme seam

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,17 @@ jobs:
             exit 1
           fi
 
+      - name: Resolve release version
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            release_version="${GITHUB_REF_NAME}"
+          else
+            release_version="$(git rev-parse --short=7 HEAD)"
+          fi
+          echo "RELEASE_VERSION=${release_version}" >> "$GITHUB_ENV"
+
       - name: Run gate (non-Windows)
         if: runner.os != 'Windows'
         shell: bash
@@ -139,8 +150,7 @@ jobs:
           TARGET: ${{ matrix.target }}
           OUT_DIR: dist
           BUILD_TOOL: ${{ matrix.build_tool }}
-          VERSION: ${{ github.ref_name }}
-        run: bash scripts/release.sh
+        run: VERSION="${RELEASE_VERSION}" bash scripts/release.sh
 
       - name: Package release archive (Windows)
         if: runner.os == 'Windows'
@@ -149,7 +159,7 @@ jobs:
           TARGET: ${{ matrix.target }}
           OUT_DIR: dist
         run: |
-          .\scripts\release.ps1 -Version $env:GITHUB_REF_NAME -Target $env:TARGET -OutDir $env:OUT_DIR
+          .\scripts\release.ps1 -Version $env:RELEASE_VERSION -Target $env:TARGET -OutDir $env:OUT_DIR
 
       - name: Upload dist artifact
         uses: actions/upload-artifact@v6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,6 +490,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
 name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,6 +783,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
+ "unicode-width",
  "windows-sys 0.61.2",
 ]
 
@@ -1053,6 +1069,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
+name = "dialoguer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
+dependencies = [
+ "console 0.16.3",
+ "shell-words",
+ "tempfile",
+ "zeroize",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1263,6 +1291,12 @@ dependencies = [
  "regex-automata",
  "regex-syntax",
 ]
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "faster-hex"
@@ -3835,6 +3869,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "palette_derive",
+ "phf",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "papergrid"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6013,6 +6071,7 @@ dependencies = [
  "console 0.15.11",
  "crossbeam-channel",
  "crossterm",
+ "dialoguer",
  "dirs",
  "dunce",
  "eventsource-client",
@@ -6046,6 +6105,7 @@ dependencies = [
  "notify",
  "oauth2",
  "open",
+ "palette",
  "pathdiff",
  "portable-pty",
  "pretty_assertions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,6 +481,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2653,6 +2659,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "human-panic"
+version = "2.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2815d0c49773c6e0a9753960b3d0e50b822e48e08c77bcb4780be8474c9cc3d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "backtrace",
+ "serde",
+ "serde_derive",
+ "sysinfo",
+ "toml 1.1.2+spec-1.1.0",
+ "uuid",
+]
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3568,6 +3590,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3715,6 +3746,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-io-surface"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3792,6 +3833,17 @@ name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
+name = "papergrid"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6978128c8b51d8f4080631ceb2302ab51e32cc6e8615f735ee2f83fd269ae3f1"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width",
+]
 
 [[package]]
 name = "parking_lot"
@@ -4094,6 +4146,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -4868,6 +4942,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5194,6 +5277,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
+]
+
+[[package]]
+name = "tabled"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e39a2ee1fbcd360805a771e1b300f78cc88fec7b8d3e2f71cd37bbf23e725c7d"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+ "testing_table",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846"
+dependencies = [
+ "heck",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5283,6 +5404,15 @@ dependencies = [
  "wezterm-dynamic",
  "wezterm-input-types",
  "winapi",
+]
+
+[[package]]
+name = "testing_table"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -5482,9 +5612,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_writer",
 ]
 
 [[package]]
@@ -5497,6 +5639,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5504,8 +5655,8 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
  "winnow",
 ]
@@ -5515,6 +5666,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -5874,6 +6031,7 @@ dependencies = [
  "hickory-resolver",
  "http 1.4.0",
  "httpdate",
+ "human-panic",
  "hyper",
  "hyper-util",
  "ignore",
@@ -5905,6 +6063,7 @@ dependencies = [
  "similar",
  "strip-ansi-escapes",
  "syntect",
+ "tabled",
  "tempfile",
  "textwrap",
  "thiserror 2.0.18",
@@ -5912,7 +6071,7 @@ dependencies = [
  "tokio-rustls 0.26.4",
  "tokio-stream",
  "tokio-util",
- "toml",
+ "toml 0.8.23",
  "tower",
  "tower-http",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,10 +110,12 @@ x509-parser = "0.18"
 arboard = { version = "3", default-features = false }
 color-eyre = "0.6"
 human-panic = "2"
+dialoguer = "0.12"
 dirs = "6"
 tracing-appender = "0.2"
 similar = "2"
 pulldown-cmark = { version = "0.13", default-features = false }
+palette = "0.7"
 syntect = { version = "5", default-features = false, features = [
   "default-fancy",
 ] }
@@ -215,9 +217,11 @@ serde = [
 arboard = ["src/clipboard.rs", "src/app/commands/session.rs"]
 # Markdown rendering stack — both crates are consumed together at one site.
 pulldown-cmark = ["src/ui/render/markdown.rs"]
+palette = ["src/ui/render/markdown.rs"]
 syntect = ["src/ui/render/markdown.rs"]
 # CLI panic/reporting polish — release panic hook and interactive task table.
 human-panic = ["src/bin/vex.rs"]
+dialoguer = ["src/bin/vex.rs"]
 tabled = ["src/bin/vex.rs"]
 # TUI text bridge — converts ANSI escape sequences to ratatui spans.
 ansi-to-tui = ["src/ui/tui.rs"]
@@ -256,6 +260,7 @@ tokio = "Runtime helpers are localized in src/runtime/tokio.rs; attribute macros
 tree-sitter = "All five grammar crates share the same seam (src/tools/index.rs); bump them together."
 gix = "The four gix-* sub-crates share the same seam (src/runtime/git_rollup.rs); coordinate their bumps."
 pulldown-cmark = "pulldown-cmark and syntect share src/ui/render/markdown.rs; check both when either changes."
+palette = "Semantic markdown accent derivation stays localized in src/ui/render/markdown.rs."
 async-compression = "Compression and decompression wiring stays localized in src/net/compression.rs, including output-cap enforcement."
 hickory-resolver = "DoH resolver configuration and rustls-dependent DNS wiring stay localized in src/net/dns.rs."
 jsonwebtoken = "JWT/JWS helpers stay localized in src/net/jwt.rs; keep RFC 7519 audience parsing and expiry semantics aligned when upgrading."
@@ -263,6 +268,7 @@ oauth2 = "Native-app PKCE generation, authorization URL assembly, and the custom
 open = "Browser-launch helpers for RFC 8252 native-app authorization stay localized in src/net/oauth.rs."
 reqwest = "Core HTTP client seams remain in src/api/client/mod.rs, src/net/http_client.rs, and src/server/, with proxy-specific URL handling isolated in src/net/proxy.rs."
 human-panic = "The release-build panic path stays localized in src/bin/vex.rs so panic-hook ownership remains explicit alongside color-eyre's eyre hook."
+dialoguer = "Interactive credential-secret entry stays localized in src/bin/vex.rs; keep hidden TTY prompts on the CLI credential path only."
 tabled = "Interactive task-list rendering stays localized in src/bin/vex.rs; non-TTY and --json output remain separate compatibility paths."
 
 [package]
@@ -334,6 +340,7 @@ arboard.workspace = true
 # --- diagnostics, path utilities, diff rendering ---
 color-eyre.workspace = true
 human-panic.workspace = true
+dialoguer.workspace = true
 dirs.workspace = true
 tracing-appender.workspace = true
 similar.workspace = true
@@ -341,6 +348,7 @@ similar.workspace = true
 # --- rich terminal rendering ---
 ratatui-macros.workspace = true
 pulldown-cmark.workspace = true
+palette.workspace = true
 syntect.workspace = true
 indicatif.workspace = true
 console.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ tree-sitter-rust = "0.24"
 x509-parser = "0.18"
 arboard = { version = "3", default-features = false }
 color-eyre = "0.6"
+human-panic = "2"
 dirs = "6"
 tracing-appender = "0.2"
 similar = "2"
@@ -118,6 +119,7 @@ syntect = { version = "5", default-features = false, features = [
 ] }
 indicatif = "0.17"
 console = "0.15"
+tabled = "0.20"
 ignore = "0.4"
 globset = "0.4"
 pathdiff = "0.2"
@@ -214,6 +216,9 @@ arboard = ["src/clipboard.rs", "src/app/commands/session.rs"]
 # Markdown rendering stack — both crates are consumed together at one site.
 pulldown-cmark = ["src/ui/render/markdown.rs"]
 syntect = ["src/ui/render/markdown.rs"]
+# CLI panic/reporting polish — release panic hook and interactive task table.
+human-panic = ["src/bin/vex.rs"]
+tabled = ["src/bin/vex.rs"]
 # TUI text bridge — converts ANSI escape sequences to ratatui spans.
 ansi-to-tui = ["src/ui/tui.rs"]
 # Network wrappers — focused seams for transport-related helper crates.
@@ -257,6 +262,8 @@ jsonwebtoken = "JWT/JWS helpers stay localized in src/net/jwt.rs; keep RFC 7519 
 oauth2 = "Native-app PKCE generation, authorization URL assembly, and the custom async token-exchange adapter stay localized in src/net/oauth.rs."
 open = "Browser-launch helpers for RFC 8252 native-app authorization stay localized in src/net/oauth.rs."
 reqwest = "Core HTTP client seams remain in src/api/client/mod.rs, src/net/http_client.rs, and src/server/, with proxy-specific URL handling isolated in src/net/proxy.rs."
+human-panic = "The release-build panic path stays localized in src/bin/vex.rs so panic-hook ownership remains explicit alongside color-eyre's eyre hook."
+tabled = "Interactive task-list rendering stays localized in src/bin/vex.rs; non-TTY and --json output remain separate compatibility paths."
 
 [package]
 name = "vexcoder"
@@ -326,6 +333,7 @@ arboard.workspace = true
 
 # --- diagnostics, path utilities, diff rendering ---
 color-eyre.workspace = true
+human-panic.workspace = true
 dirs.workspace = true
 tracing-appender.workspace = true
 similar.workspace = true
@@ -336,6 +344,7 @@ pulldown-cmark.workspace = true
 syntect.workspace = true
 indicatif.workspace = true
 console.workspace = true
+tabled.workspace = true
 
 # --- workspace navigation and path normalization ---
 ignore.workspace = true

--- a/TASKS/ACTIVE-ROADMAP.md
+++ b/TASKS/ACTIVE-ROADMAP.md
@@ -207,7 +207,7 @@ without changing machine-facing lifecycle values or diff color semantics.
   display-only.
 - Do not rename code symbols, persisted schema fields, or JSON payload keys.
 
-Concrete targets (7 display-facing strings across 4 files):
+Concrete targets (6 display-facing strings across 3 files):
 
 | File | Count | Terms to normalize |
 | :--- | :--- | :--- |

--- a/TASKS/ACTIVE-ROADMAP.md
+++ b/TASKS/ACTIVE-ROADMAP.md
@@ -207,12 +207,11 @@ without changing machine-facing lifecycle values or diff color semantics.
   display-only.
 - Do not rename code symbols, persisted schema fields, or JSON payload keys.
 
-Concrete targets (9 display-facing strings across 5 files):
+Concrete targets (7 display-facing strings across 4 files):
 
 | File | Count | Terms to normalize |
 | :--- | :--- | :--- |
 | `src/app/commands/mod.rs` | 3 | `parent=` -> `origin=` in watch lines; `branched from` -> `derived from`; `fork aborted` -> `fork halted` |
-| `src/bin/vex.rs` | 2 | `parent=` -> `origin=` in session-task status lines |
 | `src/app/model_update.rs` | 1 | `aborted` -> `halted` in edit loop approval denial |
 | `src/app/input.rs` | 2 | `busy` -> `occupied` in turn-in-progress status lines |
 

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -281,7 +281,8 @@ adopt only when there is a live code path and a focused verification seam.
 | `console-subscriber` | **Deferred** | Useful for local runtime diagnostics, but it is debug-only instrumentation and not part of the shipping transport, auth, or CLI contract. |
 | `tui-textarea`, `tui-input`, `ratatui-image`, `tui-tree-widget`, `tui-logger`, `throbber-widgets-tui`, `ratatui-splash-screen` | **Deferred** | The current editor, transcript, and task-surface code already own these concerns.  A widget-crate swap would be a UI-architecture lane, not a transport follow-up. |
 | `directories`, `config`, `strum`, `bytesize` | **Deferred** | Current config loading, XDG path resolution, enum handling, and byte-count formatting already stay localized in existing repo seams.  Adding alternate helpers now would duplicate working code. |
-| `dialoguer`, `palette` | **Deferred** | These remain plausible polish crates, but the current tree still lacks a concrete prompt or theme seam that would justify them without speculative churn. |
+| `dialoguer` | **Adopted now** | Hidden credential entry belongs on the CLI-only credential-management seam in `src/bin/vex.rs`, where interactive TTY operators can enter secrets without argv or environment-variable exposure. |
+| `palette` | **Adopted now** | Semantic markdown accent derivation now stays localized in `src/ui/render/markdown.rs`, replacing scattered hard-coded colors with one renderer-owned theme seam. |
 
 ### Vexcoder-specific crates
 

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -281,7 +281,7 @@ adopt only when there is a live code path and a focused verification seam.
 | `console-subscriber` | **Deferred** | Useful for local runtime diagnostics, but it is debug-only instrumentation and not part of the shipping transport, auth, or CLI contract. |
 | `tui-textarea`, `tui-input`, `ratatui-image`, `tui-tree-widget`, `tui-logger`, `throbber-widgets-tui`, `ratatui-splash-screen` | **Deferred** | The current editor, transcript, and task-surface code already own these concerns.  A widget-crate swap would be a UI-architecture lane, not a transport follow-up. |
 | `directories`, `config`, `strum`, `bytesize` | **Deferred** | Current config loading, XDG path resolution, enum handling, and byte-count formatting already stay localized in existing repo seams.  Adding alternate helpers now would duplicate working code. |
-| `human-panic`, `dialoguer`, `tabled`, `palette` | **Deferred** | These are reasonable polish crates, but they do not close a current RFC or transport gap and would broaden the PR beyond the active follow-up lane. |
+| `dialoguer`, `palette` | **Deferred** | These remain plausible polish crates, but there is still no live prompt/theme seam that requires them in the current tree. |
 
 ### Vexcoder-specific crates
 
@@ -293,9 +293,11 @@ a design need specific to vexcoder's architecture.
 | `axum` | HTTP routing and handler composition for the local API server surface | Comparable CLIs may use a thinner direct HTTP surface or a different server seam. | `axum` is already the active server foundation in vexcoder; `tower-http` sits on top of it for request tracing, not in place of it. |
 | `tower-http` | `TraceLayer` HTTP middleware for the local API server (`src/server/http.rs`) | Comparable CLIs use axum directly without tower middleware.  vexcoder's `LocalApiServer` (ADR-026) requires request/response tracing for debugging multi-agent sessions. | Conventional for axum-based servers needing observability. |
 | `fs2` | File-locking for `.vex/state/` durable writes | Comparable CLIs use a different persistence model. | Prevents concurrent vexcoder sessions from corrupting task-state files.  `write_json_safe` uses temp+fsync+rename; `fs2` adds advisory locking as a second safety layer. |
+| `human-panic` | Release-build crash reports for unexpected CLI panics | Comparable CLIs often rely on raw panic output or a single issue-url hook. | `vex` keeps `color-eyre` for recoverable `Result` errors and uses `human-panic` only for unrecoverable release crashes so operators get a stable report path without replacing the normal error-reporting surface. |
 | `portable-pty` | Pseudo-TTY allocation for sandboxed command execution | Comparable CLIs use platform-specific PTY code directly. | vexcoder's command runner needs PTY for interactive tool output (e.g., `git commit` with editor).  `portable-pty` provides cross-platform PTY without platform-specific FFI. |
 | `rmcp` (workspace-managed 1.x requirement) | MCP (Model Context Protocol) client for external tool providers | Comparable CLIs implement MCP transport directly using earlier transport library versions (e.g., pre-1.0). | vexcoder supports `[[mcp_servers]]` config for connecting to external tool providers (ADR-024 PM-01). The root workspace manifest owns the `rmcp` requirement so upgrades stay in one place while the MCP wire contract remains on the stable 1.x line. |
 | `quick-xml` | XML tool-call tag parsing from model output | Comparable CLIs use string-based parsing for tool calls. | vexcoder's stream parser delegates structured XML extraction to `quick-xml` rather than hand-rolling an XML parser.  Conventional for XML processing in Rust. |
+| `tabled` | Interactive task inventory tables in `vex tasks list` | Comparable CLIs often keep ad-hoc line output or JSON-only task listings. | vexcoder keeps `--json` and non-TTY line output stable while giving TTY operators aligned task/session-task columns through one localized renderer in `src/bin/vex.rs`. |
 
 ## Ongoing boundary work
 

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -281,7 +281,7 @@ adopt only when there is a live code path and a focused verification seam.
 | `console-subscriber` | **Deferred** | Useful for local runtime diagnostics, but it is debug-only instrumentation and not part of the shipping transport, auth, or CLI contract. |
 | `tui-textarea`, `tui-input`, `ratatui-image`, `tui-tree-widget`, `tui-logger`, `throbber-widgets-tui`, `ratatui-splash-screen` | **Deferred** | The current editor, transcript, and task-surface code already own these concerns.  A widget-crate swap would be a UI-architecture lane, not a transport follow-up. |
 | `directories`, `config`, `strum`, `bytesize` | **Deferred** | Current config loading, XDG path resolution, enum handling, and byte-count formatting already stay localized in existing repo seams.  Adding alternate helpers now would duplicate working code. |
-| `dialoguer`, `palette` | **Deferred** | These remain plausible polish crates, but there is still no live prompt/theme seam that requires them in the current tree. |
+| `dialoguer`, `palette` | **Deferred** | These remain plausible polish crates, but the current tree still lacks a concrete prompt or theme seam that would justify them without speculative churn. |
 
 ### Vexcoder-specific crates
 

--- a/src/bin/vex.rs
+++ b/src/bin/vex.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 use std::io::{IsTerminal, Read};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
+use tabled::{Table, Tabled};
 use vexcoder::app::{
     run_tui_session, task_graph_rollup_path, todos_rollup_path, write_projection_rollup,
 };
@@ -175,6 +176,15 @@ struct TaskListEntry {
     agent_id: Option<String>,
 }
 
+#[derive(Tabled)]
+struct TaskListTableRow {
+    kind: &'static str,
+    id: String,
+    status: String,
+    origin: String,
+    agent: String,
+}
+
 fn collect_task_entries(working_dir: &Path) -> Result<Vec<TaskListEntry>> {
     let mut entries = Vec::new();
     for file in TaskState::state_files_from(working_dir) {
@@ -199,23 +209,62 @@ fn collect_task_entries(working_dir: &Path) -> Result<Vec<TaskListEntry>> {
     Ok(entries)
 }
 
+fn render_task_entries(entries: &[TaskListEntry], interactive: bool) -> String {
+    if entries.is_empty() {
+        return "[tasks] no saved tasks found".to_string();
+    }
+
+    if interactive {
+        return format_task_entries_table(entries);
+    }
+
+    entries
+        .iter()
+        .map(|entry| {
+            match (
+                entry.kind,
+                entry.parent_task_id.as_deref(),
+                entry.agent_id.as_deref(),
+            ) {
+                ("task", _, _) => format!("task {} status={}", entry.id, entry.status),
+                (_, Some(origin), Some(agent)) => format!(
+                    "session-task {} origin={} agent={} status={}",
+                    entry.id, origin, agent, entry.status
+                ),
+                _ => format!("{} {} status={}", entry.kind, entry.id, entry.status),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn format_task_entries_table(entries: &[TaskListEntry]) -> String {
+    let rows = entries
+        .iter()
+        .map(|entry| TaskListTableRow {
+            kind: entry.kind,
+            id: entry.id.clone(),
+            status: entry.status.clone(),
+            origin: entry
+                .parent_task_id
+                .clone()
+                .unwrap_or_else(|| "-".to_string()),
+            agent: entry.agent_id.clone().unwrap_or_else(|| "-".to_string()),
+        })
+        .collect::<Vec<_>>();
+
+    Table::new(rows).to_string()
+}
+
 fn run_tasks_list(working_dir: &Path, json: bool) -> Result<ExitCode> {
     let entries = collect_task_entries(working_dir)?;
     if json {
         println!("{}", serde_json::to_string_pretty(&entries)?);
-    } else if entries.is_empty() {
-        println!("[tasks] no saved tasks found");
     } else {
-        for entry in entries {
-            match (entry.kind, entry.parent_task_id, entry.agent_id) {
-                ("task", _, _) => println!("task {} status={}", entry.id, entry.status),
-                (_, Some(parent), Some(agent)) => println!(
-                    "session-task {} parent={} agent={} status={}",
-                    entry.id, parent, agent, entry.status
-                ),
-                _ => println!("{} {} status={}", entry.kind, entry.id, entry.status),
-            }
-        }
+        println!(
+            "{}",
+            render_task_entries(&entries, std::io::stdout().is_terminal())
+        );
     }
     Ok(ExitCode::SUCCESS)
 }
@@ -249,7 +298,7 @@ fn run_tasks_watch(working_dir: &Path, id: &str, json: bool) -> Result<ExitCode>
             );
         } else {
             println!(
-                "session-task {} parent={} agent={} status={}",
+                "session-task {} origin={} agent={} status={}",
                 session_task.id, state.id, session_task.agent_id, session_task.lifecycle_state
             );
         }
@@ -276,9 +325,11 @@ fn run_tasks_export_todos(working_dir: &Path) -> Result<ExitCode> {
 
 #[tokio::main]
 async fn main() -> Result<ExitCode> {
-    // Install color-eyre panic hook for pretty backtraces/suggestions.
-    // Errors are ignored here because the handler is optional diagnostic sugar.
-    let _ = color_eyre::install();
+    // Keep human-panic for unexpected release crashes while color-eyre formats
+    // recoverable Result-based failures.
+    human_panic::setup_panic!();
+    let (_, eyre_hook) = color_eyre::config::HookBuilder::default().into_hooks();
+    let _ = eyre_hook.install();
 
     let _log_guard = if std::env::var_os("RUST_LOG").is_some() {
         let file_appender = tracing_appender::rolling::daily(

--- a/src/bin/vex.rs
+++ b/src/bin/vex.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result, bail};
 use clap::{CommandFactory, Parser};
+use dialoguer::Password;
 use serde::Serialize;
 use std::io::{IsTerminal, Read};
 use std::path::{Path, PathBuf};
@@ -110,6 +111,41 @@ fn read_secret_from_env_var(name: &str) -> Result<String> {
         .with_context(|| format!("environment variable '{name}' is not set or is not valid UTF-8"))
 }
 
+fn can_prompt_for_secret() -> bool {
+    std::io::stdin().is_terminal() && std::io::stderr().is_terminal()
+}
+
+fn read_secret_from_tty_prompt(account: &str) -> Result<String> {
+    Password::new()
+        .with_prompt(format!("Credential secret for {account}"))
+        .with_confirmation(
+            "Confirm credential secret",
+            "credential secrets did not match",
+        )
+        .interact()
+        .context("failed to read credential secret interactively")
+}
+
+fn resolve_credentials_secret(
+    account: &str,
+    stdin: bool,
+    from_env: Option<String>,
+    can_prompt: bool,
+    prompt_secret: impl FnOnce(&str) -> Result<String>,
+) -> Result<String> {
+    if stdin {
+        read_secret_from_stdin()
+    } else if let Some(var_name) = from_env {
+        read_secret_from_env_var(&var_name)
+    } else if can_prompt {
+        prompt_secret(account)
+    } else {
+        bail!(
+            "refusing to read a credential secret from argv; use --stdin, --from-env VAR, or rerun on an interactive TTY"
+        )
+    }
+}
+
 fn credentials_action_from_cli(
     sub: CredentialsCommands,
 ) -> Result<vexcoder::credentials::CredentialsAction> {
@@ -121,15 +157,13 @@ fn credentials_action_from_cli(
             stdin,
             from_env,
         } => {
-            let secret = if stdin {
-                read_secret_from_stdin()?
-            } else if let Some(var_name) = from_env {
-                read_secret_from_env_var(&var_name)?
-            } else {
-                bail!(
-                    "refusing to read a credential secret from argv; use --stdin or --from-env VAR"
-                );
-            };
+            let secret = resolve_credentials_secret(
+                &account,
+                stdin,
+                from_env,
+                can_prompt_for_secret(),
+                read_secret_from_tty_prompt,
+            )?;
             Ok(CredentialsAction::Set { account, secret })
         }
         CredentialsCommands::Get { account } => Ok(CredentialsAction::Get { account }),

--- a/src/bin/vex/cli.rs
+++ b/src/bin/vex/cli.rs
@@ -133,6 +133,8 @@ pub(super) enum CredentialsCommands {
     ///
     /// Example:
     /// `printf '%s' "$VEX_MODEL_TOKEN" | vex credentials set model-token --stdin`
+    /// If no flag is passed on an interactive TTY, vex prompts for the secret
+    /// without echoing it.
     Set {
         /// Account identifier (e.g., `model-token`).
         account: String,

--- a/src/bin/vex/tests.rs
+++ b/src/bin/vex/tests.rs
@@ -4,8 +4,9 @@
 
 use super::{
     Cli, Commands, CredentialsCommands, MigrateCommands, SkillsCommands,
-    credentials_action_from_cli, emit_migrate_config_output, format_task_entries_table,
-    read_secret_from_env_var, read_secret_from_reader, render_task_entries, resolve_resume_state,
+    emit_migrate_config_output, format_task_entries_table, read_secret_from_env_var,
+    read_secret_from_reader, render_task_entries,
+    resolve_credentials_secret, resolve_resume_state,
 };
 use clap::Parser;
 use clap_complete::Shell;
@@ -1111,13 +1112,20 @@ fn test_credentials_set_cli_rejects_positional_secret() {
 
 #[test]
 fn test_credentials_action_from_cli_requires_non_argv_secret_source() {
-    let err = credentials_action_from_cli(CredentialsCommands::Set {
-        account: "model-token".to_string(),
-        stdin: false,
-        from_env: None,
-    })
-    .unwrap_err();
+    let err = resolve_credentials_secret("model-token", false, None, false, |_| unreachable!())
+        .unwrap_err();
     assert!(err.to_string().contains("--stdin") || err.to_string().contains("--from-env"));
+}
+
+#[test]
+fn test_resolve_credentials_secret_uses_interactive_prompt_when_tty_available() {
+    let secret = resolve_credentials_secret("model-token", false, None, true, |account| {
+        assert_eq!(account, "model-token");
+        Ok("prompt-secret".to_string())
+    })
+    .expect("interactive secret");
+
+    assert_eq!(secret, "prompt-secret");
 }
 
 #[test]

--- a/src/bin/vex/tests.rs
+++ b/src/bin/vex/tests.rs
@@ -5,8 +5,7 @@
 use super::{
     Cli, Commands, CredentialsCommands, MigrateCommands, SkillsCommands,
     emit_migrate_config_output, format_task_entries_table, read_secret_from_env_var,
-    read_secret_from_reader, render_task_entries,
-    resolve_credentials_secret, resolve_resume_state,
+    read_secret_from_reader, render_task_entries, resolve_credentials_secret, resolve_resume_state,
 };
 use clap::Parser;
 use clap_complete::Shell;

--- a/src/bin/vex/tests.rs
+++ b/src/bin/vex/tests.rs
@@ -4,8 +4,8 @@
 
 use super::{
     Cli, Commands, CredentialsCommands, MigrateCommands, SkillsCommands,
-    credentials_action_from_cli, emit_migrate_config_output, read_secret_from_env_var,
-    read_secret_from_reader, resolve_resume_state,
+    credentials_action_from_cli, emit_migrate_config_output, format_task_entries_table,
+    read_secret_from_env_var, read_secret_from_reader, render_task_entries, resolve_resume_state,
 };
 use clap::Parser;
 use clap_complete::Shell;
@@ -934,6 +934,51 @@ fn test_resolve_resume_state_explicit_id_falls_back_to_legacy_subdir() {
     assert_eq!(loaded.id, "task-legacy");
 
     std::env::set_current_dir(old_cwd).unwrap();
+}
+
+#[test]
+fn task_list_interactive_render_uses_columns() {
+    let entries = vec![
+        super::TaskListEntry {
+            id: "task-parent".to_string(),
+            status: "Ready".to_string(),
+            kind: "task",
+            parent_task_id: None,
+            agent_id: None,
+        },
+        super::TaskListEntry {
+            id: "task-parent-reviewer-123".to_string(),
+            status: "Running".to_string(),
+            kind: "session-task",
+            parent_task_id: Some("task-parent".to_string()),
+            agent_id: Some("reviewer".to_string()),
+        },
+    ];
+
+    let rendered = format_task_entries_table(&entries);
+
+    assert!(rendered.contains("kind"), "table output: {rendered}");
+    assert!(rendered.contains("origin"), "table output: {rendered}");
+    assert!(rendered.contains("reviewer"), "table output: {rendered}");
+    assert!(rendered.contains("task-parent"), "table output: {rendered}");
+}
+
+#[test]
+fn task_list_noninteractive_render_keeps_line_mode_and_origin_copy() {
+    let entries = vec![super::TaskListEntry {
+        id: "task-parent-reviewer-123".to_string(),
+        status: "Running".to_string(),
+        kind: "session-task",
+        parent_task_id: Some("task-parent".to_string()),
+        agent_id: Some("reviewer".to_string()),
+    }];
+
+    let rendered = render_task_entries(&entries, false);
+
+    assert_eq!(
+        rendered,
+        "session-task task-parent-reviewer-123 origin=task-parent agent=reviewer status=Running"
+    );
 }
 
 // -- PM-03 ----------------------------------------------------------------

--- a/src/ui/render/markdown.rs
+++ b/src/ui/render/markdown.rs
@@ -1,3 +1,4 @@
+use palette::{Mix, Srgb};
 use pulldown_cmark::{Event, Parser, Tag, TagEnd};
 use std::sync::OnceLock;
 use syntect::highlighting::{Theme, ThemeSet};
@@ -14,6 +15,27 @@ use crate::ui::tui::{
 
 static MARKDOWN_SYNTAX_SET: OnceLock<SyntaxSet> = OnceLock::new();
 static MARKDOWN_THEME_SET: OnceLock<ThemeSet> = OnceLock::new();
+static MARKDOWN_SEMANTIC_PALETTE: OnceLock<MarkdownSemanticPalette> = OnceLock::new();
+
+#[derive(Clone, Copy)]
+struct MarkdownSemanticPalette {
+    heading_h1: Color,
+    heading_h2: Color,
+    heading_h3: Color,
+    bullet: Color,
+    inline_code: Color,
+    code_fallback: Color,
+}
+
+impl MarkdownSemanticPalette {
+    fn heading_color(self, level: pulldown_cmark::HeadingLevel) -> Color {
+        match level {
+            pulldown_cmark::HeadingLevel::H1 => self.heading_h1,
+            pulldown_cmark::HeadingLevel::H2 => self.heading_h2,
+            _ => self.heading_h3,
+        }
+    }
+}
 
 /// Parse a single logical markdown row when it can be rendered as one line.
 pub fn markdown_to_inline_line(input: &str) -> Option<Line<'static>> {
@@ -30,6 +52,7 @@ pub fn markdown_to_inline_line(input: &str) -> Option<Line<'static>> {
 pub fn markdown_to_lines(input: &str) -> Vec<Line<'static>> {
     let ss = markdown_syntax_set();
     let theme = markdown_theme();
+    let palette = markdown_semantic_palette();
 
     let parser = Parser::new(input);
     let mut lines: Vec<Line<'static>> = Vec::new();
@@ -43,11 +66,7 @@ pub fn markdown_to_lines(input: &str) -> Vec<Line<'static>> {
         match event {
             Event::Start(Tag::Heading { level, .. }) => {
                 flush_line(&mut current_spans, &mut lines);
-                let color = match level {
-                    pulldown_cmark::HeadingLevel::H1 => Color::Yellow,
-                    pulldown_cmark::HeadingLevel::H2 => Color::Cyan,
-                    _ => Color::Green,
-                };
+                let color = palette.heading_color(level);
                 style_stack.push(Style::default().fg(color).add_modifier(Modifier::BOLD));
             }
             Event::End(TagEnd::Heading(_)) => {
@@ -81,7 +100,7 @@ pub fn markdown_to_lines(input: &str) -> Vec<Line<'static>> {
                 } else {
                     for source_line in code_buffer.lines() {
                         lines.push(line![
-                            span!(Style::default().fg(Color::Gray); "{source_line}")
+                            span!(Style::default().fg(palette.code_fallback); "{source_line}")
                         ]);
                     }
                 }
@@ -98,7 +117,7 @@ pub fn markdown_to_lines(input: &str) -> Vec<Line<'static>> {
             Event::Code(code) => {
                 current_spans.push(span!(
                     Style::default()
-                        .fg(Color::Magenta)
+                        .fg(palette.inline_code)
                         .add_modifier(Modifier::BOLD);
                     "`{code}`"
                 ));
@@ -112,7 +131,7 @@ pub fn markdown_to_lines(input: &str) -> Vec<Line<'static>> {
                 lines.push(Line::from(""));
             }
             Event::Start(Tag::Item) => {
-                current_spans.push(span!(Color::Yellow; "  • "));
+                current_spans.push(span!(palette.bullet; "  • "));
             }
             Event::End(TagEnd::Item) => {
                 flush_line(&mut current_spans, &mut lines);
@@ -136,8 +155,41 @@ fn markdown_theme() -> Option<&'static Theme> {
         .or_else(|| themes.themes.values().next())
 }
 
+fn markdown_semantic_palette() -> &'static MarkdownSemanticPalette {
+    MARKDOWN_SEMANTIC_PALETTE.get_or_init(|| {
+        let ocean = srgb(0x8f, 0xbc, 0xbb);
+        let amber = srgb(0xeb, 0xcb, 0x8b);
+        let sky = srgb(0x81, 0xa1, 0xc1);
+        let moss = srgb(0xa3, 0xbe, 0x8c);
+        let blossom = srgb(0xb4, 0x8e, 0xad);
+        let slate = srgb(0x4c, 0x56, 0x6a);
+
+        MarkdownSemanticPalette {
+            heading_h1: ratatui_color(ocean.mix(amber, 0.8)),
+            heading_h2: ratatui_color(ocean.mix(sky, 0.65)),
+            heading_h3: ratatui_color(ocean.mix(moss, 0.6)),
+            bullet: ratatui_color(ocean.mix(amber, 0.55)),
+            inline_code: ratatui_color(ocean.mix(blossom, 0.7)),
+            code_fallback: ratatui_color(slate.mix(sky, 0.35)),
+        }
+    })
+}
+
 fn current_style(stack: &[Style]) -> Style {
     stack.last().copied().unwrap_or_default()
+}
+
+fn srgb(red: u8, green: u8, blue: u8) -> Srgb<f32> {
+    Srgb::new(
+        red as f32 / 255.0,
+        green as f32 / 255.0,
+        blue as f32 / 255.0,
+    )
+}
+
+fn ratatui_color(color: Srgb<f32>) -> Color {
+    let bytes = color.into_format::<u8>();
+    Color::Rgb(bytes.red, bytes.green, bytes.blue)
 }
 
 fn flush_line(spans: &mut Vec<Span<'static>>, lines: &mut Vec<Line<'static>>) {
@@ -172,7 +224,7 @@ fn highlight_code_block(
             Err(_) => {
                 lines.push(Line::styled(
                     source_line.to_string(),
-                    Style::default().fg(Color::Gray),
+                    Style::default().fg(markdown_semantic_palette().code_fallback),
                 ));
             }
         }
@@ -198,7 +250,10 @@ mod tests {
             .collect();
 
         assert_eq!(text, "Heading");
-        assert_eq!(line.spans[0].style.fg, Some(Color::Cyan));
+        assert_eq!(
+            line.spans[0].style.fg,
+            Some(markdown_semantic_palette().heading_h2)
+        );
     }
 
     #[test]
@@ -211,5 +266,20 @@ mod tests {
         let lines = markdown_to_lines("```rust\nfn main() {}\n```");
 
         assert!(!lines.is_empty());
+    }
+
+    #[test]
+    fn markdown_to_inline_line_uses_semantic_palette_for_inline_code() {
+        let line = markdown_to_inline_line("Use `cargo fmt`").expect("single inline-code line");
+        let code_span = line
+            .spans
+            .iter()
+            .find(|span| span.content.as_ref().contains("`cargo fmt`"))
+            .expect("inline code span");
+
+        assert_eq!(
+            code_span.style.fg,
+            Some(markdown_semantic_palette().inline_code)
+        );
     }
 }

--- a/src/ui/render/tests.rs
+++ b/src/ui/render/tests.rs
@@ -569,6 +569,8 @@ fn transcript_output_line_defaults_plain_text_to_white() {
 #[test]
 fn transcript_output_line_styles_single_line_markdown_without_dropping_rows() {
     use crate::app::TranscriptRow;
+    let expected = crate::ui::render::markdown::markdown_to_inline_line("## Heading")
+        .expect("single heading line");
     let heading = transcript_output_line(&TranscriptRow::AssistantText {
         text: "## Heading".to_string(),
         streaming: false,
@@ -580,7 +582,7 @@ fn transcript_output_line_styles_single_line_markdown_without_dropping_rows() {
         .collect();
 
     assert_eq!(text, "Heading");
-    assert_eq!(heading.spans[0].style.fg, Some(Color::Cyan));
+    assert_eq!(heading.spans[0].style.fg, expected.spans[0].style.fg);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds two operator-facing seams deferred from prior reviews: hidden-secret credential prompting on the CLI path and a palette-derived semantic color seam for the markdown renderer. Carries forward the \`workflow_dispatch\` release version fix and related CLI polish from the superseded PR.

Target files (10 changed):
- \`.github/workflows/release.yml\`: resolves \`RELEASE_VERSION\` before packaging; falls back to a 7-char SHA for non-tag \`workflow_dispatch\` runs
- \`Cargo.toml\`: adds \`human-panic\`, \`dialoguer\`, \`palette\`, \`tabled\` as workspace dependencies
- \`Cargo.lock\`: locks transitive dependencies introduced by the four new crates
- \`src/bin/vex.rs\`: implements \`resolve_credentials_secret\` for TTY-based hidden prompting; adds table-based task list rendering; adjusts panic-hook setup
- \`src/bin/vex/cli.rs\`: documents the new interactive TTY prompting behavior in the \`credentials set\` help text
- \`src/bin/vex/tests.rs\`: adds unit coverage for task-list rendering helpers and the credential-secret resolution seam
- \`src/ui/render/markdown.rs\`: introduces \`MarkdownSemanticPalette\` behind \`OnceLock\`; routes heading, bullet, and inline-code accent colors through a single derived palette
- \`src/ui/render/tests.rs\`: updates renderer tests to assert against the palette seam rather than fixed color constants
- \`docs/src/architecture.md\`: records \`dialoguer\`/\`palette\` as adopted dependencies with their seam rationale
- \`TASKS/ACTIVE-ROADMAP.md\`: updates roadmap counts to reflect completed normalization scope

## Motivation

Three gaps required addressing.

The operator credential path had no fallback for interactive TTY sessions. When neither \`--stdin\` nor \`--from-env\` was provided, the path returned an error even when running on a terminal where a hidden prompt would be unambiguous and safe.

The markdown renderer had semantic accent colors scattered as fixed \`Color\` constants across the render loop. Centralizing them into a single palette seam makes future theme changes a one-place edit and lets tests assert against the seam rather than internal constants that can drift.

The release workflow passed \`\${{ github.ref_name }}\` to the packaging scripts. On tag pushes this resolves to the tag name; on \`workflow_dispatch\` runs it resolves to the branch name, producing an invalid version string in release artifacts.

## Approach

\`resolve_credentials_secret\` in \`src/bin/vex.rs\` accepts an injectable \`prompt_fn\` closure. The interactive path activates only when \`std::io::stdout().is_terminal()\` is true and no \`--stdin\` or \`--from-env\` flag is provided. The non-interactive error path is preserved unchanged. Keeping the prompt closure in \`src/bin/vex.rs\` prevents interactive TTY logic from leaking into the keyring seam or config loading paths.

\`MarkdownSemanticPalette\` is initialized once via \`OnceLock\`. Heading, bullet, and inline-code accent colors are derived from a set of base sRGB points using linear interpolation, then converted to \`ratatui::Color::Rgb\` at startup. Renderer tests now assert against \`markdown_semantic_palette()\` rather than fixed \`Color\` constants.

The release workflow adds a \`Resolve release version\` step that reads \`\$GITHUB_REF\`. If the ref is a tag, it uses \`\$GITHUB_REF_NAME\`. Otherwise it falls back to \`git rev-parse --short=7 HEAD\`. The resolved value is written to \`\$GITHUB_ENV\` and consumed by both the non-Windows and Windows packaging steps.

## Validation

All twelve CI checks passed on head SHA \`db6abf8bc64a27ef79ee357d3f4f550481366cf3\`: arch-check, build, cargo deny check, check-map-coverage, clippy, doctest, lint, nextest, test-all-targets, windows-clippy, windows-package, windows-test.

A committed-secret scan of the last 24 hours of non-merge commits found no API keys, bearer credentials, private keys, or environment-variable dumps. Matches were limited to documented auth/token implementation text and test literals.

The \`sysinfo\` transitive dependency (via \`human-panic\`) reads operating-system metadata — OS name, CPU architecture, available memory — only when the process panics, to populate a crash report written to the system temporary directory. It does not read environment variables, credentials, or network resources. Environment-variable reads in the changed source are limited to: \`RUST_LOG\` (enables file logging, read at startup, not a secret) and the user-named variable when \`--from-env\` is explicitly provided by the operator.

A \`workflow_dispatch\` release run succeeded on this branch at the pre-merge head, confirming the version-resolution fix produces a valid packaging input on non-tag runs.

## Risks

- **Duplication**: None identified. The credential resolution helper is called from one site on the CLI credential-management path. The palette seam consolidates previously scattered constants into one location.
- **Unreachable code**: None identified. \`resolve_credentials_secret\` is exercised by focused unit tests. The palette is consumed immediately by the markdown renderer on first render.
- **Regression risk**: Interactive \`vex credentials set\` now prompts when running on a TTY without an explicit secret source. Automation callers must supply \`--stdin\` or \`--from-env\`; the non-interactive error path is unchanged. Renderer tests that previously compared against fixed color constants have been updated to assert against the palette seam.
- **ADR inconsistency**: None identified. The interactive prompt is confined to the CLI-only operator surface in \`src/bin/vex.rs\`. The renderer change is confined to \`src/ui/render/markdown.rs\`.
- **Test gaps**: Hidden-secret prompting is covered through the injected \`prompt_fn\` closure rather than an end-to-end PTY integration test. Branch-dispatch release packaging is covered by a successful \`workflow_dispatch\` validation run; publish and signing paths remain untested without a release tag.
- **Dependency version alignment**: \`dialoguer 0.12.0\` requires \`console 0.16.x\` while the workspace pins \`console = "0.15"\`. Bumping the workspace pin also requires updating \`indicatif 0.17.11\`, which pins \`console 0.15.11\` in its own lock entry. A coordinated bump of both \`indicatif\` and \`console\` is deferred to a follow-up PR to avoid an unreviewed dependency cascade in this batch.
- **System information access**: The \`human-panic\` dependency introduces \`sysinfo\` as a transitive dependency. This crate reads system metadata only on panic, for crash-report generation. No sensitive system files, environment variables, or credentials are accessed during normal operation.