### PR TITLE
Standardize repository terminology across docs and guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,8 @@ Read this file first.
 
 If this is a repository-hosted background session:
 
-- Stop here before reading any local bootstrap instruction below.
-- Ignore every `../vexdraft` reference in this file. Those lines are for local
+- Stop here before reading any operator-workstation bootstrap instruction below.
+- Ignore every `../vexdraft` reference in this file. Those lines are for operator-workstation
   operator sessions only.
 - Do not bootstrap, clone, sync, fetch, inspect, or depend on private skills,
   adjacent repos, or setup-workflow copies of the private skill tree.
@@ -23,11 +23,11 @@ If this is a repository-hosted background session:
 - Continue with the repository-hosted agent instructions file under `.github/`,
   `.github/instructions/repository.instructions.md`, and `CONTRIBUTING.md`.
 
-## Local bootstrap only
+## Operator-workstation bootstrap only
 
 Ignore this section in repository-hosted background sessions.
 
-- Only local operator sessions bootstrap private skills.
+- Only operator-workstation sessions bootstrap private skills.
 - Load `../vexdraft/.agents/skills/vex-local-bash/SKILL.md`.
 - Load `../vexdraft/.agents/skills/vex-remote-contract/SKILL.md`.
 - Load `../vexdraft/.agents/skills/vex-rust-arch/SKILL.md` for Rust changes.
@@ -53,8 +53,8 @@ Ignore this section in repository-hosted background sessions.
   same lane across multiple overlapping draft branches or PRs unless the lane
   is intentionally sharded for repository-hosted sessions with explicit
   disjoint file ownership and one shared integration branch.
-- Reuse or consolidate existing related draft PRs before starting a new one.
-- For any remote code-bearing lane, create or reuse the draft PR before the
+- Reuse or consolidate existing related pre-review PRs before starting a new one.
+- For any remote code-bearing lane, create or reuse the pre-review PR before the
   first code-bearing push and keep the branch pushed after every code-bearing
   commit or patch set.
 - Once remote work begins, treat `origin/<branch>` as authoritative. Do not
@@ -76,9 +76,9 @@ Ignore this section in repository-hosted background sessions.
   explicitly instructs the agent to merge in the current conversation, execute
   `gh pr merge --merge --delete-branch` immediately without re-asking. The
   user's instruction is the confirmation.
-- Release tags are a local operator step after the reviewed merge commit lands
+- Release tags are an operator-workstation step after the reviewed merge commit lands
   on `main`. Do not open a separate PR patch just to publish `v<version>`; sync
-  `main`, create the annotated tag locally with `git` or `gh`, and push the tag
+  `main`, create the annotated tag on the workstation with `git` or `gh`, and push the tag
   from that local checkout.
 
 ## Before committing
@@ -90,7 +90,7 @@ cargo test --all-targets
 bash scripts/check_forbidden_names.sh
 ```
 
-Keep `.git/hooks/pre-push` installed so the local push path re-runs
+Keep `.git/hooks/pre-push` installed so the workstation push path re-runs
 `cargo nextest run` automatically.
 
 The `ci` workflow runs 8 parallel jobs (lint, clippy, nextest, doctest,
@@ -125,9 +125,9 @@ repository's centralized workflow.
 
 Use five sections: Summary, Motivation, Approach, Validation, Risks.
 
-## For local operator sessions
+## For operator-workstation sessions
 
-Local operator workflows use private skills from `../vexdraft/.agents/skills/`.
+Operator-workstation workflows use private skills from `../vexdraft/.agents/skills/`.
 See `CONTRIBUTING.md` for the full local workflow, session commands, and the
 A–H post-session checklist.
 
@@ -135,7 +135,7 @@ A–H post-session checklist.
 
 - Stay self-contained within this repository.
 - Do not fetch or load private skills.
-- Ignore the `Local bootstrap only` section above and every `../vexdraft`
+- Ignore the `Operator-workstation bootstrap only` section above and every `../vexdraft`
   reference in this file.
 - Use the repository-hosted agent instructions file under `.github/`,
   `.github/instructions/`, and the checked-in agent profiles as the
@@ -168,7 +168,7 @@ A–H post-session checklist.
   file reads and continue.
 - Promote remote agent output onto a `work/<topic>` branch before
   commit-debug, CI watch, and PR preparation.
-- Create or reuse the draft PR for that review branch before the first
+- Create or reuse the pre-review PR for that review branch before the first
   code-bearing push, then keep `HEAD` in sync with `origin/<branch>` after
   every code-bearing fix.
 - Before every feature-branch push, refresh from `origin` and rebase onto the
@@ -178,7 +178,7 @@ A–H post-session checklist.
   disjoint write set. Keep the final merge path to `main` on the shared
   integration branch only.
 - If the hosted run opens a non-review branch or ends with only a planning
-  commit and no file diff, treat it as draft-only evidence. Do not present the
+  commit and no file diff, treat it as planning-only evidence. Do not present the
   change as implemented until code-bearing commits are promoted onto a
   review branch.
 - If `main` moves while hosted shards are running, do not force the running

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,7 +189,7 @@ bash scripts/check_forbidden_names.sh
 
 ## Release Packaging
 
-Package release changes on a review branch first, verify them locally, and open the PR without waiting on a duplicate packaging workflow run.
+Package release changes on a review branch first, verify them on the operator workstation, and open the PR without waiting on a duplicate packaging workflow run.
 
 ```bash
 git switch -c work/v<current-version>-packaging
@@ -211,7 +211,7 @@ git push -u origin work/v<current-version>-packaging
 
 Windows packaging is currently an unsigned alpha path. Platform trust warnings are expected until code signing lands; evaluate a compatible signing service only when the packaging ADR set explicitly requires it.
 
-The packaging scripts derive the archive tag from `Cargo.toml` and reject mismatched tag inputs. `.github/workflows/release.yml` now runs only for tag pushes and manual dispatch so review branches do not duplicate the main PR checks. After the branch gates are green and the local packaging smoke checks look correct, open the PR. Publish the prerelease only after the merge commit is on `main`:
+The packaging scripts derive the archive tag from `Cargo.toml` and reject mismatched tag inputs. `.github/workflows/release.yml` now runs only for tag pushes and manual dispatch so review branches do not duplicate the main PR checks. After the branch gates are green and the workstation packaging smoke checks look correct, open the PR. Publish the prerelease only after the merge commit is on `main`:
 
 ```bash
 git switch main
@@ -220,7 +220,7 @@ git tag -a v<current-version> -m "Release v<current-version>"
 git push origin v<current-version>
 ```
 
