### PR TITLE
fix(rfc): close remaining compliance gaps

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -562,13 +562,15 @@ export VEX_MODEL_TOKEN="your-token"
 
 The `[api_client]` section is live. `base_url` enables the ADR-047 host-and-port
 connection path, `explicit_protocol` can pin the wire format for the session,
-and `delta_accumulator_memory_watermark_mb` bounds in-flight tool-call delta
+`probe_timeout_ms` controls the discovery-request ceiling, and
+`delta_accumulator_memory_watermark_mb` bounds in-flight tool-call delta
 state.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `base_url` | string | `""` | Optional scheme-and-host base URL (for example `http://127.0.0.1:8000`). When set, the client discovers or applies the protocol and adapts requests to `/v1/messages` or `/v1/chat/completions`. |
 | `explicit_protocol` | `"block_delta"` \| `"choices_delta"` | unset | Optional override that bypasses discovery and pins request routing plus SSE parsing to the selected format. |
+| `probe_timeout_ms` | integer | `2000` | Per-request timeout budget for each ADR-047 protocol-discovery probe (`/v1/messages`, then `/v1/chat/completions`). Raise this for slower local runtimes or remote tunnels. |
 | `delta_accumulator_memory_watermark_mb` | integer | `256` | Memory ceiling (MiB) for in-flight streaming tool-argument deltas. When exceeded, the oldest pending entry is evicted. |
 
 Discovery-based form:
@@ -576,6 +578,7 @@ Discovery-based form:
 ```toml
 [api_client]
 base_url = "http://127.0.0.1:8000"
+probe_timeout_ms = 2000
 delta_accumulator_memory_watermark_mb = 512
 ```
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -563,7 +563,7 @@ export VEX_MODEL_TOKEN="your-token"
 The `[api_client]` section is live. `base_url` enables the ADR-047 host-and-port
 connection path, `explicit_protocol` can pin the wire format for the session,
 `probe_timeout_ms` controls the discovery-request ceiling, and
-`delta_accumulator_memory_watermark_mb` bounds in-flight tool-call delta
+`delta_accumulator_memory_watermark_mb` bounds in-progress tool-call delta
 state.
 
 | Field | Type | Default | Description |
@@ -571,7 +571,7 @@ state.
 | `base_url` | string | `""` | Optional scheme-and-host base URL (for example `http://127.0.0.1:8000`). When set, the client discovers or applies the protocol and adapts requests to `/v1/messages` or `/v1/chat/completions`. |
 | `explicit_protocol` | `"block_delta"` \| `"choices_delta"` | unset | Optional override that bypasses discovery and pins request routing plus SSE parsing to the selected format. |
 | `probe_timeout_ms` | integer | `2000` | Per-request timeout budget for each ADR-047 protocol-discovery probe (`/v1/messages`, then `/v1/chat/completions`). Raise this for slower local runtimes or remote tunnels. |
-| `delta_accumulator_memory_watermark_mb` | integer | `256` | Memory ceiling (MiB) for in-flight streaming tool-argument deltas. When exceeded, the oldest pending entry is evicted. |
+| `delta_accumulator_memory_watermark_mb` | integer | `256` | Memory ceiling (MiB) for in-progress streaming tool-argument deltas. When exceeded, the oldest pending entry is evicted. |
 
 Discovery-based form:
 

--- a/src/api/client/mod.rs
+++ b/src/api/client/mod.rs
@@ -52,11 +52,19 @@ struct LocalServerGenSettings {
 /// recognised discovery endpoint. Best-effort; never blocks the session.
 pub async fn poll_server_info(http: &reqwest::Client, api_url: &str) -> Option<ServerInfo> {
     let base = local_endpoint_base_url(api_url)?;
+    let props_url = format!("{base}/props");
+    let models_url = format!("{base}/v1/models");
 
     // Try the /props discovery endpoint first (supported by some local servers).
     let mut info: Option<ServerInfo> = None;
+    tracing::debug!(
+        target: "vex::http",
+        method = "GET",
+        url = %crate::runtime::rewrite_url_for_logs(&props_url),
+        "sending local server discovery request"
+    );
     if let Ok(resp) = http
-        .get(format!("{base}/props"))
+        .get(&props_url)
         .timeout(std::time::Duration::from_secs(3))
         .send()
         .await
@@ -74,9 +82,15 @@ pub async fn poll_server_info(http: &reqwest::Client, api_url: &str) -> Option<S
     }
 
     // Fallback: try /v1/models for other servers.
+    tracing::debug!(
+        target: "vex::http",
+        method = "GET",
+        url = %crate::runtime::rewrite_url_for_logs(&models_url),
+        "sending local server discovery request"
+    );
     if info.is_none()
         && let Ok(resp) = http
-            .get(format!("{base}/v1/models"))
+            .get(&models_url)
             .timeout(std::time::Duration::from_secs(3))
             .send()
             .await
@@ -124,15 +138,20 @@ async fn discover_native_protocol(
     http: &reqwest::Client,
     base_url: &str,
     explicit_protocol: Option<ProtocolVariant>,
+    probe_timeout_ms: u64,
 ) -> Option<ModelProtocol> {
     if let Some(protocol) = explicit_protocol {
         return Some(protocol_variant_to_model_protocol(protocol));
     }
 
-    discover_protocol(base_url, http)
-        .await
-        .ok()
-        .map(|result| protocol_variant_to_model_protocol(result.protocol))
+    discover_protocol(
+        base_url,
+        http,
+        std::time::Duration::from_millis(probe_timeout_ms.max(1)),
+    )
+    .await
+    .ok()
+    .map(|result| protocol_variant_to_model_protocol(result.protocol))
 }
 /// Base system prompt applied to every API call.
 /// Project instructions are appended at runtime via
@@ -193,6 +212,7 @@ pub struct ApiClient {
     extra_tool_definitions: Vec<Value>,
     server_info: Arc<RwLock<Option<ServerInfo>>>,
     tls_verification_disabled: bool,
+    probe_timeout_ms: u64,
     #[cfg(test)]
     mock_stream_producer: Option<Arc<dyn MockStreamProducer>>,
 }
@@ -235,6 +255,7 @@ impl ApiClient {
             extra_tool_definitions: Vec::new(),
             server_info: Arc::new(RwLock::new(None)),
             tls_verification_disabled: config.model_url_skip_tls_check,
+            probe_timeout_ms: config.api_client.probe_timeout_ms,
             #[cfg(test)]
             mock_stream_producer: None,
         })
@@ -266,6 +287,7 @@ impl ApiClient {
             extra_tool_definitions: Vec::new(),
             server_info: Arc::new(RwLock::new(None)),
             tls_verification_disabled: false,
+            probe_timeout_ms: crate::config::ApiClientConfig::default().probe_timeout_ms,
             mock_stream_producer: Some(mock_producer),
         }
     }
@@ -287,9 +309,13 @@ impl ApiClient {
             return;
         };
 
