### PR TITLE
Move streamed tool argument assembly into the runtime boundary

### DIFF
--- a/src/api/eventsource.rs
+++ b/src/api/eventsource.rs
@@ -85,6 +85,11 @@ struct EventStreamState {
     request_url: String,
 }
 
+fn finish_pending_events(state: &mut EventStreamState) -> Option<RuntimeEnvelope> {
+    state.pending.extend(state.parser.finish());
+    state.pending.pop_front()
+}
+
 async fn next_stream_event(state: &mut EventStreamState) -> Result<Option<RuntimeEnvelope>> {
     loop {
         if let Some(event) = state.pending.pop_front() {
@@ -92,8 +97,7 @@ async fn next_stream_event(state: &mut EventStreamState) -> Result<Option<Runtim
         }
 
         let Some(item) = state.upstream.next().await else {
-            state.pending.extend(state.parser.finish());
-            if let Some(event) = state.pending.pop_front() {
+            if let Some(event) = finish_pending_events(state) {
                 return Ok(Some(event));
             }
             return Ok(None);
@@ -108,7 +112,12 @@ async fn next_stream_event(state: &mut EventStreamState) -> Result<Option<Runtim
                         .process_sse_event(event.event_type.as_str(), event.data.as_str())?,
                 );
             }
-            Err(eventsource_client::Error::Eof) => return Ok(None),
+            Err(eventsource_client::Error::Eof) => {
+                if let Some(event) = finish_pending_events(state) {
+                    return Ok(Some(event));
+                }
+                return Ok(None);
+            }
             Err(eventsource_client::Error::UnexpectedResponse(response, body)) => {
                 let retry_after = response
                     .get_header_value("retry-after")
@@ -221,5 +230,34 @@ impl HttpTransport for ReqwestEventSourceTransport {
 
             response_builder.body(body).map_err(TransportError::new)
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::RuntimeEvent;
+    use futures::stream;
+
+    #[tokio::test]
+    async fn eof_still_flushes_provider_normalized_turn_end() {
+        let mut parser = StreamParser::new();
+        let _ = parser
+            .process(
+                b"event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"output_tokens\":15}}\n\n",
+            )
+            .unwrap();
+
+        let mut state = EventStreamState {
+            upstream: Box::pin(stream::iter(vec![Err(eventsource_client::Error::Eof)])),
+            parser,
+            pending: VecDeque::new(),
+            request_url: "https://example.test/sse".to_string(),
+        };
+
+        let event = next_stream_event(&mut state).await.unwrap().unwrap();
+
+        assert!(matches!(event.event, RuntimeEvent::TurnEnd { .. }));
+        assert!(next_stream_event(&mut state).await.unwrap().is_none());
     }
 }

--- a/src/api/stream/tests.rs
+++ b/src/api/stream/tests.rs
@@ -70,6 +70,27 @@ fn test_process_messages_v1_legacy_thinking_tag_emits_recoverable_error() {
 }
 
 #[test]
+fn test_process_messages_v1_thinking_data_block_emits_thinking_delta() {
+    let mut parser = StreamParser::new();
+    let frame =
+        b"event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking_data\",\"data\":\"opaque\"}}\n\n";
+    let events = parser.process(frame).unwrap();
+
+    assert!(events.iter().any(|event| matches!(
+        &event.event,
+        RuntimeEvent::TranscriptBlockDelta { delta, .. } if delta == "opaque"
+    )));
+    assert!(!events.iter().any(|event| matches!(
+        &event.event,
+        RuntimeEvent::Error {
+            code,
+            recoverable,
+            ..
+        } if code == "provider_content_block_start_decode" && *recoverable
+    )));
+}
+
+#[test]
 fn test_process_chat_compat_emits_message_start_metadata() {
     let mut parser = StreamParser::new();
     let events = parser

--- a/src/local_api.rs
+++ b/src/local_api.rs
@@ -539,7 +539,7 @@ mod tests {
                 block: StreamBlock::ToolCall {
                     id: "provider-call-1".to_string(),
                     name: "read_file".to_string(),
-                    input: json!({"path":"src/local_api.rs"}),
+                    input: json!({}),
                     status: crate::state::ToolStatus::Pending,
                 },
             },
@@ -584,7 +584,7 @@ mod tests {
                     status: crate::state::ToolStatus::Pending,
                     ..
                 }
-            } if name == "read_file" && input["path"] == "src/local_api.rs"
+            } if name == "read_file" && input == &json!({})
         ));
         assert!(matches!(
             tool_call.event,
@@ -592,16 +592,18 @@ mod tests {
                 ref tool_name,
                 ref arguments,
                 ..
-            } if tool_name == "read_file" && arguments["path"] == "src/local_api.rs"
+            } if tool_name == "read_file" && arguments == &json!({})
         ));
         assert!(matches!(
             tool_call_arguments_delta.event,
             RuntimeEvent::ToolCallArgumentsDelta {
                 ref tool_name,
                 ref delta,
+                arguments: Some(ref arguments),
                 ..
             } if tool_name.as_deref() == Some("read_file")
                 && delta == "{\"path\":\"src/local_api.rs\"}"
+                && arguments["path"] == "src/local_api.rs"
         ));
         assert!(matches!(
             transcript_block_delta.event,

--- a/src/runtime/json_handoff.rs
+++ b/src/runtime/json_handoff.rs
@@ -101,6 +101,8 @@ pub enum RuntimeEvent {
         tool_name: Option<String>,
         delta: String,
         status: ToolStatus,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        arguments: Option<serde_json::Value>,
         #[serde(default)]
         invalid_json: bool,
     },
@@ -256,11 +258,19 @@ pub fn generate_tool_call_id(counter: &AtomicU32, entropy: u16) -> ToolCallId {
     format!("tx_{}_{entropy:04x}", count)
 }
 
+fn serialize_tool_arguments(arguments: &serde_json::Value) -> String {
+    match arguments {
+        serde_json::Value::Object(map) if map.is_empty() => String::new(),
+        _ => serde_json::to_string(arguments).unwrap_or_default(),
+    }
+}
+
 #[derive(Debug, Clone)]
 struct PendingToolCall {
     runtime_id: ToolCallId,
     name: String,
     arguments: serde_json::Value,
+    raw_arguments: String,
     start_event_id: String,
     started_at: DateTime<Utc>,
 }
@@ -306,6 +316,9 @@ enum ProviderContentBlockCompat {
         thinking: String,
         signature: String,
     },
+    ThinkingData {
+        data: String,
+    },
     ServerToolUse {
         id: String,
         name: String,
@@ -332,6 +345,9 @@ enum ProviderContentBlock {
     ToolResult,
     Thinking {
         thinking: String,
+    },
+    ThinkingData {
+        data: String,
     },
     ServerToolUse {
         id: String,
@@ -874,7 +890,7 @@ impl RuntimeEnvelopeNormalizer {
             return envelopes;
         }
 
-        for choice in chunk.choices.clone() {
+        for choice in std::mem::take(&mut chunk.choices) {
             let ChatCompatChoice {
                 index: choice_index,
                 delta,
@@ -1124,6 +1140,7 @@ impl RuntimeEnvelopeNormalizer {
                 runtime_id: runtime_id.clone(),
                 name: name.clone(),
                 arguments: arguments.clone(),
+                raw_arguments: serialize_tool_arguments(&arguments),
                 start_event_id: envelope.event_id.clone(),
                 started_at,
             },
@@ -1162,6 +1179,7 @@ impl RuntimeEnvelopeNormalizer {
                 runtime_id: runtime_id.clone(),
                 name: name.clone(),
                 arguments: arguments.clone(),
+                raw_arguments: serialize_tool_arguments(&arguments),
                 start_event_id: envelope.event_id.clone(),
                 started_at,
             },
@@ -1267,6 +1285,7 @@ impl RuntimeEnvelopeNormalizer {
             self.accumulate_tool_delta(tool_call_id, delta),
             Some(AccumulationError::MalformedPartial)
         );
+        let arguments = self.append_pending_tool_delta(tool_call_id, delta);
 
         self.next_envelope_with_context(
             RuntimeEvent::ToolCallArgumentsDelta {
@@ -1274,6 +1293,7 @@ impl RuntimeEnvelopeNormalizer {
                 tool_name,
                 delta: delta.to_string(),
                 status: ToolStatus::Pending,
+                arguments,
                 invalid_json,
             },
             None,
@@ -1343,6 +1363,24 @@ impl RuntimeEnvelopeNormalizer {
         };
 
         delta_accumulator.finish(tool_call_id);
+    }
+
+    fn append_pending_tool_delta(
+        &mut self,
+        tool_call_id: &ToolCallId,
+        delta: &str,
+    ) -> Option<serde_json::Value> {
+        let pending = self
+            .pending_tool_calls
+            .values_mut()
+            .find(|pending| pending.runtime_id == *tool_call_id)?;
+
+        pending.raw_arguments.push_str(delta);
+        let arguments = serde_json::from_str::<serde_json::Value>(&pending.raw_arguments)
+            .or_else(|_| serde_json::from_str(pending.raw_arguments.trim()))
+            .ok()?;
+        pending.arguments = arguments.clone();
+        Some(arguments)
     }
 
     fn finish_pending_tool_accumulations(&self) {
@@ -1440,6 +1478,7 @@ impl From<ProviderContentBlockCompat> for ProviderContentBlock {
                 let _ = signature;
                 Self::Thinking { thinking }
             }
+            ProviderContentBlockCompat::ThinkingData { data } => Self::ThinkingData { data },
             ProviderContentBlockCompat::ServerToolUse { id, name, input } => {
                 Self::ServerToolUse { id, name, input }
             }
@@ -1471,6 +1510,13 @@ fn provider_stream_block(
                 collapsed: false,
             },
             Some(thinking.clone()),
+        )),
+        ProviderContentBlock::ThinkingData { data } => Some((
+            StreamBlock::Thinking {
+                content: String::new(),
+                collapsed: false,
+            },
+            Some(data.clone()),
         )),
         ProviderContentBlock::ToolUse { id, name, input }
         | ProviderContentBlock::ServerToolUse { id, name, input } => Some((

--- a/src/runtime/json_handoff/tests.rs
+++ b/src/runtime/json_handoff/tests.rs
@@ -218,7 +218,7 @@ fn test_pi_10_normalization_projects_ui_updates_and_approval_events() {
             block: StreamBlock::ToolCall {
                 id: "provider-call-1".to_string(),
                 name: "read_file".to_string(),
-                input: json!({"path":"src/lib.rs"}),
+                input: json!({}),
                 status: crate::state::ToolStatus::Pending,
             },
         },
@@ -235,7 +235,7 @@ fn test_pi_10_normalization_projects_ui_updates_and_approval_events() {
                 status: crate::state::ToolStatus::Pending,
                 ..
             }
-        } if name == "read_file" && input["path"] == "src/lib.rs"
+        } if name == "read_file" && input == &json!({})
     ));
     assert!(matches!(
         transcript_block_start[1].event,
@@ -243,7 +243,7 @@ fn test_pi_10_normalization_projects_ui_updates_and_approval_events() {
             ref tool_name,
             ref arguments,
             ..
-        } if tool_name == "read_file" && arguments["path"] == "src/lib.rs"
+        } if tool_name == "read_file" && arguments == &json!({})
     ));
     assert_eq!(
         transcript_block_start[0].source,
@@ -279,9 +279,11 @@ fn test_pi_10_normalization_projects_ui_updates_and_approval_events() {
         RuntimeEvent::ToolCallArgumentsDelta {
             ref tool_name,
             ref delta,
+            arguments: Some(ref arguments),
             ..
         } if tool_name.as_deref() == Some("read_file")
             && delta == "{\"path\":\"src/lib.rs\"}"
+            && arguments["path"] == "src/lib.rs"
     ));
 
     let transcript_block_complete = normalizer
@@ -392,14 +394,14 @@ fn test_pi_10_stream_block_deltas_feed_delta_accumulator() {
         other => panic!("expected tool_call_started event, got {other:?}"),
     };
 
-    normalizer.normalize_ui_update(
+    let first_delta = normalizer.normalize_ui_update(
         &UiUpdate::StreamBlockDelta {
             index: 0,
             delta: r#"{"path":"src/"#.to_string(),
         },
         None,
     );
-    normalizer.normalize_ui_update(
+    let second_delta = normalizer.normalize_ui_update(
         &UiUpdate::StreamBlockDelta {
             index: 0,
             delta: r#"lib.rs"}"#.to_string(),
@@ -411,6 +413,22 @@ fn test_pi_10_stream_block_deltas_feed_delta_accumulator() {
     let snapshot = accumulator.snapshot();
     let map = snapshot.lock().unwrap_or_else(|e| e.into_inner());
     let tool_state = map.get(&runtime_call_id).expect("tool state present");
+    assert!(matches!(
+        first_delta[1].event,
+        RuntimeEvent::ToolCallArgumentsDelta {
+            arguments: None,
+            ref delta,
+            ..
+        } if delta == r#"{"path":"src/"#
+    ));
+    assert!(matches!(
+        second_delta[1].event,
+        RuntimeEvent::ToolCallArgumentsDelta {
+            arguments: Some(ref arguments),
+            ref delta,
+            ..
+        } if delta == r#"lib.rs"}"# && arguments["path"] == "src/lib.rs"
+    ));
     assert_eq!(tool_state.partial_args, r#"{"path":"src/lib.rs"}"#);
     assert_eq!(
         tool_state.delta_queue.iter().cloned().collect::<Vec<_>>(),

--- a/src/state/conversation/send_message.rs
+++ b/src/state/conversation/send_message.rs
@@ -15,92 +15,6 @@ use futures::StreamExt;
 use std::collections::{HashMap, HashSet, VecDeque};
 use tokio::sync::mpsc;
 
-#[derive(Default)]
-struct ToolArgumentBufferState {
-    raw: String,
-    object_depth: usize,
-    array_depth: usize,
-    in_string: bool,
-    escape: bool,
-    saw_non_whitespace: bool,
-    invalid_nesting: bool,
-}
-
-impl ToolArgumentBufferState {
-    fn push_delta(&mut self, delta: &str) {
-        self.raw.push_str(delta);
-
-        for ch in delta.chars() {
-            if !ch.is_whitespace() {
-                self.saw_non_whitespace = true;
-            }
-
-            if self.in_string {
-                if self.escape {
-                    self.escape = false;
-                    continue;
-                }
-
-                match ch {
-                    '\\' => self.escape = true,
-                    '"' => self.in_string = false,
-                    _ => {}
-                }
-                continue;
-            }
-
-            match ch {
-                '"' => self.in_string = true,
-                '{' => self.object_depth = self.object_depth.saturating_add(1),
-                '}' => {
-                    if self.object_depth == 0 {
-                        self.invalid_nesting = true;
-                    } else {
-                        self.object_depth -= 1;
-                    }
-                }
-                '[' => self.array_depth = self.array_depth.saturating_add(1),
-                ']' => {
-                    if self.array_depth == 0 {
-                        self.invalid_nesting = true;
-                    } else {
-                        self.array_depth -= 1;
-                    }
-                }
-                _ => {}
-            }
-        }
-    }
-
-    fn maybe_parse(&self) -> Option<serde_json::Value> {
-        if !self.should_attempt_parse() {
-            return None;
-        }
-
-        serde_json::from_str::<serde_json::Value>(&self.raw)
-            .or_else(|_| serde_json::from_str(self.raw.trim()))
-            .ok()
-    }
-
-    fn should_attempt_parse(&self) -> bool {
-        if !self.saw_non_whitespace
-            || self.invalid_nesting
-            || self.in_string
-            || self.escape
-            || self.object_depth != 0
-            || self.array_depth != 0
-        {
-            return false;
-        }
-
-        self.raw
-            .trim_end()
-            .chars()
-            .next_back()
-            .is_some_and(|ch| matches!(ch, '}' | ']' | '"' | '0'..='9' | 'e' | 'l'))
-    }
-}
-
 impl ConversationManager {
     pub async fn send_message_with_policy(
         &mut self,
@@ -222,7 +136,6 @@ impl ConversationManager {
             let mut assistant_text = String::new();
             let mut tool_use_blocks = Vec::new();
             let mut tool_use_positions: HashMap<String, usize> = HashMap::new();
-            let mut tool_input_buffers: HashMap<String, ToolArgumentBufferState> = HashMap::new();
             let mut pending_tool_block_indices = VecDeque::new();
             let mut tool_block_indices: HashMap<String, usize> = HashMap::new();
             let mut block_tool_call_ids: HashMap<usize, String> = HashMap::new();
@@ -320,6 +233,7 @@ impl ConversationManager {
                         tool_call_id,
                         tool_name,
                         delta,
+                        arguments,
                         ..
                     } => {
                         let tool_name_for_ui = tool_name.clone();
@@ -332,14 +246,7 @@ impl ConversationManager {
                             *name = tool_name;
                         }
 
-                        let current_arguments = {
-                            let buffer =
-                                tool_input_buffers.entry(tool_call_id.clone()).or_default();
-                            buffer.push_delta(&delta);
-                            buffer.maybe_parse()
-                        };
-
-                        if let Some(arguments) = current_arguments.clone()
+                        if let Some(arguments) = arguments.clone()
                             && let Some(position) = tool_use_positions.get(&tool_call_id).copied()
                             && let Some(ContentBlock::ToolUse { input, .. }) =
                                 tool_use_blocks.get_mut(position)
@@ -353,7 +260,7 @@ impl ConversationManager {
                                 ConversationStreamUpdate::BlockDelta { index, delta },
                             );
                         }
-                        if let Some(arguments) = current_arguments {
+                        if let Some(arguments) = arguments {
                             emit_stream_update(
                                 stream_delta_tx,
                                 ConversationStreamUpdate::ToolCallArgumentsUpdated {
@@ -416,35 +323,6 @@ impl ConversationManager {
                             ConversationStreamUpdate::StreamError(format!(
                                 "stream error ({code}): {message}"
                             )),
-                        );
-                    }
-                }
-            }
-
-            for (tool_call_id, buffer) in tool_input_buffers {
-                if buffer.raw.is_empty() {
-                    continue;
-                }
-                let Some(position) = tool_use_positions.get(&tool_call_id).copied() else {
-                    continue;
-                };
-                let Some(ContentBlock::ToolUse { input, .. }) = tool_use_blocks.get_mut(position)
-                else {
-                    continue;
-                };
-
-                let parse_result: Result<serde_json::Value, _> = serde_json::from_str(&buffer.raw)
-                    .or_else(|_| serde_json::from_str(buffer.raw.trim()));
-                match parse_result {
-                    Ok(parsed_input) => {
-                        *input = parsed_input;
-                    }
-                    Err(err) => {
-                        tracing::warn!(
-                            tool_call_id,
-                            json_len = buffer.raw.len(),
-                            err = %err,
-                            "tool input JSON parse failed; tool will run with prior arguments"
                         );
                     }
                 }
@@ -955,33 +833,4 @@ fn parse_runtime_timestamp(value: &str) -> Option<DateTime<Utc>> {
     DateTime::parse_from_rfc3339(value)
         .ok()
         .map(|timestamp| timestamp.with_timezone(&Utc))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use serde_json::json;
-
-    #[test]
-    fn test_tool_argument_buffer_waits_for_complete_json() {
-        let mut buffer = ToolArgumentBufferState::default();
-
-        buffer.push_delta("{\"path\": \"file");
-        assert!(!buffer.should_attempt_parse());
-        assert_eq!(buffer.maybe_parse(), None);
-
-        buffer.push_delta(".txt\"}");
-        assert!(buffer.should_attempt_parse());
-        assert_eq!(buffer.maybe_parse(), Some(json!({"path": "file.txt"})));
-    }
-
-    #[test]
-    fn test_tool_argument_buffer_accepts_complete_string_value() {
-        let mut buffer = ToolArgumentBufferState::default();
-
-        buffer.push_delta("\"ready\"");
-
-        assert!(buffer.should_attempt_parse());
-        assert_eq!(buffer.maybe_parse(), Some(json!("ready")));
-    }
 }

--- a/src/state/conversation/send_message.rs
+++ b/src/state/conversation/send_message.rs
@@ -246,12 +246,12 @@ impl ConversationManager {
                             *name = tool_name;
                         }
 
-                        if let Some(arguments) = arguments.clone()
+                        if let Some(arguments) = arguments.as_ref()
                             && let Some(position) = tool_use_positions.get(&tool_call_id).copied()
                             && let Some(ContentBlock::ToolUse { input, .. }) =
                                 tool_use_blocks.get_mut(position)
                         {
-                            *input = arguments;
+                            *input = arguments.clone();
                         }
 
                         if let Some(index) = tool_block_indices.get(&tool_call_id).copied() {

--- a/src/state/conversation/tests/setup.rs
+++ b/src/state/conversation/tests/setup.rs
@@ -77,7 +77,7 @@ data: {"type":"content_block_start","index":0,"content_block":{"type":"text","te
 data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I will read it."}}"#
             .to_string(),
         r#"event: content_block_stop
-    data: {"type":"content_block_stop","index":0}"#
+data: {"type":"content_block_stop","index":0}"#
             .to_string(),
         format!(
             r#"event: content_block_start


### PR DESCRIPTION
## Summary
This follow-up removes the last significant downstream parallel tool-call parsing lane by moving streamed tool-argument assembly entirely into the runtime normalization boundary. It also hardens provider-normalized EOF handling, accepts canonical `thinking_data` blocks at ingress, and keeps consumer surfaces on canonical pre-parsed runtime events.

## Motivation
RuntimeEnvelope was intended to centralize tool-argument accumulation, tool lifecycle events, and streamed thinking and tool deltas. One real duplication remained: the conversation manager kept `ToolArgumentBufferState`, which re-accumulated JSON already being accumulated by the runtime normalizer. The remaining post-merge question is therefore narrower: which compatibility and public-schema surfaces still remain after removal of that last downstream parser.

## Approach
The branch deletes `ToolArgumentBufferState`, extends `RuntimeEvent::ToolCallArgumentsDelta` with structured `arguments`, keeps canonical parsing in `RuntimeEnvelopeNormalizer`, and flushes the EventSource bridge on explicit EOF as well as natural stream exhaustion. The residual surfaces are narrower than earlier drafts suggested: `src/server/sse.rs` is already a pure RuntimeEnvelope forwarder, `src/api/stream.rs` is now a thin protocol and framing entry point with `ProviderNormalized` state and a `provider_normalizer` handle, the remaining compatibility accumulation state for legacy provider and chat-compat payloads is owned by `src/runtime/json_handoff.rs`, and the client-facing `vexcoder-api-types` schema still remains as a higher-level public surface.

## Validation
- Repository-map verification against head `80fbdde`:
  - `src/server/sse.rs`: 28 lines, pure RuntimeEnvelope SSE forwarder
  - `src/api/stream.rs`: 58 lines, thin entry point with `ProviderNormalized` plus `provider_normalizer`, but no separate `ChatCompatToolState` parser
  - `src/runtime/json_handoff.rs`: 1814 lines, owns `chat_compat_tools`, canonical tool-argument parsing, `thinking_data` ingress, and `ToolCallArgumentsDelta` emission
  - `src/state/conversation/send_message.rs`: 836 lines, no `ToolArgumentBufferState`
  - `crates/vexcoder-api-types/src/lib.rs`: 361 lines, still exposes the higher-level `ContentBlock` schema
  - `src/api/stream/mappers.rs`: absent from the current tree
- Local verification completed on head `80fbdde`:
  - `cargo fmt --check`
  - `cargo clippy --all-targets -- -D warnings`
  - `cargo nextest run -j 2`
  - `bash scripts/check_forbidden_names.sh`
  - `cargo run -- --help`
- Focused regressions exercised during the follow-up:
  - `cargo nextest run test_process_messages_v1_thinking_data_block_emits_thinking_delta`
  - `cargo nextest run test_tool_call_argument_delta_emits_typed_stream_update`
  - `cargo nextest run eof_still_flushes_provider_normalized_turn_end`
  - `cargo nextest run test_local_api_mode_emits_transcript_block_events`
  - `cargo nextest run test_pi_10_normalization_projects_ui_updates_and_approval_events`
- Remote CI passed on pushed head `80fbddea4370e6401cc20dacd05c156d2b83f01d`:
  - Architecture Contracts: https://github.com/aistar-au/vexcoder/actions/runs/24628113972
  - doc-ref-check: https://github.com/aistar-au/vexcoder/actions/runs/24628113970
  - ci: https://github.com/aistar-au/vexcoder/actions/runs/24628113973

## Risks
- Duplication and missed shared-code opportunity: materially reduced, but not literally zero across every public surface. The removed conversation-layer parser was the last clear duplicate tool-argument accumulator in downstream code, yet the repository still maintains a client-facing content schema alongside the runtime-envelope schema.
- Unused code: low risk on this branch. The downstream buffer and fallback parsing lane are removed, and no stale helper remains in the conversation path after the follow-up commits.
- Bugs and regression risk: low to moderate. The main behavioral changes are concentrated in streamed tool-argument ownership, explicit EOF finalization, and `thinking_data` ingress handling. The remaining compatibility ingestion path for legacy provider and chat-compat streams still warrants care because it performs protocol adaptation before events reach the accepted runtime surface.
- Inconsistency with ADRs: none identified. The branch strengthens ADR-025 single accepted runtime contract by ensuring downstream consumers observe canonical runtime events instead of parsing stream deltas independently.
- Test coverage gaps: the changed seams are covered by targeted regressions and the full local and remote gates passed, but residual compatibility behavior still depends on provider and chat-compat fixture coverage rather than exhaustive replay against every upstream variant.
- Follow-up work deferred: if the repository goal is literal zero-remnant dual schema exposure, the next deliberate step is to deprecate the public `vexcoder-api-types` content schema with a migration path to direct RuntimeEnvelope consumption and, separately, retire the remaining compatibility ingestion path once legacy upstream protocols are no longer required.