-The tag push is a local post-merge release step. Do not open a second PR patch
+The tag push is an operator-workstation post-merge release step. Do not open a second PR patch
 just to publish the matching `v<current-version>` tag.
 
 For semver and short-SHA tags, the pushed tag drives the rest of the release
@@ -254,7 +254,7 @@ depend on the private `vexdraft` skill tree. Use the checked-in background
 session contract under `.github/instructions/` and the repository-hosted agent
 instructions file under `.github/`.
 
-- In `AGENTS.md`, hosted sessions must ignore the `Local bootstrap only`
+- In `AGENTS.md`, hosted sessions must ignore the `Operator-workstation bootstrap only`
   section and every `../vexdraft` reference.
 - Hosted sessions must not read any `SKILL.md` file.
 - Hosted sessions must use English only in agent-authored output.
@@ -303,12 +303,12 @@ instructions file under `.github/`.
   final PR to `main`. Parallel hosted shard PRs are allowed only when each
   shard has an explicit disjoint write set and all accepted commits are
   promoted onto the shared integration branch before merge.
-- For any remote code-bearing branch, create or reuse the draft PR before the
+- For any remote code-bearing branch, create or reuse the pre-review PR before the
   first code-bearing push. Do not wait for a later merge prompt to open the
   PR.
 - After every code-bearing commit or patch set, push immediately, fetch
   `origin`, and verify `HEAD` matches `origin/<branch>`. Do not continue from
-  unpublished local-only branch state.
+  unpublished workstation-only branch state.
 - Once the remote branch/PR exists, treat the remote branch head and PR state as
   authoritative for commit-debug, CI watch, PR body updates, review cleanup,
   and merge readiness.
@@ -462,7 +462,7 @@ order.
    Inspect the hosted PR first with
    `gh pr view <pr> --json headRefName,commits,statusCheckRollup`.
    If the hosted PR has only a planning commit or no file diff, treat it as
-   draft-only evidence and do not present the change as implemented.
+  planning-only evidence and do not present the change as implemented.
    For parallel shards, cherry-pick them onto one shared integration branch in
    a deterministic order, then resolve cross-shard conflicts there rather than
    reopening multiple competing PRs to `main`.

--- a/adr/ADR-022-amendment-2026-03-13.md
+++ b/adr/ADR-022-amendment-2026-03-13.md
@@ -3,7 +3,7 @@
 **Date:** 2026-03-13
 **Status:** Amended
 **Related:** ADR-018, ADR-019, ADR-027, ADR-030
-**Supersedes:** Previous ADR-022 command execution section
+**Deprecates:** Previous ADR-022 command execution section
 
 ## Command Execution (AMENDED 2026-03-13)
 

--- a/adr/ADR-030-runtime-task-state-and-orchestrator-control-flow.md
+++ b/adr/ADR-030-runtime-task-state-and-orchestrator-control-flow.md
@@ -4,8 +4,8 @@
 - **Date:** 2026-03-16
 - **Deciders:** Maintainers
 - **Depends on:** ADR-023, ADR-025, ADR-027, ADR-028, ADR-029
-- **Supersedes:** None
-- **Superseded by:** None
+- **Deprecates:** None
+- **Deprecated by:** None
 
 ## Context
 

--- a/adr/ADR-031-operator-surface-ui-overhaul.md
+++ b/adr/ADR-031-operator-surface-ui-overhaul.md
@@ -4,8 +4,8 @@
 - **Date:** 2026-03-18
 - **Deciders:** Core maintainer
 - **Depends on:** ADR-022, ADR-027, ADR-028, ADR-030
-- **Supersedes:** None
-- **Superseded by:** None
+- **Deprecates:** None
+- **Deprecated by:** None
 
 ## Context
 

--- a/adr/ADR-032-prompt-area-interactivity-and-context-guard.md
+++ b/adr/ADR-032-prompt-area-interactivity-and-context-guard.md
@@ -4,8 +4,8 @@
 - **Date:** 2026-03-22
 - **Deciders:** Core maintainer
 - **Depends on:** ADR-031, ADR-015
-- **Supersedes:** None
-- **Superseded by:** None
+- **Deprecates:** None
+- **Deprecated by:** None
 
 ## Context
 

--- a/adr/ADR-033-hybrid-retrieval-context-architecture.md
+++ b/adr/ADR-033-hybrid-retrieval-context-architecture.md
@@ -4,8 +4,8 @@
 - **Date:** 2026-03-22
 - **Deciders:** Core maintainer
 - **Depends on:** ADR-032, ADR-031, ADR-029
-- **Supersedes:** None
-- **Superseded by:** None
+- **Deprecates:** None
+- **Deprecated by:** None
 
 ## Context
 

--- a/adr/ADR-034-multi-agent-parallel-task-execution.md
+++ b/adr/ADR-034-multi-agent-parallel-task-execution.md
@@ -4,8 +4,8 @@
 - **Date:** 2026-03-26
 - **Deciders:** Core maintainer
 - **Depends on:** ADR-024, ADR-025, ADR-026, ADR-030, ADR-033
-- **Supersedes:** None
-- **Superseded by:** None
+- **Deprecates:** None
+- **Deprecated by:** None
 
 ## Context
 

--- a/adr/ADR-035-undo-checkpoints-and-binary-safe-rollback.md
+++ b/adr/ADR-035-undo-checkpoints-and-binary-safe-rollback.md
@@ -4,8 +4,8 @@
 - **Date:** 2026-03-30
 - **Deciders:** Core maintainer
 - **Depends on:** ADR-024, ADR-030, ADR-031
-- **Supersedes:** None
-- **Superseded by:** None
+- **Deprecates:** None
+- **Deprecated by:** None
 
 ## Context
 