-        let native_protocol =
-            discover_native_protocol(&self.http, &base_url, self.api_client_explicit_protocol)
-                .await;
+        let native_protocol = discover_native_protocol(
+            &self.http,
+            &base_url,
+            self.api_client_explicit_protocol,
+            self.probe_timeout_ms,
+        )
+        .await;
 
         if let Some(mut info) = poll_server_info(&self.http, &base_url).await {
             info.native_protocol = native_protocol;

--- a/src/api/client/mod.rs
+++ b/src/api/client/mod.rs
@@ -175,6 +175,7 @@ For repository summaries or unfamiliar codebases, start with list_files at the w
 For edit_file, use a focused old_str snippet around the target change and avoid whole-file replacements; use write_file only for smaller full-file rewrites that stay under the write-file guard thresholds.\n\
 For large files, prefer apply_patch or edit_file over write_file; if write_file warns or rejects due to line limits, switch tools instead of retrying the same call.\n\
 For code edits, prefer this sequence: search_files -> read_file -> edit_file -> read_file (verify), escalating to apply_patch when the change is too broad for edit_file.\n\
+For Rust edits, keep diffs rustfmt-canonical and avoid formatting-only churn: preserve surrounding style, make the smallest semantic change that solves the task, and do not hand-wrap argument lists or method chains against local conventions.\n\
 For read-only requests (show/read/list/count/status/log/diff), use read-only tools and do not call mutating tools unless the user explicitly asks for changes.\n\
 If asked what git tools are available, only list built-in git tools: git_status, git_diff, git_log, git_show, git_add, git_commit.\n\
 Do not claim unsupported git tools like git_clone, git_init, git_remote, git_config, git_pull, git_push, git_branch, git_checkout, or git_stash.\n\

--- a/src/api/client/protocol_discovery.rs
+++ b/src/api/client/protocol_discovery.rs
@@ -15,6 +15,7 @@
 //! ADR-047 §6 — Client-Side Protocol Discovery.
 
 use crate::config::ProtocolVariant;
+use crate::runtime::rewrite_url_for_logs;
 use std::time::{Duration, Instant};
 
 /// Result of a successful protocol probe.
@@ -67,14 +68,28 @@ pub enum DiscoveryError {
 ///
 /// A probe is considered successful when the server returns `200 OK` and
 /// a `Content-Type` that contains `text/event-stream`.
-async fn probe_endpoint(url: &str, accept_header: &str, client: &reqwest::Client) -> ProbeAttempt {
+async fn probe_endpoint(
+    url: &str,
+    accept_header: &str,
+    timeout: Duration,
+    client: &reqwest::Client,
+) -> ProbeAttempt {
     let start = Instant::now();
+
+    tracing::debug!(
+        target: "vex::http",
+        method = "GET",
+        url = %rewrite_url_for_logs(url),
+        accept = accept_header,
+        timeout_ms = timeout.as_millis() as u64,
+        "sending protocol discovery probe"
+    );
 
     let response = client
         .get(url)
         .header("Accept", accept_header)
         .header("Accept-Encoding", "identity")
-        .timeout(Duration::from_secs(2))
+        .timeout(timeout)
         .send()
         .await;
 
@@ -133,6 +148,7 @@ async fn probe_endpoint(url: &str, accept_header: &str, client: &reqwest::Client
 pub async fn discover_protocol(
     base_url: &str,
     client: &reqwest::Client,
+    timeout: Duration,
 ) -> Result<DiscoveryResult, DiscoveryError> {
     let base = base_url.trim_end_matches('/');
     let mut attempts = Vec::with_capacity(2);
@@ -140,6 +156,7 @@ pub async fn discover_protocol(
     let block_probe = probe_endpoint(
         &format!("{base}/v1/messages"),
         "application/vnd.block-delta+sse",
+        timeout,
         client,
     )
     .await;
@@ -160,6 +177,7 @@ pub async fn discover_protocol(
     let choices_probe = probe_endpoint(
         &format!("{base}/v1/chat/completions"),
         "application/vnd.choices-delta+sse",
+        timeout,
         client,
     )
     .await;

--- a/src/api/client/tests.rs
+++ b/src/api/client/tests.rs
@@ -7,6 +7,7 @@ use axum::http::{StatusCode, header};
 use axum::response::IntoResponse;
 use axum::routing::get;
 use std::collections::BTreeSet;
+use std::time::Duration;
 
 fn with_vex_max_tokens_env<T>(value: Option<&str>, run: impl FnOnce() -> T) -> T {
     let env_lock = ENV_LOCK.blocking_lock();
@@ -255,6 +256,53 @@ async fn test_populate_server_info_discovers_protocol_from_local_model_url_sessi
     assert_eq!(
         client.request_url(),
         format!("http://{addr}/v1/chat/completions")
+    );
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn test_populate_server_info_respects_probe_timeout_config() {
+    async fn slow_probe() -> impl IntoResponse {
+        tokio::time::sleep(Duration::from_millis(75)).await;
+        (
+            [(header::CONTENT_TYPE, "text/event-stream")],
+            "data: {\"ok\":true}\n\n",
+        )
+    }
+
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        axum::serve(
+            listener,
+            Router::new()
+                .route("/v1/messages", get(slow_probe))
+                .route("/v1/chat/completions", get(slow_probe)),
+        )
+        .await
+        .unwrap();
+    });
+
+    let mut config = crate::config::Config::default_for_tui();
+    config.model_name = "local/test-model".to_string();
+    config.model_url.clear();
+    config.model_token = None;
+    config.api_client.base_url = format!("http://{addr}");
+    config.api_client.probe_timeout_ms = 10;
+
+    let client = ApiClient::new(&config).expect("client should build");
+    client.populate_server_info().await;
+
+    let info = client.server_info();
+    assert!(
+        info.is_none()
+            || info
+                .as_ref()
+                .is_some_and(|entry| entry.native_protocol.is_none()),
+        "probe should time out before protocol discovery succeeds"
     );
 
     server.abort();
@@ -1006,6 +1054,7 @@ fn test_native_protocol_overrides_configured_protocol() {
         supplementary_system_prompt: Arc::new(RwLock::new(None)),
         api_url: "http://localhost:8000/v1/messages".to_string(),
         api_client_explicit_protocol: None,
+        probe_timeout_ms: 2000,
         model_backend: ModelBackendKind::LocalRuntime,
         model_protocol: ModelProtocol::MessagesV1,
         tool_call_mode: ToolCallMode::Structured,
@@ -1049,6 +1098,7 @@ fn test_no_native_protocol_falls_back_to_configured() {
         supplementary_system_prompt: Arc::new(RwLock::new(None)),
         api_url: "http://localhost:8000/v1/messages".to_string(),
         api_client_explicit_protocol: None,
+        probe_timeout_ms: 2000,
         model_backend: ModelBackendKind::LocalRuntime,
         model_protocol: ModelProtocol::MessagesV1,
         tool_call_mode: ToolCallMode::Structured,

--- a/src/api/client/tests.rs
+++ b/src/api/client/tests.rs
@@ -673,6 +673,12 @@ fn test_system_prompt_includes_large_file_edit_guidance() {
 }
 
 #[test]
+fn test_system_prompt_discourages_non_rustfmt_rust_diffs() {
+    assert!(BASE_SYSTEM_PROMPT.contains("keep diffs rustfmt-canonical"));
+    assert!(BASE_SYSTEM_PROMPT.contains("do not hand-wrap argument lists or method chains"));
+}
+
+#[test]
 fn test_write_file_tool_description_uses_guard_names_instead_of_hardcoded_numbers() {
     let definitions = tool_definitions();
     let description = definitions
@@ -690,6 +696,32 @@ fn test_write_file_tool_description_uses_guard_names_instead_of_hardcoded_number
     assert!(description.contains("max line limit"));
     assert!(!description.contains("~200"));
     assert!(!description.contains("~500"));
+}
+
+#[test]
+fn test_edit_tools_discourage_non_rustfmt_rust_diffs() {
+    let definitions = tool_definitions();
+    let entries = definitions
+        .as_array()
+        .expect("tool definitions must be an array");
+
+    let apply_patch_description = entries
+        .iter()
+        .find(|entry| entry.get("name").and_then(|v| v.as_str()) == Some("apply_patch"))
+        .and_then(|entry| entry.get("description"))
+        .and_then(|value| value.as_str())
+        .expect("apply_patch description must be present");
+    assert!(apply_patch_description.contains("rustfmt-canonical"));
+    assert!(apply_patch_description.contains("formatting-only churn"));
+
+    let edit_file_description = entries
+        .iter()
+        .find(|entry| entry.get("name").and_then(|v| v.as_str()) == Some("edit_file"))
+        .and_then(|entry| entry.get("description"))
+        .and_then(|value| value.as_str())
+        .expect("edit_file description must be present");
+    assert!(edit_file_description.contains("rustfmt-canonical"));
+    assert!(edit_file_description.contains("preserve surrounding style"));
 }
 
 #[test]

--- a/src/api/client/tools.rs
+++ b/src/api/client/tools.rs
@@ -67,7 +67,7 @@ pub(super) fn tool_definitions() -> &'static Value {
                 },
                 {
                     "name": "apply_patch",
-                    "description": "Apply the provided full-file content as a patch to an existing workspace path.",
+                    "description": "Apply the provided full-file content as a patch to an existing workspace path. Keep the resulting diff minimal, preserve surrounding style, and keep Rust edits rustfmt-canonical instead of introducing formatting-only churn.",
                     "input_schema": {
                         "type": "object",
                         "properties": {
@@ -79,7 +79,7 @@ pub(super) fn tool_definitions() -> &'static Value {
                 },
                 {
                     "name": "edit_file",
-                    "description": "Edit existing file by replacing one exact, unique snippet (old_str -> new_str). Do not send entire-file replacements via this tool.",
+                    "description": "Edit existing file by replacing one exact, unique snippet (old_str -> new_str). Keep edits tightly scoped, preserve surrounding style, and keep Rust replacements rustfmt-canonical. Do not send entire-file replacements via this tool.",
                     "input_schema": {
                         "type": "object",
                         "properties": {

--- a/src/config.rs
+++ b/src/config.rs
@@ -260,6 +260,10 @@ pub struct ApiClientConfig {
     /// Optional explicit protocol override. When set, protocol discovery is
     /// skipped and this variant is used for the entire session.
     pub explicit_protocol: Option<ProtocolVariant>,
+    /// Timeout budget in milliseconds for each protocol-discovery probe.
+    /// The client probes `/v1/messages` and `/v1/chat/completions` separately;
+    /// this ceiling applies to each individual request.
+    pub probe_timeout_ms: u64,
     /// Memory ceiling for the delta accumulator in mebibytes (default: 256).
     /// When the in-flight tool-delta map exceeds this threshold, the oldest
     /// pending entry is evicted to stay within the bound.
@@ -271,6 +275,7 @@ impl Default for ApiClientConfig {
         Self {
             base_url: String::new(),
             explicit_protocol: None,
+            probe_timeout_ms: 2000,
             delta_accumulator_memory_watermark_mb: 256,
         }
     }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -75,6 +75,12 @@ fn test_config_validate_accepts_api_client_base_url_without_model_url() {
 }
 
 #[test]
+fn test_api_client_config_defaults_probe_timeout_ms() {
+    let config = crate::config::ApiClientConfig::default();
+    assert_eq!(config.probe_timeout_ms, 2000);
+}
+
+#[test]
 fn test_config_loads_vex_model_name_without_legacy_prefix() {
     let _lock = crate::test_support::ENV_LOCK.blocking_lock();
     crate::test_support::test_set_var(&_lock, "VEX_MODEL_URL", "http://localhost:8080/v1");

--- a/src/net/jwt.rs
+++ b/src/net/jwt.rs
@@ -14,10 +14,19 @@
 //! not a wrapper tweak.
 
 use anyhow::{Context, Result, anyhow};
+use base64::Engine as _;
 use jsonwebtoken::{
     Algorithm, DecodingKey, EncodingKey, Header, TokenData, Validation, decode, encode,
 };
 use serde::{Deserialize, Deserializer, Serialize};
+use std::collections::HashSet;
+
+#[derive(Debug, Deserialize)]
+struct RawJoseHeader {
+    alg: Option<String>,
+    typ: Option<String>,
+    cty: Option<String>,
+}
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(untagged)]
@@ -84,15 +93,40 @@ pub fn encode_hs256<C: Serialize>(claims: &C, secret: &[u8]) -> Result<String> {
 
 /// Decode and validate a JWT signed with HMAC-SHA256 (HS256).
 ///
-/// Validates the signature and the `exp` claim (if present).  The caller
-/// may further validate `iss`, `sub`, and `aud` claims per RFC 7519 §7.2.
+/// This wrapper enforces RFC 7519 registered claims (`iss`, `aud`, `exp`) and
+/// rejects RFC 8725 forbidden or unsupported header values such as `alg: none`,
+/// missing `typ: JWT`, or unexpected `cty` values.
 pub fn decode_hs256<C: for<'de> Deserialize<'de>>(
     token: &str,
     secret: &[u8],
+    expected_issuer: &str,
+    expected_audience: &str,
 ) -> Result<TokenData<C>> {
+    let raw_header = peek_raw_header(token)?;
+    if raw_header.alg.as_deref() == Some("none") {
+        return Err(anyhow!(
+            "JWT header uses forbidden alg=none (RFC 8725 §3.1)"
+        ));
+    }
+    peek_header(token)?;
+    if raw_header.typ.as_deref() != Some("JWT") {
+        return Err(anyhow!(
+            "JWT header typ must be JWT (RFC 7519 §5.1 / RFC 8725 §3.11)"
+        ));
+    }
+    if raw_header.cty.is_some() {
+        return Err(anyhow!(
+            "nested JWT content types are not supported by this HS256 wrapper (RFC 8725 §3.11)"
+        ));
+    }
+
     let mut validation = Validation::new(Algorithm::HS256);
-    // Disable automatic audience check — caller performs claim validation.
-    validation.validate_aud = false;
+    validation.validate_exp = true;
+    validation.validate_aud = true;
+    validation.required_spec_claims =
+        HashSet::from(["exp".to_string(), "aud".to_string(), "iss".to_string()]);
+    validation.set_audience(&[expected_audience]);
+    validation.set_issuer(&[expected_issuer]);
     decode::<C>(token, &DecodingKey::from_secret(secret), &validation)
         .context("JWT HS256 validation failed (RFC 7519/7515)")
 }
@@ -118,6 +152,17 @@ pub fn validate_expiry(claims: &RegisteredClaims, now_secs: u64) -> Result<()> {
 /// the algorithm before signature verification.
 pub fn peek_header(token: &str) -> Result<Header> {
     jsonwebtoken::decode_header(token).context("JWT header decode failed (RFC 7519 §7.2)")
+}
+
+fn peek_raw_header(token: &str) -> Result<RawJoseHeader> {
+    let encoded = token
+        .split('.')
+        .next()
+        .ok_or_else(|| anyhow!("JWT compact serialisation is missing a JOSE header segment"))?;
+    let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(encoded)
+        .context("JWT JOSE header base64url decode failed")?;
+    serde_json::from_slice(&decoded).context("JWT JOSE header JSON decode failed")
 }
 
 #[cfg(test)]
@@ -146,7 +191,7 @@ mod tests {
             registered: RegisteredClaims {
                 iss: Some("vexcoder".to_string()),
                 sub: Some("test-subject".to_string()),
-                aud: None,
+                aud: Some(vec!["cli".to_string()]),
                 exp: Some(now() + 3600),
                 nbf: None,
                 iat: Some(now()),
@@ -164,7 +209,8 @@ mod tests {
             "RFC 7519 compact serialisation"
         );
 
-        let decoded: TokenData<TestClaims> = decode_hs256(&token, SECRET).expect("decode");
+        let decoded: TokenData<TestClaims> =
+            decode_hs256(&token, SECRET, "vexcoder", "cli").expect("decode");
         assert_eq!(decoded.claims, claims);
         assert_eq!(decoded.header.alg, Algorithm::HS256);
     }
@@ -172,16 +218,16 @@ mod tests {
     #[test]
     fn wrong_secret_fails_validation_rfc7515() {
         let claims = RegisteredClaims {
-            iss: None,
+            iss: Some("issuer".to_string()),
             sub: Some("s".to_string()),
-            aud: None,
+            aud: Some(vec!["cli".to_string()]),
             exp: Some(now() + 60),
             nbf: None,
             iat: None,
             jti: None,
         };
         let token = encode_hs256(&claims, SECRET).expect("encode");
-        let result = decode_hs256::<RegisteredClaims>(&token, b"wrong-secret");
+        let result = decode_hs256::<RegisteredClaims>(&token, b"wrong-secret", "issuer", "cli");
         assert!(
             result.is_err(),
             "mismatched HMAC must be rejected (RFC 7515)"
@@ -192,12 +238,14 @@ mod tests {
     fn single_string_audience_decodes_rfc7519() {
         #[derive(Serialize)]
         struct SingleAudienceClaims {
+            iss: String,
             aud: String,
             exp: u64,
         }
 
         let token = encode_hs256(
             &SingleAudienceClaims {
+                iss: "issuer".to_string(),
                 aud: "cli".to_string(),
                 exp: now() + 60,
             },
@@ -205,8 +253,45 @@ mod tests {
         )
         .expect("encode");
 
-        let decoded = decode_hs256::<RegisteredClaims>(&token, SECRET).expect("decode");
+        let decoded =
+            decode_hs256::<RegisteredClaims>(&token, SECRET, "issuer", "cli").expect("decode");
         assert_eq!(decoded.claims.aud, Some(vec!["cli".to_string()]));
+    }
+
+    #[test]
+    fn decode_hs256_rejects_missing_required_claims_rfc7519() {
+        let claims = RegisteredClaims {
+            iss: Some("issuer".to_string()),
+            sub: None,
+            aud: None,
+            exp: None,
+            nbf: None,
+            iat: None,
+            jti: None,
+        };
+        let token = encode_hs256(&claims, SECRET).expect("encode");
+        let result = decode_hs256::<RegisteredClaims>(&token, SECRET, "issuer", "cli");
+        assert!(result.is_err(), "missing aud/exp must be rejected");
+    }
+
+    #[test]
+    fn decode_hs256_rejects_alg_none_rfc8725() {
+        let header = serde_json::json!({"alg": "none", "typ": "JWT"});
+        let claims = serde_json::json!({
+            "iss": "issuer",
+            "aud": "cli",
+            "exp": now() + 60
+        });
+        let token = format!(
+            "{}.{}.",
+            base64::engine::general_purpose::URL_SAFE_NO_PAD
+                .encode(serde_json::to_vec(&header).expect("header json")),
+            base64::engine::general_purpose::URL_SAFE_NO_PAD
+                .encode(serde_json::to_vec(&claims).expect("claims json"))
+        );
+
+        let result = decode_hs256::<RegisteredClaims>(&token, SECRET, "issuer", "cli");
+        assert!(result.is_err(), "alg=none must be rejected");
     }
 
     #[test]

--- a/src/runtime/rate_limit.rs
+++ b/src/runtime/rate_limit.rs
@@ -1,7 +1,7 @@
 //! Rate-limit and Retry-After extraction using `regex-lite`.
 //!
 //! Parses retry delay hints from HTTP `Retry-After` header values and
-//! from error response body text (e.g. "try again in 5 seconds").
+//! from structured or unstructured error response bodies.
 //! All patterns are ASCII-only.
 //!
 //! Design boundary: this module extracts *structured delay hints* from
@@ -10,6 +10,8 @@
 
 use std::sync::OnceLock;
 use std::time::{Duration, SystemTime};
+
+use serde::Deserialize;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -64,6 +66,12 @@ fn clamp_delay_ms(value: f64) -> Option<u64> {
     Some(value.min(u64::MAX as f64) as u64)
 }
 
+#[derive(Debug, Deserialize)]
+struct RetryBodyHint {
+    #[serde(default)]
+    retry_after_ms: Option<u64>,
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -95,11 +103,22 @@ pub fn parse_retry_after_header(value: &str) -> Option<RetryHint> {
 
 /// Parse a retry delay from an error response body.
 ///
-/// Scans for natural-language phrases like "try again in 5 seconds",
-/// "retry in 500ms", "wait 30 sec", etc.
+/// Accepts JSON objects with `retry_after_ms` first, then falls back to
+/// natural-language phrases like "try again in 5 seconds", "retry in 500ms",
+/// and "wait 30 sec".
 pub fn parse_retry_from_body(body: &str) -> Option<RetryHint> {
+    let trimmed = body.trim();
+    if let Ok(hint) = serde_json::from_str::<RetryBodyHint>(trimmed)
+        && let Some(delay_ms) = hint.retry_after_ms
+    {
+        return Some(RetryHint {
+            delay_ms,
+            source: RetryHintSource::Body,
+        });
+    }
+
     let re = re_retry_body();
-    let caps = re.captures(body)?;
+    let caps = re.captures(trimmed)?;
     let value: f64 = caps[1].parse().ok()?;
     let unit = caps[2].to_ascii_lowercase();
     let delay_ms = if unit.starts_with("ms") || unit.starts_with("milli") {
@@ -208,6 +227,20 @@ mod tests {
     #[test]
     fn test_parse_retry_from_body_seconds() {
         let hint = parse_retry_from_body("Rate limited: try again in 5 seconds").unwrap();
+        assert_eq!(hint.delay_ms, 5000);
+        assert_eq!(hint.source, RetryHintSource::Body);
+    }
+
+    #[test]
+    fn test_parse_retry_from_body_json_retry_after_ms() {
+        let hint = parse_retry_from_body(r#"{"retry_after_ms":2500}"#).unwrap();
+        assert_eq!(hint.delay_ms, 2500);
+        assert_eq!(hint.source, RetryHintSource::Body);
+    }
+
+    #[test]
+    fn test_parse_retry_from_body_json_falls_back_to_regex_when_field_missing() {
+        let hint = parse_retry_from_body(r#"{"message":"try again in 5 seconds"}"#).unwrap();
         assert_eq!(hint.delay_ms, 5000);
         assert_eq!(hint.source, RetryHintSource::Body);
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -21,7 +21,7 @@ use crate::app::runtime_tokio::{signal, spawn, task::JoinSet};
 #[cfg(not(unix))]
 use anyhow::bail;
 use anyhow::{Result, anyhow};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -75,6 +75,17 @@ pub struct ControlResponse {
     pub ok: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<&'static str>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProblemDetails {
+    pub r#type: String,
+    pub title: String,
+    pub status: u16,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instance: Option<String>,
 }
 
 pub async fn serve_local_api(

--- a/src/server/handlers/mod.rs
+++ b/src/server/handlers/mod.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex};
 
 use super::SSE_KEEPALIVE_INTERVAL;
 use super::sse::{negotiate_turns_sse_mode, runtime_sse_response};
-use super::util::{bad_request, conflict, internal_error, not_found};
+use super::util::{ProblemResponse, bad_request, conflict, internal_error, not_found};
 use crate::app::runtime_tokio::{spawn, sync::mpsc};
 use crate::app::{
     DelegateError, ScheduleTeamError, execute_facade_runtime, facade_delegate_session_task,
@@ -89,15 +89,9 @@ pub struct WatchRollup {
     worktree_path: Option<String>,
 }
 
-fn internal_anyhow(err: anyhow::Error) -> (StatusCode, Json<ControlResponse>) {
+fn internal_anyhow(err: anyhow::Error) -> ProblemResponse {
     tracing::error!(%err, "handler returned internal error");
-    (
-        StatusCode::INTERNAL_SERVER_ERROR,
-        Json(ControlResponse {
-            ok: false,
-            reason: Some("internal_error"),
-        }),
-    )
+    ProblemResponse::new(StatusCode::INTERNAL_SERVER_ERROR, "internal_error")
 }
 
 pub async fn health_handler() -> Json<HealthResponse> {
@@ -108,7 +102,7 @@ pub async fn health_handler() -> Json<HealthResponse> {
     })
 }
 
-pub async fn schema_handler() -> Result<Json<SchemaBundle>, (StatusCode, Json<ControlResponse>)> {
+pub async fn schema_handler() -> Result<Json<SchemaBundle>, ProblemResponse> {
     let request_schema: Value =
         serde_json::from_str(include_str!("../../../schemas/runtime_request_v1.json"))
             .map_err(internal_error)?;
@@ -124,7 +118,7 @@ pub async fn schema_handler() -> Result<Json<SchemaBundle>, (StatusCode, Json<Co
 
 pub async fn agents_handler(
     State(state): State<LocalApiState>,
-) -> Result<Json<AgentsResponse>, (StatusCode, Json<ControlResponse>)> {
+) -> Result<Json<AgentsResponse>, ProblemResponse> {
     let listing = facade_list_agents(&state.config.working_dir).map_err(internal_anyhow)?;
 
     Ok(Json(AgentsResponse {
@@ -156,7 +150,7 @@ pub async fn agents_handler(
 pub async fn delegate_handler(
     State(state): State<LocalApiState>,
     Json(request): Json<DelegateRequest>,
-) -> Result<Json<DelegateResponse>, (StatusCode, Json<ControlResponse>)> {
+) -> Result<Json<DelegateResponse>, ProblemResponse> {
     if request.agent_id.trim().is_empty() || request.prompt.trim().is_empty() {
         return Err(bad_request("invalid_delegate_request"));
     }
@@ -187,7 +181,7 @@ pub async fn delegate_handler(
 pub async fn watch_handler(
     State(state): State<LocalApiState>,
     Path(id): Path<String>,
-) -> Result<Json<WatchRollup>, (StatusCode, Json<ControlResponse>)> {
+) -> Result<Json<WatchRollup>, ProblemResponse> {
     let snapshot = facade_watch_rollup(&state.config.working_dir, &id)
         .map_err(internal_anyhow)?
         .ok_or_else(|| not_found("task_not_found"))?;
@@ -212,7 +206,7 @@ pub async fn watch_handler(
 pub async fn release_session_task_handler(
     State(state): State<LocalApiState>,
     Path(id): Path<String>,
-) -> Result<Json<ControlResponse>, (StatusCode, Json<ControlResponse>)> {
+) -> Result<Json<ControlResponse>, ProblemResponse> {
     let released =
         facade_release_session_task(&state.config.working_dir, &id).map_err(internal_anyhow)?;
     if released {
@@ -272,7 +266,7 @@ pub async fn schedule_team_handler(
     State(state): State<LocalApiState>,
     Path(team_name): Path<String>,
     Json(request): Json<ScheduleTeamRequest>,
-) -> Result<Json<ScheduleTeamResponse>, (StatusCode, Json<ControlResponse>)> {
+) -> Result<Json<ScheduleTeamResponse>, ProblemResponse> {
     let result = facade_schedule_team(
         &state.config.working_dir,
         &request.parent_task_id,
@@ -304,7 +298,7 @@ pub async fn schedule_team_handler(
 pub async fn join_status_handler(
     State(state): State<LocalApiState>,
     Path(task_id): Path<String>,
-) -> Result<Json<JoinStatusResponse>, (StatusCode, Json<ControlResponse>)> {
+) -> Result<Json<JoinStatusResponse>, ProblemResponse> {
     let outcome = facade_poll_join(&state.config.working_dir, &task_id).map_err(internal_anyhow)?;
 
     match outcome {
@@ -335,7 +329,7 @@ pub async fn turns_handler(
     State(state): State<LocalApiState>,
     headers: HeaderMap,
     Json(request): Json<RuntimeRequest>,
-) -> Result<impl IntoResponse, (StatusCode, Json<ControlResponse>)> {
+) -> Result<impl IntoResponse, ProblemResponse> {
     let RuntimeRequest::SubmitInput { task_id, input, .. } = request else {
         return Err(bad_request("invalid_request_type"));
     };
@@ -389,7 +383,7 @@ pub async fn turns_handler(
 pub async fn interrupt_handler(
     State(state): State<LocalApiState>,
     Json(request): Json<RuntimeRequest>,
-) -> Result<Json<ControlResponse>, (StatusCode, Json<ControlResponse>)> {
+) -> Result<Json<ControlResponse>, ProblemResponse> {
     let RuntimeRequest::Interrupt { task_id, .. } = request else {
         return Err(bad_request("invalid_request_type"));
     };
@@ -411,7 +405,7 @@ pub async fn interrupt_handler(
 pub async fn approve_handler(
     State(state): State<LocalApiState>,
     Json(request): Json<RuntimeRequest>,
-) -> Result<Json<ControlResponse>, (StatusCode, Json<ControlResponse>)> {
+) -> Result<Json<ControlResponse>, ProblemResponse> {
     let task_id = match &request {
         RuntimeRequest::ApproveCapability { task_id, .. }
         | RuntimeRequest::DenyCapability { task_id, .. } => task_id.clone(),

--- a/src/server/handlers/mod.rs
+++ b/src/server/handlers/mod.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex};
 
 use super::SSE_KEEPALIVE_INTERVAL;
 use super::sse::{negotiate_turns_sse_mode, runtime_sse_response};
-use super::util::{ProblemResponse, bad_request, conflict, internal_error, not_found};
+use super::util::{ProblemDetailsResponse, bad_request, conflict, internal_error, not_found};
 use crate::app::runtime_tokio::{spawn, sync::mpsc};
 use crate::app::{
     DelegateError, ScheduleTeamError, execute_facade_runtime, facade_delegate_session_task,
@@ -89,9 +89,9 @@ pub struct WatchRollup {
     worktree_path: Option<String>,
 }
 
-fn internal_anyhow(err: anyhow::Error) -> ProblemResponse {
+fn internal_anyhow(err: anyhow::Error) -> ProblemDetailsResponse {
     tracing::error!(%err, "handler returned internal error");
-    ProblemResponse::new(StatusCode::INTERNAL_SERVER_ERROR, "internal_error")
+    ProblemDetailsResponse::from_reason(StatusCode::INTERNAL_SERVER_ERROR, "internal_error")
 }
 
 pub async fn health_handler() -> Json<HealthResponse> {
@@ -102,7 +102,7 @@ pub async fn health_handler() -> Json<HealthResponse> {
     })
 }
 
-pub async fn schema_handler() -> Result<Json<SchemaBundle>, ProblemResponse> {
+pub async fn schema_handler() -> Result<Json<SchemaBundle>, ProblemDetailsResponse> {
     let request_schema: Value =
         serde_json::from_str(include_str!("../../../schemas/runtime_request_v1.json"))
             .map_err(internal_error)?;
@@ -118,7 +118,7 @@ pub async fn schema_handler() -> Result<Json<SchemaBundle>, ProblemResponse> {
 
 pub async fn agents_handler(
     State(state): State<LocalApiState>,
-) -> Result<Json<AgentsResponse>, ProblemResponse> {
+) -> Result<Json<AgentsResponse>, ProblemDetailsResponse> {
     let listing = facade_list_agents(&state.config.working_dir).map_err(internal_anyhow)?;
 
     Ok(Json(AgentsResponse {
@@ -150,7 +150,7 @@ pub async fn agents_handler(
 pub async fn delegate_handler(
     State(state): State<LocalApiState>,
     Json(request): Json<DelegateRequest>,
-) -> Result<Json<DelegateResponse>, ProblemResponse> {
+) -> Result<Json<DelegateResponse>, ProblemDetailsResponse> {
     if request.agent_id.trim().is_empty() || request.prompt.trim().is_empty() {
         return Err(bad_request("invalid_delegate_request"));
     }
@@ -181,7 +181,7 @@ pub async fn delegate_handler(
 pub async fn watch_handler(
     State(state): State<LocalApiState>,
     Path(id): Path<String>,
-) -> Result<Json<WatchRollup>, ProblemResponse> {
+) -> Result<Json<WatchRollup>, ProblemDetailsResponse> {
     let snapshot = facade_watch_rollup(&state.config.working_dir, &id)
         .map_err(internal_anyhow)?
         .ok_or_else(|| not_found("task_not_found"))?;
@@ -206,7 +206,7 @@ pub async fn watch_handler(
 pub async fn release_session_task_handler(
     State(state): State<LocalApiState>,
     Path(id): Path<String>,
-) -> Result<Json<ControlResponse>, ProblemResponse> {
+) -> Result<Json<ControlResponse>, ProblemDetailsResponse> {
     let released =
         facade_release_session_task(&state.config.working_dir, &id).map_err(internal_anyhow)?;
     if released {
@@ -266,7 +266,7 @@ pub async fn schedule_team_handler(
     State(state): State<LocalApiState>,
     Path(team_name): Path<String>,
     Json(request): Json<ScheduleTeamRequest>,
-) -> Result<Json<ScheduleTeamResponse>, ProblemResponse> {
+) -> Result<Json<ScheduleTeamResponse>, ProblemDetailsResponse> {
     let result = facade_schedule_team(
         &state.config.working_dir,
         &request.parent_task_id,
@@ -298,7 +298,7 @@ pub async fn schedule_team_handler(
 pub async fn join_status_handler(
     State(state): State<LocalApiState>,
     Path(task_id): Path<String>,
-) -> Result<Json<JoinStatusResponse>, ProblemResponse> {
+) -> Result<Json<JoinStatusResponse>, ProblemDetailsResponse> {
     let outcome = facade_poll_join(&state.config.working_dir, &task_id).map_err(internal_anyhow)?;
 
     match outcome {
@@ -329,7 +329,7 @@ pub async fn turns_handler(
     State(state): State<LocalApiState>,
     headers: HeaderMap,
     Json(request): Json<RuntimeRequest>,
-) -> Result<impl IntoResponse, ProblemResponse> {
+) -> Result<impl IntoResponse, ProblemDetailsResponse> {
     let RuntimeRequest::SubmitInput { task_id, input, .. } = request else {
         return Err(bad_request("invalid_request_type"));
     };
@@ -383,7 +383,7 @@ pub async fn turns_handler(
 pub async fn interrupt_handler(
     State(state): State<LocalApiState>,
     Json(request): Json<RuntimeRequest>,
-) -> Result<Json<ControlResponse>, ProblemResponse> {
+) -> Result<Json<ControlResponse>, ProblemDetailsResponse> {
     let RuntimeRequest::Interrupt { task_id, .. } = request else {
         return Err(bad_request("invalid_request_type"));
     };
@@ -405,7 +405,7 @@ pub async fn interrupt_handler(
 pub async fn approve_handler(
     State(state): State<LocalApiState>,
     Json(request): Json<RuntimeRequest>,
-) -> Result<Json<ControlResponse>, ProblemResponse> {
+) -> Result<Json<ControlResponse>, ProblemDetailsResponse> {
     let task_id = match &request {
         RuntimeRequest::ApproveCapability { task_id, .. }
         | RuntimeRequest::DenyCapability { task_id, .. } => task_id.clone(),

--- a/src/server/handlers/session.rs
+++ b/src/server/handlers/session.rs
@@ -9,11 +9,11 @@ use crate::app::{
     facade_task_graph, facade_update_session_task_status, task_graph_rollup_path,
     todos_rollup_path, write_projection_rollup,
 };
-use crate::http_facade::{HeaderName, HeaderValue, StatusCode, header};
+use crate::http_facade::{HeaderName, HeaderValue, header};
 use crate::local_api::LocalApiState;
-use crate::server::util::{bad_request, conflict, not_found};
+use crate::server::util::{ProblemResponse, bad_request, conflict, not_found};
 use crate::server::{
-    ControlResponse, SSE_CACHE_CONTROL_HEADER, SSE_KEEPALIVE_INTERVAL, SSE_KEEPALIVE_TEXT,
+    SSE_CACHE_CONTROL_HEADER, SSE_KEEPALIVE_INTERVAL, SSE_KEEPALIVE_TEXT,
     SSE_PROXY_BUFFERING_DISABLED, SSE_PROXY_BUFFERING_HEADER,
 };
 use axum::Json;
@@ -61,7 +61,7 @@ pub struct UpdateSessionTaskStatusRequest {
 #[tracing::instrument(skip_all)]
 pub async fn list_tasks_handler(
     State(state): State<LocalApiState>,
-) -> Result<Json<Vec<TaskSummaryResponse>>, (StatusCode, Json<ControlResponse>)> {
+) -> Result<Json<Vec<TaskSummaryResponse>>, ProblemResponse> {
     let summaries = facade_list_tasks(&state.config.working_dir).map_err(internal_anyhow)?;
     Ok(Json(
         summaries
@@ -82,7 +82,7 @@ pub async fn list_tasks_handler(
 #[tracing::instrument(skip_all)]
 pub async fn list_session_tasks_handler(
     State(state): State<LocalApiState>,
-) -> Result<Json<Vec<SessionTaskRollupResponse>>, (StatusCode, Json<ControlResponse>)> {
+) -> Result<Json<Vec<SessionTaskRollupResponse>>, ProblemResponse> {
     let tasks = facade_list_session_tasks(&state.config.working_dir).map_err(internal_anyhow)?;
     Ok(Json(tasks.into_iter().map(rollup_to_response).collect()))
 }
@@ -92,7 +92,7 @@ pub async fn list_session_tasks_handler(
 pub async fn get_session_task_handler(
     State(state): State<LocalApiState>,
     Path(id): Path<String>,
-) -> Result<Json<SessionTaskRollupResponse>, (StatusCode, Json<ControlResponse>)> {
+) -> Result<Json<SessionTaskRollupResponse>, ProblemResponse> {
     let snap = facade_get_session_task(&state.config.working_dir, &id).map_err(internal_anyhow)?;
     match snap {
         Some(s) => Ok(Json(rollup_to_response(s))),
@@ -106,7 +106,7 @@ pub async fn update_session_task_status_handler(
     State(state): State<LocalApiState>,
     Path(id): Path<String>,
     Json(body): Json<UpdateSessionTaskStatusRequest>,
-) -> Result<Json<SessionTaskRollupResponse>, (StatusCode, Json<ControlResponse>)> {
+) -> Result<Json<SessionTaskRollupResponse>, ProblemResponse> {
     match facade_update_session_task_status(&state.config.working_dir, &id, &body.status) {
         Ok(snap) => {
             state.publish_session_task_rollup(snap.clone());
@@ -165,7 +165,7 @@ fn lifecycle_state_is_terminal(state: &str) -> bool {
 pub async fn watch_session_task_handler(
     State(state): State<LocalApiState>,
     Path(id): Path<String>,
-) -> Result<impl IntoResponse, (StatusCode, Json<ControlResponse>)> {
+) -> Result<impl IntoResponse, ProblemResponse> {
     let mut updates = state.subscribe_session_task_events();
 
     let initial_rollup = facade_get_session_task(&state.config.working_dir, &id)
@@ -262,7 +262,7 @@ pub struct TaskGraphResponse {
 #[tracing::instrument(skip_all)]
 pub async fn task_graph_handler(
     State(state): State<LocalApiState>,
-) -> Result<Json<TaskGraphResponse>, (StatusCode, Json<ControlResponse>)> {
+) -> Result<Json<TaskGraphResponse>, ProblemResponse> {
     let graph = facade_task_graph(&state.config.working_dir).map_err(internal_anyhow)?;
     Ok(Json(TaskGraphResponse {
         nodes: graph
@@ -300,7 +300,7 @@ pub struct TodoItemResponse {
 #[tracing::instrument(skip_all)]
 pub async fn list_todos_handler(
     State(state): State<LocalApiState>,
-) -> Result<Json<Vec<TodoItemResponse>>, (StatusCode, Json<ControlResponse>)> {
+) -> Result<Json<Vec<TodoItemResponse>>, ProblemResponse> {
     let todos = facade_list_todos(&state.config.working_dir).map_err(internal_anyhow)?;
     Ok(Json(
         todos
@@ -345,7 +345,7 @@ fn file_modified_ms(path: &std::path::Path) -> Option<u64> {
 #[tracing::instrument(skip_all)]
 pub async fn projection_handler(
     State(state): State<LocalApiState>,
-) -> Result<Json<ProjectionStatusResponse>, (StatusCode, Json<ControlResponse>)> {
+) -> Result<Json<ProjectionStatusResponse>, ProblemResponse> {
     let working_dir = &state.config.working_dir;
     let graph_path = task_graph_rollup_path(working_dir);
     let todos_path = todos_rollup_path(working_dir);
@@ -406,7 +406,7 @@ pub async fn post_peer_message_handler(
     State(state): State<LocalApiState>,
     Path(parent_task_id): Path<String>,
     Json(body): Json<PostPeerMessageRequest>,
-) -> Result<Json<PeerMessageResponse>, (StatusCode, Json<ControlResponse>)> {
+) -> Result<Json<PeerMessageResponse>, ProblemResponse> {
     match facade_post_peer_message(
         &state.config.working_dir,
         &parent_task_id,
@@ -432,7 +432,7 @@ pub async fn read_peer_messages_handler(
     State(state): State<LocalApiState>,
     Path(parent_task_id): Path<String>,
     axum::extract::Query(query): axum::extract::Query<ReadPeerMessagesQuery>,
-) -> Result<Json<Vec<PeerMessageResponse>>, (StatusCode, Json<ControlResponse>)> {
+) -> Result<Json<Vec<PeerMessageResponse>>, ProblemResponse> {
     let messages = facade_read_peer_messages(
         &state.config.working_dir,
         &parent_task_id,

--- a/src/server/handlers/session.rs
+++ b/src/server/handlers/session.rs
@@ -11,7 +11,7 @@ use crate::app::{
 };
 use crate::http_facade::{HeaderName, HeaderValue, header};
 use crate::local_api::LocalApiState;
-use crate::server::util::{ProblemResponse, bad_request, conflict, not_found};
+use crate::server::util::{ProblemDetailsResponse, bad_request, conflict, not_found};
 use crate::server::{
     SSE_CACHE_CONTROL_HEADER, SSE_KEEPALIVE_INTERVAL, SSE_KEEPALIVE_TEXT,
     SSE_PROXY_BUFFERING_DISABLED, SSE_PROXY_BUFFERING_HEADER,
@@ -61,7 +61,7 @@ pub struct UpdateSessionTaskStatusRequest {
 #[tracing::instrument(skip_all)]
 pub async fn list_tasks_handler(
     State(state): State<LocalApiState>,
-) -> Result<Json<Vec<TaskSummaryResponse>>, ProblemResponse> {
+) -> Result<Json<Vec<TaskSummaryResponse>>, ProblemDetailsResponse> {
     let summaries = facade_list_tasks(&state.config.working_dir).map_err(internal_anyhow)?;
     Ok(Json(
         summaries
@@ -82,7 +82,7 @@ pub async fn list_tasks_handler(
 #[tracing::instrument(skip_all)]
 pub async fn list_session_tasks_handler(
     State(state): State<LocalApiState>,
-) -> Result<Json<Vec<SessionTaskRollupResponse>>, ProblemResponse> {
+) -> Result<Json<Vec<SessionTaskRollupResponse>>, ProblemDetailsResponse> {
     let tasks = facade_list_session_tasks(&state.config.working_dir).map_err(internal_anyhow)?;
     Ok(Json(tasks.into_iter().map(rollup_to_response).collect()))
 }
@@ -92,7 +92,7 @@ pub async fn list_session_tasks_handler(
 pub async fn get_session_task_handler(
     State(state): State<LocalApiState>,
     Path(id): Path<String>,
-) -> Result<Json<SessionTaskRollupResponse>, ProblemResponse> {
+) -> Result<Json<SessionTaskRollupResponse>, ProblemDetailsResponse> {
     let snap = facade_get_session_task(&state.config.working_dir, &id).map_err(internal_anyhow)?;
     match snap {
         Some(s) => Ok(Json(rollup_to_response(s))),
@@ -106,7 +106,7 @@ pub async fn update_session_task_status_handler(
     State(state): State<LocalApiState>,
     Path(id): Path<String>,
     Json(body): Json<UpdateSessionTaskStatusRequest>,
-) -> Result<Json<SessionTaskRollupResponse>, ProblemResponse> {
+) -> Result<Json<SessionTaskRollupResponse>, ProblemDetailsResponse> {
     match facade_update_session_task_status(&state.config.working_dir, &id, &body.status) {
         Ok(snap) => {
             state.publish_session_task_rollup(snap.clone());
@@ -165,7 +165,7 @@ fn lifecycle_state_is_terminal(state: &str) -> bool {
 pub async fn watch_session_task_handler(
     State(state): State<LocalApiState>,
     Path(id): Path<String>,
-) -> Result<impl IntoResponse, ProblemResponse> {
+) -> Result<impl IntoResponse, ProblemDetailsResponse> {
     let mut updates = state.subscribe_session_task_events();
 
     let initial_rollup = facade_get_session_task(&state.config.working_dir, &id)
@@ -262,7 +262,7 @@ pub struct TaskGraphResponse {
 #[tracing::instrument(skip_all)]
 pub async fn task_graph_handler(
     State(state): State<LocalApiState>,
-) -> Result<Json<TaskGraphResponse>, ProblemResponse> {
+) -> Result<Json<TaskGraphResponse>, ProblemDetailsResponse> {
     let graph = facade_task_graph(&state.config.working_dir).map_err(internal_anyhow)?;
     Ok(Json(TaskGraphResponse {
         nodes: graph
@@ -300,7 +300,7 @@ pub struct TodoItemResponse {
 #[tracing::instrument(skip_all)]
 pub async fn list_todos_handler(
     State(state): State<LocalApiState>,
-) -> Result<Json<Vec<TodoItemResponse>>, ProblemResponse> {
+) -> Result<Json<Vec<TodoItemResponse>>, ProblemDetailsResponse> {
     let todos = facade_list_todos(&state.config.working_dir).map_err(internal_anyhow)?;
     Ok(Json(
         todos
@@ -345,7 +345,7 @@ fn file_modified_ms(path: &std::path::Path) -> Option<u64> {
 #[tracing::instrument(skip_all)]
 pub async fn projection_handler(
     State(state): State<LocalApiState>,
-) -> Result<Json<ProjectionStatusResponse>, ProblemResponse> {
+) -> Result<Json<ProjectionStatusResponse>, ProblemDetailsResponse> {
     let working_dir = &state.config.working_dir;
     let graph_path = task_graph_rollup_path(working_dir);
     let todos_path = todos_rollup_path(working_dir);
@@ -406,7 +406,7 @@ pub async fn post_peer_message_handler(
     State(state): State<LocalApiState>,
     Path(parent_task_id): Path<String>,
     Json(body): Json<PostPeerMessageRequest>,
-) -> Result<Json<PeerMessageResponse>, ProblemResponse> {
+) -> Result<Json<PeerMessageResponse>, ProblemDetailsResponse> {
     match facade_post_peer_message(
         &state.config.working_dir,
         &parent_task_id,
@@ -432,7 +432,7 @@ pub async fn read_peer_messages_handler(
     State(state): State<LocalApiState>,
     Path(parent_task_id): Path<String>,
     axum::extract::Query(query): axum::extract::Query<ReadPeerMessagesQuery>,
-) -> Result<Json<Vec<PeerMessageResponse>>, ProblemResponse> {
+) -> Result<Json<Vec<PeerMessageResponse>>, ProblemDetailsResponse> {
     let messages = facade_read_peer_messages(
         &state.config.working_dir,
         &parent_task_id,

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -1,9 +1,9 @@
 use anyhow::{Context, Result};
+use axum::Router;
 use axum::extract::DefaultBodyLimit;
 use axum::middleware::{self, Next};
 use axum::response::Response;
 use axum::routing::{get, patch, post};
-use axum::{Json, Router};
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use hyper_util::server::conn::auto::Builder as HyperConnectionBuilder;
 use hyper_util::service::TowerToHyperService;
@@ -20,7 +20,8 @@ use super::handlers::{
     release_session_task_handler, schedule_team_handler, schema_handler, task_graph_handler,
     turns_handler, update_session_task_status_handler, watch_handler, watch_session_task_handler,
 };
-use super::{HSTS_HEADER_VALUE, HttpSurfaceSettings, ProblemDetails, ResolvedHttpSurface};
+use super::util::ProblemDetailsResponse;
+use super::{HSTS_HEADER_VALUE, HttpSurfaceSettings, ResolvedHttpSurface};
 use crate::app::runtime_tokio::{net::TcpListener, select, spawn};
 #[cfg(test)]
 use crate::config::Config;
@@ -113,22 +114,7 @@ async fn authorize_http_request(
 
 fn unauthorized_response() -> Response {
     use axum::response::IntoResponse;
-    let mut response = (
-        StatusCode::UNAUTHORIZED,
-        Json(ProblemDetails {
-            r#type: "https://aistar-au.github.io/vexcoder/problems/unauthorized".to_string(),
-            title: "unauthorized".to_string(),
-            status: StatusCode::UNAUTHORIZED.as_u16(),
-            detail: Some("unauthorized".to_string()),
-            instance: None,
-        }),
-    )
-        .into_response();
-    response.headers_mut().insert(
-        header::CONTENT_TYPE,
-        HeaderValue::from_static("application/problem+json"),
-    );
-    response
+    ProblemDetailsResponse::from_reason(StatusCode::UNAUTHORIZED, "unauthorized").into_response()
 }
 
 pub async fn run_http_surface(

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -20,7 +20,7 @@ use super::handlers::{
     release_session_task_handler, schedule_team_handler, schema_handler, task_graph_handler,
     turns_handler, update_session_task_status_handler, watch_handler, watch_session_task_handler,
 };
-use super::{ControlResponse, HSTS_HEADER_VALUE, HttpSurfaceSettings, ResolvedHttpSurface};
+use super::{HSTS_HEADER_VALUE, HttpSurfaceSettings, ProblemDetails, ResolvedHttpSurface};
 use crate::app::runtime_tokio::{net::TcpListener, select, spawn};
 #[cfg(test)]
 use crate::config::Config;
@@ -113,14 +113,22 @@ async fn authorize_http_request(
 
 fn unauthorized_response() -> Response {
     use axum::response::IntoResponse;
-    (
+    let mut response = (
         StatusCode::UNAUTHORIZED,
-        Json(ControlResponse {
-            ok: false,
-            reason: Some("unauthorized"),
+        Json(ProblemDetails {
+            r#type: "https://aistar-au.github.io/vexcoder/problems/unauthorized".to_string(),
+            title: "unauthorized".to_string(),
+            status: StatusCode::UNAUTHORIZED.as_u16(),
+            detail: Some("unauthorized".to_string()),
+            instance: None,
         }),
     )
-        .into_response()
+        .into_response();
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/problem+json"),
+    );
+    response
 }
 
 pub async fn run_http_surface(

--- a/src/server/tests/core.rs
+++ b/src/server/tests/core.rs
@@ -245,13 +245,21 @@ async fn test_release_session_task_route_returns_not_found_for_unknown_id() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let content_type = response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_owned);
     let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
     let payload: Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(payload.get("ok"), Some(&Value::Bool(false)));
     assert_eq!(
-        payload.get("reason"),
-        Some(&Value::String("session_task_not_found".to_string()))
+        payload.get("type"),
+        Some(&Value::String(
+            "https://aistar-au.github.io/vexcoder/problems/session_task_not_found".to_string()
+        ))
     );
+    assert_eq!(payload.get("status"), Some(&Value::Number(404u64.into())));
+    assert_eq!(content_type.as_deref(), Some("application/problem+json"));
 }
 
 #[tokio::test]
@@ -315,12 +323,56 @@ async fn test_http_router_rejects_invalid_bearer_token() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    let content_type = response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_owned);
     let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
     let payload: Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(payload.get("ok"), Some(&Value::Bool(false)));
     assert_eq!(
-        payload.get("reason"),
-        Some(&Value::String("unauthorized".to_string()))
+        payload.get("type"),
+        Some(&Value::String(
+            "https://aistar-au.github.io/vexcoder/problems/unauthorized".to_string()
+        ))
+    );
+    assert_eq!(payload.get("status"), Some(&Value::Number(401u64.into())));
+    assert_eq!(content_type.as_deref(), Some("application/problem+json"));
+}
+
+#[tokio::test]
+async fn test_turns_invalid_request_uses_problem_details_content_type() {
+    let router = build_router(Config::default_for_tui());
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/turns")
+                .header(CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    r#"{"type":"interrupt","request_id":"req-1","task_id":"task-1"}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        response
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok()),
+        Some("application/problem+json")
+    );
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let payload: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(payload.get("status"), Some(&Value::Number(400u64.into())));
+    assert_eq!(
+        payload.get("type"),
+        Some(&Value::String(
+            "https://aistar-au.github.io/vexcoder/problems/invalid_request_type".to_string()
+        ))
     );
 }
 
@@ -774,13 +826,21 @@ async fn test_interrupt_handler_returns_not_found_for_unknown_task() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let content_type = response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_owned);
     let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
     let payload: Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(payload.get("ok"), Some(&Value::Bool(false)));
+    assert_eq!(payload.get("status"), Some(&Value::Number(404u64.into())));
     assert_eq!(
-        payload.get("reason"),
-        Some(&Value::String("task_not_found".to_string()))
+        payload.get("type"),
+        Some(&Value::String(
+            "https://aistar-au.github.io/vexcoder/problems/task_not_found".to_string()
+        ))
     );
+    assert_eq!(content_type.as_deref(), Some("application/problem+json"));
 }
 
 #[tokio::test]
@@ -811,13 +871,21 @@ async fn test_approve_handler_returns_not_found_for_unknown_task() {
             .unwrap();
 
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let content_type = response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_owned);
     let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
     let payload: Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(payload.get("ok"), Some(&Value::Bool(false)));
+    assert_eq!(payload.get("status"), Some(&Value::Number(404u64.into())));
     assert_eq!(
-        payload.get("reason"),
-        Some(&Value::String("task_not_found".to_string()))
+        payload.get("type"),
+        Some(&Value::String(
+            "https://aistar-au.github.io/vexcoder/problems/task_not_found".to_string()
+        ))
     );
+    assert_eq!(content_type.as_deref(), Some("application/problem+json"));
 }
 
 #[tokio::test]
@@ -869,13 +937,21 @@ async fn test_approve_handler_returns_conflict_without_pending_approval() {
             .unwrap();
 
     assert_eq!(response.status(), StatusCode::CONFLICT);
+    let content_type = response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_owned);
     let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
     let payload: Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(payload.get("ok"), Some(&Value::Bool(false)));
+    assert_eq!(payload.get("status"), Some(&Value::Number(409u64.into())));
     assert_eq!(
-        payload.get("reason"),
-        Some(&Value::String("no_pending_approval".to_string()))
+        payload.get("type"),
+        Some(&Value::String(
+            "https://aistar-au.github.io/vexcoder/problems/no_pending_approval".to_string()
+        ))
     );
+    assert_eq!(content_type.as_deref(), Some("application/problem+json"));
 }
 
 #[tokio::test]

--- a/src/server/tests/teams.rs
+++ b/src/server/tests/teams.rs
@@ -186,8 +186,11 @@ async fn test_schedule_team_handler_enforces_max_parallel_tasks_under_parallel_r
             StatusCode::CONFLICT => {
                 conflicts += 1;
                 assert_eq!(
-                    payload.get("reason"),
-                    Some(&Value::String("concurrency_limit_reached".into()))
+                    payload.get("type"),
+                    Some(&Value::String(
+                        "https://aistar-au.github.io/vexcoder/problems/concurrency_limit_reached"
+                            .into()
+                    ))
                 );
             }
             other => panic!("unexpected schedule_team status: {other}"),

--- a/src/server/util.rs
+++ b/src/server/util.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result, anyhow, bail};
 use axum::Json;
+use axum::response::{IntoResponse, Response};
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use std::io::BufReader;
@@ -9,7 +10,7 @@ use std::sync::Arc;
 
 #[cfg(unix)]
 use super::ResolvedUnixSurface;
-use super::{ControlResponse, HttpSurfaceSettings, ResolvedHttpSurface, ResolvedServeConfig};
+use super::{HttpSurfaceSettings, ProblemDetails, ResolvedHttpSurface, ResolvedServeConfig};
 use crate::config::Config;
 use crate::http_facade::StatusCode;
 
@@ -167,42 +168,50 @@ pub fn default_unix_socket_path() -> std::path::PathBuf {
         .join("vexcoder.sock")
 }
 
-pub fn bad_request(reason: &'static str) -> (StatusCode, Json<ControlResponse>) {
-    (
-        StatusCode::BAD_REQUEST,
-        Json(ControlResponse {
-            ok: false,
-            reason: Some(reason),
-        }),
-    )
+#[derive(Debug)]
+pub struct ProblemResponse {
+    status: StatusCode,
+    problem: ProblemDetails,
 }
 
-pub fn not_found(reason: &'static str) -> (StatusCode, Json<ControlResponse>) {
-    (
-        StatusCode::NOT_FOUND,
-        Json(ControlResponse {
-            ok: false,
-            reason: Some(reason),
-        }),
-    )
+impl ProblemResponse {
+    pub fn new(status: StatusCode, reason: &'static str) -> Self {
+        Self {
+            status,
+            problem: ProblemDetails {
+                r#type: format!("https://aistar-au.github.io/vexcoder/problems/{reason}"),
+                title: reason.replace('_', " "),
+                status: status.as_u16(),
+                detail: Some(reason.replace('_', " ")),
+                instance: None,
+            },
+        }
+    }
 }
 
-pub fn conflict(reason: &'static str) -> (StatusCode, Json<ControlResponse>) {
-    (
-        StatusCode::CONFLICT,
-        Json(ControlResponse {
-            ok: false,
-            reason: Some(reason),
-        }),
-    )
+impl IntoResponse for ProblemResponse {
+    fn into_response(self) -> Response {
+        let mut response = (self.status, Json(self.problem)).into_response();
+        response.headers_mut().insert(
+            crate::http_facade::header::CONTENT_TYPE,
+            crate::http_facade::HeaderValue::from_static("application/problem+json"),
+        );
+        response
+    }
 }
 
-pub fn internal_error(_: serde_json::Error) -> (StatusCode, Json<ControlResponse>) {
-    (
-        StatusCode::INTERNAL_SERVER_ERROR,
-        Json(ControlResponse {
-            ok: false,
-            reason: Some("internal_error"),
-        }),
-    )
+pub fn bad_request(reason: &'static str) -> ProblemResponse {
+    ProblemResponse::new(StatusCode::BAD_REQUEST, reason)
+}
+
+pub fn not_found(reason: &'static str) -> ProblemResponse {
+    ProblemResponse::new(StatusCode::NOT_FOUND, reason)
+}
+
+pub fn conflict(reason: &'static str) -> ProblemResponse {
+    ProblemResponse::new(StatusCode::CONFLICT, reason)
+}
+
+pub fn internal_error(_: serde_json::Error) -> ProblemResponse {
+    ProblemResponse::new(StatusCode::INTERNAL_SERVER_ERROR, "internal_error")
 }

--- a/src/server/util.rs
+++ b/src/server/util.rs
@@ -169,16 +169,16 @@ pub fn default_unix_socket_path() -> std::path::PathBuf {
 }
 
 #[derive(Debug)]
-pub struct ProblemResponse {
+pub struct ProblemDetailsResponse {
     status: StatusCode,
-    problem: ProblemDetails,
+    details: ProblemDetails,
 }
 
-impl ProblemResponse {
-    pub fn new(status: StatusCode, reason: &'static str) -> Self {
+impl ProblemDetailsResponse {
+    pub fn from_reason(status: StatusCode, reason: &'static str) -> Self {
         Self {
             status,
-            problem: ProblemDetails {
+            details: ProblemDetails {
                 r#type: format!("https://aistar-au.github.io/vexcoder/problems/{reason}"),
                 title: reason.replace('_', " "),
                 status: status.as_u16(),
@@ -189,9 +189,9 @@ impl ProblemResponse {
     }
 }
 
-impl IntoResponse for ProblemResponse {
+impl IntoResponse for ProblemDetailsResponse {
     fn into_response(self) -> Response {
-        let mut response = (self.status, Json(self.problem)).into_response();
+        let mut response = (self.status, Json(self.details)).into_response();
         response.headers_mut().insert(
             crate::http_facade::header::CONTENT_TYPE,
             crate::http_facade::HeaderValue::from_static("application/problem+json"),
@@ -200,18 +200,18 @@ impl IntoResponse for ProblemResponse {
     }
 }
 
-pub fn bad_request(reason: &'static str) -> ProblemResponse {
-    ProblemResponse::new(StatusCode::BAD_REQUEST, reason)
+pub fn bad_request(reason: &'static str) -> ProblemDetailsResponse {
+    ProblemDetailsResponse::from_reason(StatusCode::BAD_REQUEST, reason)
 }
 
-pub fn not_found(reason: &'static str) -> ProblemResponse {
-    ProblemResponse::new(StatusCode::NOT_FOUND, reason)
+pub fn not_found(reason: &'static str) -> ProblemDetailsResponse {
+    ProblemDetailsResponse::from_reason(StatusCode::NOT_FOUND, reason)
 }
 
-pub fn conflict(reason: &'static str) -> ProblemResponse {
-    ProblemResponse::new(StatusCode::CONFLICT, reason)
+pub fn conflict(reason: &'static str) -> ProblemDetailsResponse {
+    ProblemDetailsResponse::from_reason(StatusCode::CONFLICT, reason)
 }
 
-pub fn internal_error(_: serde_json::Error) -> ProblemResponse {
-    ProblemResponse::new(StatusCode::INTERNAL_SERVER_ERROR, "internal_error")
+pub fn internal_error(_: serde_json::Error) -> ProblemDetailsResponse {
+    ProblemDetailsResponse::from_reason(StatusCode::INTERNAL_SERVER_ERROR, "internal_error")
 }

--- a/src/state/conversation/history.rs
+++ b/src/state/conversation/history.rs
@@ -674,9 +674,9 @@ fn tool_error_hint(name: &str) -> Option<&'static str> {
         "search_files" | "search" | "search_content" | "codebase_search" => Some(
             "Retry with a focused query or a concrete path scope so the next search result is easier to use.",
         ),
-        "write_file" | "apply_patch" | "edit_file" | "rename_file" => {
-            Some("Re-read the target path and retry with a streamlined file edit or patch.")
-        }
+        "write_file" | "apply_patch" | "edit_file" | "rename_file" => Some(
+            "Re-read the target path and retry with a streamlined file edit or patch that preserves local style; for Rust, keep the diff rustfmt-canonical.",
+        ),
         "git_status" | "git_diff" | "git_log" | "git_show" => {
             Some("Retry with a focused git target if the repository state is larger than expected.")
         }


### PR DESCRIPTION
## Summary
This change closes the remaining RFC-compliance items that were still absent on top of the earlier transport batches. It adds configurable protocol-discovery probe timeouts and request tracing, tightens JWT and rate-limit parsing, and moves Local API failures to RFC 9457 problem-details responses while documenting the new client setting.

## Motivation
Current main already contains the earlier transport, SSE, and TLS work, but a narrower set of standards gaps remained. Protocol discovery still used a fixed timeout with limited observability, retry parsing relied on textual heuristics alone, JWT validation accepted under-constrained headers and claims, and Local API failures still returned ad hoc `{ ok, reason }` payloads instead of a stable problem-details contract. Closing those gaps completes the remaining ADR-047-aligned transport work without reopening the larger surfaces that were already merged.

## Approach
The client now carries an `api_client.probe_timeout_ms` setting through protocol discovery so each probe uses an explicit timeout budget, and discovery requests emit `vex::http` debug traces for `/v1/messages`, `/props`, and `/v1/models`. Rate-limit handling now parses a typed JSON `retry_after_ms` field before falling back to the existing text heuristics so existing servers remain compatible while newer ones can provide a precise machine-readable hint. The HS256 JWT helper now rejects forbidden or unsupported JOSE header combinations, requires `iss`, `aud`, and `exp`, and validates issuer and audience explicitly. On the server side, the shared error helpers now return RFC 9457 `application/problem+json` payloads so handler error paths use one consistent contract instead of a parallel tuple of status code and `{ ok, reason }` JSON.

An alternative was to preserve the legacy error envelope and add problem-details fields beside it for a transition period. That approach was rejected because it would keep two competing error contracts alive in the same Local API surface and make the server tests ambiguous about which shape is authoritative. For retry parsing, a header-only approach was also considered, but it would discard useful structured hints already present in some rate-limit bodies.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo nextest run -j 2`
- `bash scripts/check_forbidden_names.sh`
- `cargo build --bin vex`
- `cargo run --bin vex -- --help`
- `cargo nextest run test_populate_server_info_respects_probe_timeout_config test_turns_invalid_request_uses_problem_details_content_type test_http_router_rejects_invalid_bearer_token test_interrupt_handler_returns_not_found_for_unknown_task test_approve_handler_returns_not_found_for_unknown_task test_approve_handler_returns_conflict_without_pending_approval`

## Risks
- Duplication / missed shared-code opportunity: `src/server/http.rs` still builds the unauthorized problem-details payload inline because the authentication middleware returns a raw response. If additional authentication failure variants are added, extracting that constructor into `src/server/util.rs` would reduce duplication.
- Unused code: none identified after `cargo clippy --all-targets -- -D warnings`; the touched helpers and tests are all referenced.
- Bugs / regression risk: clients that hard-coded the old `{ ok, reason }` error envelope will need to accept `application/problem+json`. A very small `api_client.probe_timeout_ms` can suppress protocol detection for slow local runtimes, and the stricter JWT validation will now reject tokens that were previously accepted without `iss`, `aud`, `exp`, `typ`, or with an unexpected `cty`.
- Inconsistency with ADRs: none identified. The branch keeps the server routed through facade entrypoints required by ADR-028, does not alter the runtime envelope covered by ADR-030, and aligns the remaining transport and discovery edges with ADR-047 and its addendum.
- Test coverage gaps: unit and integration tests cover the new timeout setting, retry parsing, JWT validation, and server error payloads. I did not run an external client against the Local API from outside the repository test harness, so third-party client compatibility is inferred from the updated server contract tests rather than a separate manual integration.
- Follow-up work deferred: RFC 9457 responses now populate `type`, `title`, `status`, and `detail`, but `instance` remains unset. If the server later gains stable request identifiers, attaching per-request instance URIs would fit naturally in a follow-up.