--- a/adr/ADR-038-memory-first-architecture-with-minimal-disk-io.md
+++ b/adr/ADR-038-memory-first-architecture-with-minimal-disk-io.md
@@ -4,8 +4,8 @@
 - **Date:** 2026-03-30
 - **Deciders:** Core maintainer
 - **Depends on:** ADR-029, ADR-030, ADR-033, ADR-034
-- **Supersedes:** None
-- **Superseded by:** None
+- **Deprecates:** None
+- **Deprecated by:** None
 
 ## Context
 

--- a/adr/ADR-039-neutral-cli-voice-and-spatial-status-language.md
+++ b/adr/ADR-039-neutral-cli-voice-and-spatial-status-language.md
@@ -4,8 +4,8 @@
 - **Date:** 2026-03-31
 - **Deciders:** Core maintainer
 - **Depends on:** ADR-023, ADR-030, ADR-031, ADR-034
-- **Supersedes:** None
-- **Superseded by:** None
+- **Deprecates:** None
+- **Deprecated by:** None
 
 ## Context
 

--- a/adr/ADR-040-real-time-local-turn-telemetry.md
+++ b/adr/ADR-040-real-time-local-turn-telemetry.md
@@ -4,8 +4,8 @@
 - **Date:** 2026-03-31
 - **Deciders:** Core maintainer
 - **Depends on:** ADR-030, ADR-031, ADR-038, ADR-039
-- **Supersedes:** None
-- **Superseded by:** None
+- **Deprecates:** None
+- **Deprecated by:** None
 
 ## Context
 

--- a/adr/ADR-041-transcript-renderer-wiring-and-compact-tool-paragraphs.md
+++ b/adr/ADR-041-transcript-renderer-wiring-and-compact-tool-paragraphs.md
@@ -4,8 +4,8 @@
 - **Date:** 2026-04-01
 - **Deciders:** Core maintainer
 - **Depends on:** ADR-029, ADR-030, ADR-031, ADR-040
-- **Supersedes:** None
-- **Superseded by:** None
+- **Deprecates:** None
+- **Deprecated by:** None
 
 ## Context
 

--- a/adr/ADR-042-tool-registration-and-approval-layer.md
+++ b/adr/ADR-042-tool-registration-and-approval-layer.md
@@ -5,8 +5,8 @@
 - **Amended:** 2026-04-07
 - **Deciders:** Core maintainer
 - **Depends on:** ADR-029, ADR-040
-- **Supersedes:** None
-- **Superseded by:** None
+- **Deprecates:** None
+- **Deprecated by:** None
 
 ## Context
 

--- a/adr/ADR-043-structured-output-parser-adoption-gates.md
+++ b/adr/ADR-043-structured-output-parser-adoption-gates.md
@@ -4,8 +4,8 @@
 - **Date:** 2026-04-02
 - **Deciders:** Core maintainer
 - **Depends on:** ADR-029, ADR-030, ADR-031, ADR-041
-- **Supersedes:** None
-- **Superseded by:** None
+- **Deprecates:** None
+- **Deprecated by:** None
 
 ## Context
 

--- a/adr/ADR-044-test-suite-scalability-and-fixture-patterns.md
+++ b/adr/ADR-044-test-suite-scalability-and-fixture-patterns.md
@@ -4,8 +4,8 @@
 - **Date:** 2026-04-07
 - **Deciders:** Core maintainer
 - **Depends on:** ADR-041, ADR-043
-- **Supersedes:** None
-- **Superseded by:** None
+- **Deprecates:** None
+- **Deprecated by:** None
 
 ## Context
 

--- a/adr/ADR-045-replay-first-task-document-and-single-writer-state.md
+++ b/adr/ADR-045-replay-first-task-document-and-single-writer-state.md
@@ -4,8 +4,8 @@
 - **Date:** 2026-04-07
 - **Deciders:** Core maintainer
 - **Depends on:** ADR-025, ADR-029, ADR-030, ADR-035, ADR-041, ADR-043
-- **Supersedes:** None
-- **Superseded by:** None
+- **Deprecates:** None
+- **Deprecated by:** None
 
 ## Context
 

--- a/adr/ADR-046-agent-peer-message-channel.md
+++ b/adr/ADR-046-agent-peer-message-channel.md
@@ -4,8 +4,8 @@
 - **Date:** 2026-04-13
 - **Deciders:** Core maintainer
 - **Depends on:** ADR-034, ADR-025, ADR-028, ADR-038, ADR-045
-- **Supersedes:** None
-- **Superseded by:** None
+- **Deprecates:** None
+- **Deprecated by:** None
 
 ---
 

--- a/adr/ADR-047-block-delta-protocol-discovery-dual-protocol-support.md
+++ b/adr/ADR-047-block-delta-protocol-discovery-dual-protocol-support.md
@@ -131,4 +131,4 @@ Expanded coverage now includes HTTP-level `tx_` SSE assertions for both mapper f
 5. Add protocol mapper tests — **done; HTTP-level mapper assertions and client discovery tests are merged**
 6. Update docs + CHANGELOG — **in progress**
 
-This ADR supersedes all previous versions and captures the intended end state. The repository now contains the phase 0 foundations, mapper serialisation, live `/v1/turns` negotiated emission, and the unified local discovery cutover; remaining work is primarily documentation follow-through and broader parity coverage.
+This ADR deprecates all previous versions and captures the intended end state. The repository now contains the phase 0 foundations, mapper serialisation, live `/v1/turns` negotiated emission, and the unified workstation-discovery cutover; remaining work is primarily documentation follow-through and broader parity coverage.

--- a/adr/ADR-048-operator-permissions-overlay-and-mode-precedence.md
+++ b/adr/ADR-048-operator-permissions-overlay-and-mode-precedence.md
@@ -4,8 +4,8 @@
 - **Date:** 2026-04-19
 - **Deciders:** Core maintainer
 - **Depends on:** ADR-022, ADR-024 Gap 13, ADR-042, ADR-038
-- **Supersedes:** None
-- **Superseded by:** None
+- **Deprecates:** None
+- **Deprecated by:** None
 
 ## Context
 

--- a/adr/ADR-README.md
+++ b/adr/ADR-README.md
@@ -14,7 +14,7 @@ All ADR files are stored under `adr/`.
 | **Active** | In progress in the current tree; subsequent phases or verification may still remain |
 | **Accepted** | In effect -- code must conform |
 | **Complete** | All scoped implementation items are complete; housekeeping move to `completed/` still remains |
-| **Deprecated by ADR-XXX** | Replaced; retained for history |
+| **Deprecated by ADR-XXX** | Replaced; retained as a deprecated design record |
 | **Locked** | Accepted and immutable -- no further amendments without a new ADR |
 | **Deprecated** | Was accepted, no longer applies |
 
@@ -37,11 +37,11 @@ All ADR files are stored under `adr/`.
 | [ADR-038](ADR-038-memory-first-architecture-with-minimal-disk-io.md) | Memory-first architecture with minimal disk I/O | Accepted (Batches D-H merged) | 0 items remaining |
 | [ADR-039](ADR-039-neutral-cli-voice-and-spatial-status-language.md) | Neutral CLI voice and spatial status language | Proposed (Batch A merged on main) | Batch A merged in PR #292; search.exclude path-boundary fix in PR #293; Batch D corrected 2026-04-09 to keep paragraph progress on the owned transcript surface; remaining batches B-D cover vocabulary, active indicator, and paragraph progress stream |
 | [ADR-040](ADR-040-real-time-local-turn-telemetry.md) | Real-time local turn telemetry | Proposed (operator-surface contract corrected 2026-04-09) | Telemetry labels updated to arrow notation in ADR-041; operator-surface items 22-23 keep committed and live telemetry on the owned transcript surface |
-| [ADR-041](ADR-041-transcript-renderer-wiring-and-compact-tool-paragraphs.md) | Transcript renderer wiring and compact tool paragraphs | Accepted (2026-04-08 host-scrollback amendment deprecated 2026-04-09) | Normaliser flush, compact tool paragraphs, arrow telemetry labels; D17-D22 are retained as rejected design history, not an active cutover target |
+| [ADR-041](ADR-041-transcript-renderer-wiring-and-compact-tool-paragraphs.md) | Transcript renderer wiring and compact tool paragraphs | Accepted (2026-04-08 host-scrollback amendment deprecated 2026-04-09) | Normaliser flush, compact tool paragraphs, arrow telemetry labels; D17-D22 are retained as rejected deprecated-design context, not an active cutover target |
 | [ADR-042](ADR-042-tool-registration-and-approval-layer.md) | Tool registration and approval layer | Accepted (amended 2026-04-07) | Tool schema registration, alias-based shell approval, and session-level ToolPolicy are in effect |
 | [ADR-043](ADR-043-structured-output-parser-adoption-gates.md) | Structured output parser adoption gates | Active, with open adoption gates | Present in tree but not the default runtime parser path; 3 gates: live wiring, parity, defect reduction |
 | [ADR-044](ADR-044-test-suite-scalability-and-fixture-patterns.md) | Test suite scalability and fixture patterns | Proposed | 3-phase implementation roadmap; Phase 1: aggregator + RAII helpers; Phase 2: builder API + async; Phase 3: parameterization + coverage |
-| [ADR-045](ADR-045-replay-first-task-document-and-single-writer-state.md) | Replay-first task document and single-writer state | Proposed | Defines `TaskDocumentCondenser` as sole writer, `RuntimeEventLog` as accepted persisted history, full event coverage requirement, full-fidelity checkpoints, and session rollback markers; deprecates lossy `persistable_snapshot` as accepted resume source |
+| [ADR-045](ADR-045-replay-first-task-document-and-single-writer-state.md) | Replay-first task document and single-writer state | Proposed | Defines `TaskDocumentCondenser` as sole writer, `RuntimeEventLog` as accepted persisted history, full event coverage requirement, full-fidelity checkpoints, and session rollback markers; deprecates lossy `persistable_snapshot` as an accepted resume source |
 | [ADR-046](ADR-046-agent-peer-message-channel.md) | Agent peer message channel | Accepted | Async append-only peer correction channel is accepted; dependency-direction constraints continue to govern any cross-process bridge |
 | [ADR-047 amendment](ADR-047-amendment-2026-04-16.md) | API-first runtime event envelope and trait reduction | Amended | Phase A targets `json_handoff.rs` envelope metadata and explicit tool lifecycle events before retiring legacy runtime loop traits |
 | [ADR-047](ADR-047-block-delta-protocol-discovery-dual-protocol-support.md) | Block-delta default, discovery, and dual-protocol support | Accepted | `tx_` IDs, negotiated `/v1/turns`, mapper SSE coverage, and unified local discovery are merged; docs and broader parity follow-through remain |
@@ -55,16 +55,16 @@ the top-level `adr/` directory pending a housekeeping move.
 | ADR | Title | Status | Notes |
 | :--- | :--- | :--- | :--- |
 | [ADR-013](ADR-013-tui-completion-deployment-plan.md) | TUI completion and deployment plan | Accepted | All phases complete |
-| [ADR-018](ADR-018-managed-tui-scrollback-streaming-cell-overlays.md) | Managed TUI scrollback | deprecated by ADR-027 | Retained for history |
+| [ADR-018](ADR-018-managed-tui-scrollback-streaming-cell-overlays.md) | Managed TUI scrollback | Deprecated by ADR-027 | Retained as a deprecated design record |
 | [ADR-023](ADR-023-deterministic-edit-loop.md) | Deterministic edit loop | Complete | EL-01 through EL-13 all merged |
 | [ADR-025](ADR-025-runtime-json-handoff-contract.md) | Runtime JSON handoff contract | Complete | PI-09 through PI-12 all merged |
 | [ADR-026](ADR-026-localapiserver-transport-binding.md) | LocalApiServer transport binding | Complete | PI-13 through PI-16 all merged |
-| [ADR-027](ADR-027-full-screen-tui-command-session-capture.md) | Full-screen TUI command-session capture | Accepted (complete) | deprecated ADR-018/019 |
+| [ADR-027](ADR-027-full-screen-tui-command-session-capture.md) | Full-screen TUI command-session capture | Accepted (complete) | Deprecates ADR-018/019 |
 
 ## Remaining Work Summary (current transcript surface + 1 external dependency)
 
 ADR-031 and ADR-041 still retain the 2026-04-08 host-owned scrollback text as
-deprecated context, but that direction is displaced by the 2026-04-09
+deprecated design context, but that direction is deprecated by the 2026-04-09
 owned-transcript correction. The operator surface keeps one app-owned
 transcript, review stays in-surface or via explicit overlays, and no ratatui
 inline viewport insertion or `HostScrollbackSink` cutover is an active merge
@@ -94,7 +94,7 @@ Full history and ADR status detail are located in `TASKS/ACTIVE-ROADMAP.md`.
 | [ADR-001](completed/ADR-001-tdm-agentic-manifest-strategy.md) | Test-Driven Manifest (TDM) | Accepted |
 | [ADR-002](completed/ADR-002-lexical-path-normalization.md) | Lexical path normalization | Accepted |
 | [ADR-003](completed/ADR-003-dual-protocol-api-auto-detection.md) | Dual-protocol API auto-detection | Accepted |
-| [ADR-004](completed/ADR-004-runtime-seam-headless-first.md) | Runtime seam headless-first | deprecated by ADR-006/007 |
+| [ADR-004](completed/ADR-004-runtime-seam-headless-first.md) | Runtime seam headless-first | Deprecated by ADR-006/007 |
 | [ADR-005](completed/ADR-005-cfg-test-mock-injection.md) | cfg-test mock injection | Accepted |
 | [ADR-006](completed/ADR-006-runtime-mode-contracts.md) | Runtime mode contracts | Accepted |
 | [ADR-007](completed/ADR-007-runtime-accepted-dispatch-no-alt-routing.md) | Accepted dispatch no-alt-routing | Accepted |
@@ -106,6 +106,6 @@ Full history and ADR status detail are located in `TASKS/ACTIVE-ROADMAP.md`.
 | [ADR-014](completed/ADR-014-runtime-core-policy-dedup-and-enforcement.md) | Policy dedup and enforcement | Accepted |
 | [ADR-015](completed/ADR-015-local-endpoint-text-protocol-default.md) | Local endpoint text-protocol default | Accepted |
 | [ADR-016](completed/ADR-016-local-tool-loop-guard-and-correction.md) | Local tool-loop guard and correction | Accepted |
-| [ADR-017](completed/ADR-017-append-single-session-runtime.md) | Append single-session runtime | deprecated by ADR-018 |
-| [ADR-019](completed/ADR-019-adr-018-follow-up-correctness-cutover-cleanup.md) | ADR-018 subsequent correctness cutover | deprecated by ADR-027 |
+| [ADR-017](completed/ADR-017-append-single-session-runtime.md) | Append single-session runtime | Deprecated by ADR-018 |
+| [ADR-019](completed/ADR-019-adr-018-follow-up-correctness-cutover-cleanup.md) | ADR-018 subsequent correctness cutover | Deprecated by ADR-027 |
 | [ADR-020](completed/ADR-020-looping-architecture-enriched-response-correctness.md) | Looping architecture enriched response | Accepted |

--- a/adr/completed/ADR-004-runtime-seam-headless-first.md
+++ b/adr/completed/ADR-004-runtime-seam-headless-first.md
@@ -1,7 +1,7 @@
 # ADR-004: Runtime seam refactor — headless-first architecture (REF track)
 
 **Date:** 2026-02-18  
-**Status:** Superseded operationally by ADR-006 and ADR-007  
+**Status:** Deprecated operationally by ADR-006 and ADR-007  
 **Deciders:** Core maintainer  
 **Related tasks:** REF-02 through REF-06 in `TASKS/` (planned; to be created)  
 **Target completion:** v0.2.0

--- a/adr/completed/ADR-006-runtime-mode-contracts.md
+++ b/adr/completed/ADR-006-runtime-mode-contracts.md
@@ -5,7 +5,7 @@
 **Deciders:** Core maintainer  
 **Related tasks:** `TASKS/REF-02-runtime-mode-contract.md`, `TASKS/REF-03-tui-mode-implement.md`, `TASKS/REF-04-runtime-context-start-turn.md`, `TASKS/REF-05-runtime-loop.md`, `TASKS/REF-06-tui-frontend-adapter.md`  
 **Amendment:** 2026-02-19 signature sections synchronized with accepted ADR-008 typed poll/interrupt contracts (`UserInputEvent`, `on_interrupt`)  
-**Supersedes:** Nothing. Extends `ADR-004` with concrete type contracts.
+**Deprecates:** Nothing. Extends `ADR-004` with concrete type contracts.
 
 ---
 

--- a/adr/completed/ADR-007-runtime-accepted-dispatch-no-alt-routing.md
+++ b/adr/completed/ADR-007-runtime-accepted-dispatch-no-alt-routing.md
@@ -3,7 +3,7 @@
 **Date:** 2026-02-19
 **Status:** Accepted
 **Deciders:** Core maintainer
-**Supersedes operationally:** ADR-004 (headless-first seam — now fully realized)
+**Deprecates operationally:** ADR-004 (headless-first seam — now fully realized)
 **Related tasks:** REF-08 runtime cutover task manifest (repository-local)
 
 ## Decision (normative)

--- a/adr/completed/ADR-008-runtime-cutover-parity-guardrails.md
+++ b/adr/completed/ADR-008-runtime-cutover-parity-guardrails.md
@@ -5,7 +5,7 @@
 **Deciders:** Core maintainer
 **Related tasks:** `TASKS/completed/REF-08-full-runtime-cutover.md`,
 `TASKS/completed/REF-08-deltas/`
-**Supersedes operationally:** none (complements ADR-007)
+**Deprecates operationally:** none (complements ADR-007)
 
 ## Context
 

--- a/adr/completed/ADR-009-runtime-core-tui-interaction-contract.md
+++ b/adr/completed/ADR-009-runtime-core-tui-interaction-contract.md
@@ -4,7 +4,7 @@
 **Status:** Accepted
 **Deciders:** Core maintainer
 **Related tasks:** Runtime-core TUI feature track (follow-up manifests)
-**Supersedes operationally:** none (complements ADR-007 and ADR-008)
+**Deprecates operationally:** none (complements ADR-007 and ADR-008)
 
 ## Context
 

--- a/adr/completed/ADR-010-runtime-core-tui-viewport-and-transcript.md
+++ b/adr/completed/ADR-010-runtime-core-tui-viewport-and-transcript.md
@@ -4,7 +4,7 @@
 **Status:** Accepted
 **Deciders:** Core maintainer
 **Related tasks:** Runtime-core TUI feature track (follow-up manifests)
-**Supersedes operationally:** none (complements ADR-006 through ADR-009)
+**Deprecates operationally:** none (complements ADR-006 through ADR-009)
 
 ## Context
 

--- a/adr/completed/ADR-011-runtime-core-tui-render-loop-and-lifecycle.md
+++ b/adr/completed/ADR-011-runtime-core-tui-render-loop-and-lifecycle.md
@@ -4,7 +4,7 @@
 **Status:** Accepted
 **Deciders:** Core maintainer
 **Related tasks:** Runtime-core TUI feature track (follow-up manifests)
-**Supersedes operationally:** none (complements ADR-007 through ADR-010)
+**Deprecates operationally:** none (complements ADR-007 through ADR-010)
 
 ## Context
 

--- a/adr/completed/ADR-012-runtime-core-tui-deployment-gate.md
+++ b/adr/completed/ADR-012-runtime-core-tui-deployment-gate.md
@@ -5,7 +5,7 @@
 **Deciders:** Core maintainer
 **Related tasks:** `TASKS/completed/REF-08-full-runtime-cutover.md`,
 `TASKS/completed/REF-08-deltas/`, runtime-core TUI feature follow-up manifests
-**Supersedes operationally:** none (consolidates ADR-009, ADR-010, ADR-011 for release gating)
+**Deprecates operationally:** none (consolidates ADR-009, ADR-010, ADR-011 for release gating)
 
 ## Context
 

--- a/adr/completed/ADR-013-tui-completion-deployment-plan.md
+++ b/adr/completed/ADR-013-tui-completion-deployment-plan.md
@@ -5,7 +5,7 @@
 **Deciders:** Core maintainer
 **Related tasks:** CORE-07 through CORE-14, FEAT-10 through FEAT-16
 **ADR chain:** Implements ADR-012 deployment gate; governed by ADR-007, ADR-008, ADR-009, ADR-010, ADR-011
-**Supersedes operationally:** nothing
+**Deprecates operationally:** nothing
 
 ---
 

--- a/adr/completed/ADR-017-append-single-session-runtime.md
+++ b/adr/completed/ADR-017-append-single-session-runtime.md
@@ -1,9 +1,9 @@
 # ADR-017: Append-Terminal Single Session Runtime
 
 **Date:** 2026-02-21
-**Status:** Superseded by ADR-018
+**Status:** Deprecated by ADR-018
 **Deciders:** Core maintainer
-**Related tasks:** (withdrawn after supersession)
+**Related tasks:** (withdrawn after deprecation)
 
 ## Context
 

--- a/adr/completed/ADR-018-managed-tui-scrollback-streaming-cell-overlays.md
+++ b/adr/completed/ADR-018-managed-tui-scrollback-streaming-cell-overlays.md
@@ -1,11 +1,11 @@
 # ADR-018: Managed TUI — Scrollback, Streaming Cell, Overlays
 
 **Date:** 2026-02-22
-**Status:** Superseded by ADR-027
+**Status:** Deprecated by ADR-027
 **Deciders:** Core maintainer
 **Related tasks:** CORE-15, CORE-16, CORE-17, FEAT-17, FEAT-18, FEAT-19
 **ADR chain:** ADR-006, ADR-007, ADR-009, ADR-010
-**Supersedes:** ADR-017 (on acceptance + migration completion)
+**Deprecates:** ADR-017 (on acceptance + migration completion)
 
 ## Context
 

--- a/adr/completed/ADR-027-full-screen-tui-command-session-capture.md
+++ b/adr/completed/ADR-027-full-screen-tui-command-session-capture.md
@@ -5,7 +5,7 @@
 **Deciders:** Core maintainer
 **Related tasks:** CORE-15, CORE-16, PE-01, PJ-03
 **ADR chain:** ADR-018, ADR-019, ADR-022
-**Supersedes:** ADR-018, ADR-019 (corrective amendment)
+**Deprecates:** ADR-018, ADR-019 (corrective amendment)
 ## Context
 
 Previous discussions considered an inline overlay pattern that would keep

--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -71,7 +71,7 @@ array of `{check,status,message}` objects.
 Prints the current privacy summary for the CLI and LocalApiServer surfaces.
 
 The output is structured text so it can be reviewed in an interactive shell, written to a
-file, or copied into local operator documentation.
+file, or copied into operator-workstation documentation.
 
 ### `vex credentials <set|get|delete|list>`
 
@@ -111,11 +111,11 @@ recent task file in `.vex/state` (or `VEX_STATE_DIR`).
 ### `vex pr-summary`
 
 Builds a diff from the current branch against the merge-base of the default
-remote branch (`origin/HEAD`) and runs one model turn to draft a PR title and
+remote branch (`origin/HEAD`) and runs one model turn to propose a PR title and
 body.
 
 The result prints to stdout. The current template starts with a `Title:` line
-followed by a Markdown body, so you can review it locally or pipe it into your
+followed by a Markdown body, so you can review it on your workstation or pipe it into your
 own git-hosting CLI workflow.
 
 ### `vex migrate config [--output PATH]`

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -12,7 +12,7 @@ vex init
 Highest priority wins:
 
 1. Environment variables
-2. Repo-local `.vex/config.toml`
+2. Repo-scoped `.vex/config.toml`
 3. User config: `~/.config/vex/config.toml` or `~/.vex/config.toml`
 4. System config: `/etc/vex/config.toml`
 5. Built-in defaults
@@ -21,7 +21,7 @@ Highest priority wins:
 prefers `VEX_MODEL_TOKEN` from the environment and then falls back to the OS
 credential store unless `VEX_KEYRING_DISABLED` is set.
 
-Automatic context assembly now keeps small file rollups in a process-local
+Automatic context assembly now keeps small file rollups in a process-resident
 memory cache. Search indexes under `.vex/index/` and task-state JSON under
 `.vex/state/` remain the intended disk-backed layers.
 
@@ -419,7 +419,7 @@ result and is expected to switch strategy on the next attempt. Default: `200`.
 
 ### `VEX_WRITE_FILE_MAX_LINES`
 
-Hard line limit for `write_file`. Calls exceeding this are rejected outright
+Strict line limit for `write_file`. Calls exceeding this are rejected outright
 with an error directing the model to use `apply_patch` or `edit_file`.
 Default: `500`.
 

--- a/docs/src/dependency-upgrades.md
+++ b/docs/src/dependency-upgrades.md
@@ -254,7 +254,7 @@ the tree.
 
 When the upgrade workflow matures and all active seams are well-tested, the
 `scripts/upgrade-deps.sh apply` command can be wrapped in a GitHub Actions
-scheduled workflow that opens a draft PR. The design prerequisite is that CI
+scheduled workflow that opens a pre-review PR. The design prerequisite is that CI
 passes on the manifest-only change for crates whose seam files have no API
 churn in the release. The current Makefile targets are already structured for
 this: `make deps-deny && make deps-upgrade && make gate` is a self-contained

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -62,7 +62,7 @@ latency or scale profile:
   code that is harder to evolve and test than the current typed header.
 - A dedicated sidecar index could persist the header projection separately and
   avoid parsing the full JSON document during cold start, but it must also
-  solve invalidation and crash-consistency so the sidecar cannot drift from the
+  solve invalidation and crash-consistency so the sidecar cannot diverge from the
   task-state JSON.
 - Directory sharding by time slice or prefix can reduce `read_dir` and
   metadata pressure when the task-state surface grows large enough that one

--- a/src/api/stream.rs
+++ b/src/api/stream.rs
@@ -16,7 +16,7 @@ pub use self::text_normaliser::{NormalisedChunk, StreamTextNormaliser};
 /// real SSE frame. ADR-021 Item 26.
 const MAX_SSE_BUFFER_BYTES: usize = 1_048_576;
 
-/// Hard ceiling on the tool-call index accepted from a chat-compat stream.
+/// Strict ceiling on the tool-call index accepted from a chat-compat stream.
 /// Indices beyond this cap are clamped to prevent unbounded Vec allocation
 /// from untrusted server data.
 pub(crate) const MAX_TOOL_CALL_INDEX: usize = 1_024;

--- a/src/bin/vex/cli.rs
+++ b/src/bin/vex/cli.rs
@@ -68,7 +68,7 @@ pub(super) enum Commands {
     InstallHooks,
     /// Remove the vexcoder `prepare-commit-msg` hook.
     UninstallHooks,
-    /// Manage the local skills registry.
+    /// Manage the workstation-scoped skills registry.
     Skills {
         #[command(subcommand)]
         sub: SkillsCommands,
@@ -86,7 +86,7 @@ pub(super) enum Commands {
     },
     /// Create a new git branch from HEAD and record it on the most recent task.
     Branch { name: String },
-    /// Generate a pull request title and body draft for the current branch.
+    /// Generate a proposed pull request title and body for the current branch.
     PrSummary,
     /// Configuration migration utilities.
     Migrate {
@@ -110,7 +110,7 @@ pub(super) enum Commands {
         #[arg(long)]
         force: bool,
     },
-    /// Run the local API transport adapter.
+    /// Run the same-machine API transport adapter.
     Serve {
         #[arg(long)]
         host: Option<String>,
@@ -135,7 +135,7 @@ pub(super) enum CredentialsCommands {
     ///
     /// Example:
     /// `printf '%s' "$VEX_MODEL_TOKEN" | vex credentials set model-token --stdin`
-    /// If no flag is passed on an interactive TTY, vex prompts for the secret
+    /// If no option is passed on an interactive TTY, vex prompts for the secret
     /// without echoing it.
     Set {
         /// Account identifier (e.g., `model-token`).

--- a/src/config.rs
+++ b/src/config.rs
@@ -262,7 +262,7 @@ where
         })
 }
 
-/// Client-side configuration for the local inference API.
+/// Client-side configuration for the same-machine inference API.
 ///
 /// Simplifies user configuration to `base_url` only; protocol is discovered
 /// automatically unless `explicit_protocol` is set (ADR-047).
@@ -378,7 +378,7 @@ pub struct DoctorMcpServer {
 }
 
 /// Intermediate per-layer config built from a TOML file.
-/// `deny_unknown_fields` ensures any unrecognized key is a hard failure.
+/// `deny_unknown_fields` ensures any unrecognized key is an immediate failure.
 #[derive(Debug, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 struct ConfigLayer {
@@ -450,11 +450,11 @@ impl Config {
     /// Load config from the five-layer resolution chain.
     ///
     /// Precedence (highest ΓåÆ lowest):
-    ///   environment > repo-local `.vex/config.toml` > user > system > compiled defaults
+    ///   environment > repo-scoped `.vex/config.toml` > user > system > compiled defaults
     ///
-    /// Repo-local discovery walks ancestors of `std::env::current_dir()`.
+    /// Repo-scoped discovery walks ancestors of `std::env::current_dir()`.
     /// Missing files are silently ignored. Malformed TOML, unknown keys,
-    /// invalid enum values, and `model_token` in any file are hard failures
+    /// invalid enum values, and `model_token` in any file are immediate failures
     /// with file-path context in the error message.
     pub fn load() -> Result<Self> {
         load::load()
@@ -475,7 +475,7 @@ impl Config {
 
     /// Test-only helper. Accepts explicit user and system config paths so
     /// tests can inject fixtures without touching the operator's real home
-    /// directory or `/etc`. Repo-local config is still discovered by walking
+    /// directory or `/etc`. Repo-scoped config is still discovered by walking
     /// ancestors of `cwd`.
     pub fn load_for_tests(cwd: &Path, user: Option<&Path>, system: Option<&Path>) -> Result<Self> {
         load::load_for_tests(cwd, user, system)

--- a/src/state/conversation/tools/config.rs
+++ b/src/state/conversation/tools/config.rs
@@ -42,7 +42,7 @@ pub(super) fn write_file_diff_preferred_above_lines() -> usize {
         .unwrap_or(200)
 }
 
-/// Hard line limit for `write_file`. Calls on files exceeding this are
+/// Strict line limit for `write_file`. Calls on files exceeding this are
 /// rejected outright. Default 500. Minimum 10.
 pub(super) fn write_file_max_lines() -> usize {
     std::env::var("VEX_WRITE_FILE_MAX_LINES")

--- a/src/state/conversation/tools/dispatch.rs
+++ b/src/state/conversation/tools/dispatch.rs
@@ -97,7 +97,7 @@ pub(crate) fn execute_tool_dispatch_with_search_config(
             let content = first_tool_string(input, &["content", "text"]).unwrap_or("");
             let (chars, lines) = text_stats(content);
 
-            // Phase 3 hard guard: reject writes above VEX_WRITE_FILE_MAX_LINES.
+            // Phase 3 strict guard: reject writes above VEX_WRITE_FILE_MAX_LINES.
             let max_lines = write_file_max_lines();
             if lines > max_lines {
                 bail!(
@@ -350,12 +350,12 @@ pub(crate) fn first_tool_usize(input: &serde_json::Value, keys: &[&str]) -> Opti
 pub(crate) fn required_tool_string_any<'a>(
     input: &'a serde_json::Value,
     tool: &str,
-    canonical_key: &str,
+    accepted_key: &str,
     keys: &[&str],
 ) -> Result<&'a str> {
     let value = first_tool_string(input, keys).map(str::trim).unwrap_or("");
     if value.is_empty() {
-        bail!("{tool} requires a non-empty '{canonical_key}' string argument");
+        bail!("{tool} requires a non-empty '{accepted_key}' string argument");
     }
     Ok(value)
 }
@@ -363,12 +363,12 @@ pub(crate) fn required_tool_string_any<'a>(
 pub(crate) fn required_tool_string_any_preserve<'a>(
     input: &'a serde_json::Value,
     tool: &str,
-    canonical_key: &str,
+    accepted_key: &str,
     keys: &[&str],
 ) -> Result<&'a str> {
     let value = first_tool_string(input, keys).unwrap_or("");
     if value.is_empty() {
-        bail!("{tool} requires a non-empty '{canonical_key}' string argument");
+        bail!("{tool} requires a non-empty '{accepted_key}' string argument");
     }
     Ok(value)
 }

--- a/src/ui/editor/mod.rs
+++ b/src/ui/editor/mod.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 use crate::ui::input_metrics::{cursor_row_col, visual_layout, visual_row_bounds};
 use crate::ui::tui::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 
-/// Hard upper bound on the editor buffer size (bytes).  Large pastes or
+/// Strict upper bound on the editor buffer size (bytes).  Large pastes or
 /// runaway inserts are silently capped at this limit.  1 MiB is comfortably
 /// above any realistic interactive prompt while preventing unbounded growth.
 /// ADR-021 Item 18.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,7 +1,7 @@
 //! CLI smoke-tests using `assert_cmd`.
 //!
 //! These tests verify that the compiled `vex` binary exits predictably for
-//! flag-only invocations that require no runtime configuration.
+//! option-only invocations that require no runtime configuration.
 
 use assert_cmd::Command;
 


### PR DESCRIPTION
## Summary
This branch standardizes repository terminology across ADR metadata, contributor guidance, CLI help text, and adjacent documentation, and now also tightens the internal stream boundary so downstream consumers stay on the accepted runtime API instead of rebuilding tool-call semantics locally. The runtime owns thin JSON accumulation for streamed tool arguments across protocol adapters, the conversation and ratatui-side consumer path projects typed updates from that accepted event stream, and the reqwest EventSource bridge now flushes provider-normalized closing envelopes on explicit EOF.

## Motivation
The repository had two distinct cleanup needs on the same branch. First, glossary and lifecycle wording still drifted across ADR records, operator guidance, and help text. Second, the downstream runtime consumer path still carried a residual parallel tool-argument parsing seam: streamed tool-call JSON could be reassembled in the conversation layer instead of being treated as part of the normalized internal API contract. That duplicated responsibility weakened the intended architecture where provider or protocol quirks stop at ingress and all downstream surfaces consume one accepted stream.

## Approach
The terminology sweep remains deliberately conservative around compatibility-bound names, file paths, protocol labels, and platform-native terms. On the runtime side, the follow-up cleanup moves structured streamed tool-argument assembly into the runtime normalizer itself, extends `RuntimeEvent::ToolCallArgumentsDelta` with the current structured arguments when available, updates pending tool-call state from that same upstream source, and deletes the conversation manager's local JSON buffer and reparse fallback. The EventSource bridge also now finalizes parser state on both stream exhaustion and explicit EOF so provider-normalized turns do not lose their terminal accepted envelopes.

## Validation
- Remote CI passed on pushed head `59534fb91bfe08f193ad8a46bc3789bc371e6818`:
  Architecture Contracts: https://github.com/aistar-au/vexcoder/actions/runs/24626095631
  Hosted Agent Setup Checks: https://github.com/aistar-au/vexcoder/actions/runs/24626095628
  doc-ref-check: https://github.com/aistar-au/vexcoder/actions/runs/24626095629
  docs-build: https://github.com/aistar-au/vexcoder/actions/runs/24626095630
  ci: https://github.com/aistar-au/vexcoder/actions/runs/24626095635
- Additional local verification for the runtime-boundary follow-up now in the branch worktree:
  `cargo test eof_still_flushes_provider_normalized_turn_end`
  `cargo test test_pi_10_stream_block_deltas_feed_delta_accumulator`
  `cargo test test_tool_call_argument_delta_emits_typed_stream_update`

## Risks
- Duplication / missed shared-code opportunity: reduced. The main purpose of the runtime follow-up is to remove a remaining downstream parsing lane rather than introduce a new one.
- Unused code: none identified after deleting the conversation-layer tool argument buffer and its tests.
- Bugs / regression risk: low to moderate. The terminology sweep remains non-behavioral, but the runtime follow-up changes the ownership boundary for streamed tool arguments and SSE finalization. The targeted regressions cover the intended contract, though a full gate on the updated worktree has not been rerun yet.
- Inconsistency with ADRs: none identified. The follow-up strengthens the accepted direction that internal consumers should observe one runtime event stream and should not perform protocol-specific semantic repair downstream.
- Test coverage gaps: the new runtime-boundary assertions are targeted rather than full-suite. Broader gate coverage should be rerun after the follow-up is committed and pushed.
- Follow-up work deferred: the larger split of `src/runtime/json_handoff.rs` remains deferred; this change keeps the ownership boundary cleaner first, then leaves structural extraction for a later pass.
