### PR TITLE
Tighten chat-compat tool-call lifecycle at the ingress boundary

### DIFF
--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -88,13 +88,12 @@ The shared SSE parser in `src/api/stream.rs` and the normalized type surface in
   text, logprobs, choice indexes, and tool-call type
 
 Public streaming tool-call protocols still expose partial lifecycle state
-rather than a single finalized call object. OpenAI Responses documents
+rather than a single finalized call object. Responses-style APIs document
 `response.function_call_arguments.delta` /
-`response.function_call_arguments.done`, Anthropic Messages streams
+`response.function_call_arguments.done`, messages-style streams use
 `input_json_delta.partial_json` updates keyed by content-block `index`, and
-chat-compatible servers commonly emit incremental
-`tool_calls[*].function.arguments` fragments plus sibling
-`reasoning_content` text. The internal contract therefore treats tool-call
+chat-compatible servers commonly emit incremental tool-argument fragments plus
+a separate reasoning side channel. The internal contract therefore treats tool-call
 coalescence and reasoning normalization as ingress-only work:
 `src/runtime/json_handoff/protocol_ingress.rs` accumulates provider deltas
 into accepted runtime events, and downstream consumers such as the ratatui

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -87,6 +87,20 @@ The shared SSE parser in `src/api/stream.rs` and the normalized type surface in
 - chat-compat chunk metadata such as service tier, system fingerprint, refusal
   text, logprobs, choice indexes, and tool-call type
 
+Public streaming tool-call protocols still expose partial lifecycle state
+rather than a single finalized call object. OpenAI Responses documents
+`response.function_call_arguments.delta` /
+`response.function_call_arguments.done`, Anthropic Messages streams
+`input_json_delta.partial_json` updates keyed by content-block `index`, and
+chat-compatible servers commonly emit incremental
+`tool_calls[*].function.arguments` fragments plus sibling
+`reasoning_content` text. The internal contract therefore treats tool-call
+coalescence and reasoning normalization as ingress-only work:
+`src/runtime/json_handoff/protocol_ingress.rs` accumulates provider deltas
+into accepted runtime events, and downstream consumers such as the ratatui
+task surface observe only normalized `RuntimeEnvelope` / `RuntimeEvent`
+output.
+
 Not every metadata field is rendered in the interactive transcript today, but
 the parser keeps those values in the normalized event surface instead of
 dropping them during protocol conversion.

--- a/runtime-envelope-api-sse-normalization-plan.md
+++ b/runtime-envelope-api-sse-normalization-plan.md
@@ -121,6 +121,13 @@ CLI plus ratatui/crossterm stack remain downstream of the normalized API.
   fragments.
 - Preserve raw block deltas only for envelope projection and block-oriented
   renderer duties.
+- Keep tool-call accumulation at the ingress boundary. Current public streaming
+  protocols still emit partial tool-argument state instead of finalized call
+  objects, including OpenAI Responses
+  `response.function_call_arguments.delta`, Anthropic
+  `input_json_delta.partial_json`, and chat-compatible
+  `tool_calls[*].function.arguments` fragments. CLI and TUI consumers must stay
+  downstream of that coalescence step.
 
 ## Follow-up Lane
 

--- a/runtime-envelope-api-sse-normalization-plan.md
+++ b/runtime-envelope-api-sse-normalization-plan.md
@@ -123,10 +123,10 @@ CLI plus ratatui/crossterm stack remain downstream of the normalized API.
   renderer duties.
 - Keep tool-call accumulation at the ingress boundary. Current public streaming
   protocols still emit partial tool-argument state instead of finalized call
-  objects, including OpenAI Responses
-  `response.function_call_arguments.delta`, Anthropic
-  `input_json_delta.partial_json`, and chat-compatible
-  `tool_calls[*].function.arguments` fragments. CLI and TUI consumers must stay
+  objects, including responses-style
+  `response.function_call_arguments.delta`, messages-style
+  `input_json_delta.partial_json`, and chat-compatible incremental
+  tool-argument fragments. CLI and TUI consumers must stay
   downstream of that coalescence step.
 
 ## Follow-up Lane

--- a/src/api/stream/chat_compat.rs
+++ b/src/api/stream/chat_compat.rs
@@ -49,6 +49,12 @@ pub(crate) struct ChatCompatDelta {
     pub(crate) role: Option<String>,
     #[serde(default)]
     pub(crate) content: Option<String>,
+    // Several chat-compatible servers emit a `reasoning_content` field
+    // alongside `content` when mixed reasoning + tool-call streams are
+    // requested. The runtime treats it as a transcript-text delta so the
+    // downstream consumer observes no protocol-specific variation.
+    #[serde(default)]
+    pub(crate) reasoning_content: Option<String>,
     #[serde(default)]
     pub(crate) refusal: Option<String>,
     #[serde(default)]

--- a/src/api/stream/tests.rs
+++ b/src/api/stream/tests.rs
@@ -213,6 +213,126 @@ fn test_process_clamps_chat_compat_tool_call_index() {
 }
 
 #[test]
+fn test_process_chat_compat_emits_reasoning_content_as_transcript_delta() {
+    let mut parser = StreamParser::new();
+    let events = parser
+        .process(
+            br#"data: {"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"weighing options"},"finish_reason":null}]}
+
+"#,
+        )
+        .unwrap();
+
+    assert!(events.iter().any(|event| matches!(
+        &event.event,
+        RuntimeEvent::TranscriptBlockDelta { index: 0, delta } if delta == "weighing options"
+    )));
+}
+
+#[test]
+fn test_process_chat_compat_preserves_tool_state_across_reasoning_interleave() {
+    let mut parser = StreamParser::new();
+
+    let first = parser
+        .process(
+            br#"data: {"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"plan: call read_file","tool_calls":[{"index":0,"id":"call_a","type":"function","function":{"name":"read_file","arguments":"{\"path\":\""}}]},"finish_reason":null}]}
+
+"#,
+        )
+        .unwrap();
+
+    assert!(first.iter().any(|event| matches!(
+        &event.event,
+        RuntimeEvent::TranscriptBlockDelta { index: 0, delta } if delta == "plan: call read_file"
+    )));
+    assert!(first.iter().any(|event| matches!(
+        &event.event,
+        RuntimeEvent::TranscriptBlockStart {
+            index: 1,
+            block: crate::state::StreamBlock::ToolCall { id, name, .. }
+        } if id == "call_a" && name == "read_file"
+    )));
+
+    let second = parser
+        .process(
+            br#"data: {"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"reasoning_content":"now finalising args","tool_calls":[{"index":0,"function":{"arguments":"src/lib.rs\"}"}}]},"finish_reason":null}]}
+
+"#,
+        )
+        .unwrap();
+
+    assert!(second.iter().any(|event| matches!(
+        &event.event,
+        RuntimeEvent::TranscriptBlockDelta { index: 0, delta } if delta == "now finalising args"
+    )));
+    assert!(second.iter().any(|event| matches!(
+        &event.event,
+        RuntimeEvent::ToolCallArgumentsDelta { delta, tool_name, .. }
+            if delta == "src/lib.rs\"}" && tool_name.as_deref() == Some("read_file")
+    )));
+}
+
+#[test]
+fn test_process_chat_compat_allocates_sparse_tool_call_indices() {
+    let mut parser = StreamParser::new();
+    let events = parser
+        .process(
+            br#"data: {"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_a","type":"function","function":{"name":"read_file","arguments":"{}"}},{"index":5,"id":"call_b","type":"function","function":{"name":"write_file","arguments":"{}"}}]},"finish_reason":null}]}
+
+"#,
+        )
+        .unwrap();
+
+    let tool_starts: Vec<usize> = events
+        .iter()
+        .filter_map(|event| match &event.event {
+            RuntimeEvent::TranscriptBlockStart {
+                index,
+                block: crate::state::StreamBlock::ToolCall { .. },
+            } => Some(*index),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(tool_starts, vec![1, 6]);
+}
+
+#[test]
+fn test_process_chat_compat_ignores_deltas_after_tool_block_closed() {
+    let mut parser = StreamParser::new();
+
+    let opening = parser
+        .process(
+            br#"data: {"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_a","type":"function","function":{"name":"noop","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}
+
+"#,
+        )
+        .unwrap();
+    assert!(opening.iter().any(|event| matches!(
+        &event.event,
+        RuntimeEvent::TranscriptBlockComplete { index: 1 }
+    )));
+
+    let replay = parser
+        .process(
+            br#"data: {"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"should-be-ignored"}}]},"finish_reason":null}]}
+
+"#,
+        )
+        .unwrap();
+    let has_late_tool_event = replay.iter().any(|event| {
+        matches!(
+            &event.event,
+            RuntimeEvent::ToolCallArgumentsDelta { .. }
+                | RuntimeEvent::TranscriptBlockStart {
+                    block: crate::state::StreamBlock::ToolCall { .. },
+                    ..
+                }
+        )
+    });
+    assert!(!has_late_tool_event);
+}
+
+#[test]
 fn test_process_preserves_tab_after_single_space_strip() {
     let mut parser = StreamParser::new();
     let events = parser.process(b"data: \t{\"type\":\"ping\"}\n\n").unwrap();

--- a/src/api/stream/tests.rs
+++ b/src/api/stream/tests.rs
@@ -333,6 +333,109 @@ fn test_process_chat_compat_ignores_deltas_after_tool_block_closed() {
 }
 
 #[test]
+fn test_process_chat_compat_seals_discovered_tool_at_finish_reason() {
+    let mut parser = StreamParser::new();
+
+    let opening = parser
+        .process(
+            br#"data: {"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_a","type":"function","function":{"arguments":"{\"path\""}}]},"finish_reason":null}]}
+
+"#,
+        )
+        .unwrap();
+    let had_block_start = opening.iter().any(|event| {
+        matches!(
+            &event.event,
+            RuntimeEvent::TranscriptBlockStart {
+                block: crate::state::StreamBlock::ToolCall { .. },
+                ..
+            }
+        )
+    });
+    assert!(
+        !had_block_start,
+        "a Discovered entry must not emit a block start before a name is observed",
+    );
+
+    let terminator = parser
+        .process(
+            br#"data: {"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}
+
+"#,
+        )
+        .unwrap();
+    let had_late_start = terminator.iter().any(|event| {
+        matches!(
+            &event.event,
+            RuntimeEvent::TranscriptBlockStart {
+                block: crate::state::StreamBlock::ToolCall { .. },
+                ..
+            }
+        )
+    });
+    assert!(!had_late_start);
+
+    let replay = parser
+        .process(
+            br#"data: {"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":"read_file","arguments":":\"main.rs\"}"}}]},"finish_reason":null}]}
+
+"#,
+        )
+        .unwrap();
+    let resurrected = replay.iter().any(|event| {
+        matches!(
+            &event.event,
+            RuntimeEvent::ToolCallArgumentsDelta { .. }
+                | RuntimeEvent::TranscriptBlockStart {
+                    block: crate::state::StreamBlock::ToolCall { .. },
+                    ..
+                }
+        )
+    });
+    assert!(
+        !resurrected,
+        "a late name delta must not advance a sealed Discovered index to Opened",
+    );
+}
+
+#[test]
+fn test_process_chat_compat_rejects_tool_deltas_after_done() {
+    let mut parser = StreamParser::new();
+
+    let _ = parser
+        .process(
+            br#"data: {"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"done"},"finish_reason":"stop"}]}
+
+data: [DONE]
+
+"#,
+        )
+        .unwrap();
+
+    let late = parser
+        .process(
+            br#"data: {"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":7,"id":"call_late","type":"function","function":{"name":"read_file","arguments":"{}"}}]},"finish_reason":null}]}
+
+"#,
+        )
+        .unwrap();
+    let late_tool_event = late.iter().any(|event| {
+        matches!(
+            &event.event,
+            RuntimeEvent::ToolCallArgumentsDelta { .. }
+                | RuntimeEvent::TranscriptBlockStart {
+                    block: crate::state::StreamBlock::ToolCall { .. },
+                    ..
+                }
+        )
+    });
+    assert!(
+        !late_tool_event,
+        "tool deltas arriving after [DONE] must be dropped before lifecycle state is instantiated",
+    );
+}
+
+#[test]
 fn test_process_preserves_tab_after_single_space_strip() {
     let mut parser = StreamParser::new();
     let events = parser.process(b"data: \t{\"type\":\"ping\"}\n\n").unwrap();

--- a/src/runtime/json_handoff/protocol_ingress.rs
+++ b/src/runtime/json_handoff/protocol_ingress.rs
@@ -21,13 +21,20 @@ pub(super) struct ProtocolIngressState {
     open_blocks: BTreeSet<usize>,
     turn_tokens: TurnTokens,
     chat_compat_message_started: bool,
-    // Per-index lifecycle state for chat-compatible tool calls. Sparse
-    // storage avoids preallocating slots for gapped indices that arrive out
-    // of sequence, and the ordered key traversal gives deterministic close
-    // ordering at turn boundaries. Coalescence across streamed deltas is
-    // keyed on the tool_calls[i].index field, consistent with the ordering
-    // invariant for JSON arrays in RFC 8259 §4.
+    // Per-provider-block-index lifecycle state for chat-compatible tool
+    // calls. Sparse storage avoids preallocating slots for gapped indices
+    // that arrive out of sequence, and the ordered key traversal gives
+    // deterministic close ordering at turn boundaries. Coalescence across
+    // streamed deltas is keyed on the provider block index derived from
+    // `min(tool_call.index, MAX_TOOL_CALL_INDEX) + 1`, preserving the
+    // ordering invariant for JSON arrays in RFC 8259 §4.
     chat_compat_tool_lifecycles: BTreeMap<usize, PendingChatCompatToolState>,
+    // Tracks whether the active chat-compatible stream has been terminated
+    // by `[DONE]`. While set, `apply_chat_compat_tool_delta` rejects tool
+    // deltas without mutating lifecycle state, preventing late or
+    // protocol-violating frames from re-opening a block after the stream
+    // has finalised. Cleared when a new message start is observed.
+    chat_compat_stream_terminated: bool,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -216,6 +223,7 @@ impl RuntimeEnvelopeNormalizer {
             ChatCompatPayload::Done => {
                 let envelopes = self.close_chat_compat_tool_blocks();
                 self.protocol_ingress.chat_compat_message_started = false;
+                self.protocol_ingress.chat_compat_stream_terminated = true;
                 self.protocol_ingress.chat_compat_tool_lifecycles.clear();
                 envelopes
             }
@@ -416,6 +424,14 @@ impl RuntimeEnvelopeNormalizer {
         }
 
         self.protocol_ingress.chat_compat_message_started = true;
+        // Only a fresh `role` announcement resets the termination gate raised
+        // by the previous `[DONE]`. Bare id/model echoes that arrive after
+        // the stream has finalised are treated as protocol violations and
+        // must not re-admit tool-call deltas without an unambiguous new
+        // message signal.
+        if role.is_some() {
+            self.protocol_ingress.chat_compat_stream_terminated = false;
+        }
         message_start_metadata(metadata)
             .map(|metadata| self.emit_provider_metadata(metadata))
             .unwrap_or_default()
@@ -426,6 +442,14 @@ impl RuntimeEnvelopeNormalizer {
         choice_index: Option<usize>,
         tool_call: ChatCompatToolCallDelta,
     ) -> Vec<RuntimeEnvelope> {
+        if self.protocol_ingress.chat_compat_stream_terminated {
+            // Once `[DONE]` has been observed the stream is finalised; late
+            // tool-call frames must not instantiate fresh lifecycle state via
+            // `entry(..).or_default()`. A new message start is required before
+            // any further deltas are admitted.
+            return Vec::new();
+        }
+
         let raw_index = tool_call.index.unwrap_or(0).min(MAX_TOOL_CALL_INDEX);
         let block_index = raw_index.saturating_add(1);
         let _ = (choice_index, tool_call.call_type);
@@ -497,15 +521,25 @@ impl RuntimeEnvelopeNormalizer {
     }
 
     fn close_chat_compat_tool_blocks(&mut self) -> Vec<RuntimeEnvelope> {
+        // Every observed index must be sealed at the turn boundary so that a
+        // late delta cannot advance a `Discovered` entry to `Opened` after a
+        // `finish_reason` or `[DONE]` terminator. Only `Opened` indices emit a
+        // block close, because `Discovered` never dispatched a
+        // ContentBlockStart to the consumer.
         let to_close: Vec<usize> = self
             .protocol_ingress
             .chat_compat_tool_lifecycles
             .iter_mut()
-            .filter_map(|(index, state)| {
-                (state.lifecycle == ToolCallLifecycle::Opened).then(|| {
+            .filter_map(|(index, state)| match state.lifecycle {
+                ToolCallLifecycle::Opened => {
                     state.lifecycle = ToolCallLifecycle::Closed;
-                    *index
-                })
+                    Some(*index)
+                }
+                ToolCallLifecycle::Discovered => {
+                    state.lifecycle = ToolCallLifecycle::Closed;
+                    None
+                }
+                ToolCallLifecycle::Closed => None,
             })
             .collect();
 

--- a/src/runtime/json_handoff/protocol_ingress.rs
+++ b/src/runtime/json_handoff/protocol_ingress.rs
@@ -9,7 +9,7 @@ use crate::state::{StreamBlock, ToolStatus};
 use crate::types::{ApiUsage, StreamChunkMetadata};
 use crate::usage::TurnTokens;
 use serde::Deserialize;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 #[derive(Default)]
 pub(super) struct ProtocolIngressState {
@@ -21,7 +21,13 @@ pub(super) struct ProtocolIngressState {
     open_blocks: BTreeSet<usize>,
     turn_tokens: TurnTokens,
     chat_compat_message_started: bool,
-    chat_compat_tools: Vec<PendingChatCompatToolState>,
+    // Per-index lifecycle state for chat-compatible tool calls. Sparse
+    // storage avoids preallocating slots for gapped indices that arrive out
+    // of sequence, and the ordered key traversal gives deterministic close
+    // ordering at turn boundaries. Coalescence across streamed deltas is
+    // keyed on the tool_calls[i].index field, consistent with the ordering
+    // invariant for JSON arrays in RFC 8259 §4.
+    chat_compat_tool_lifecycles: BTreeMap<usize, PendingChatCompatToolState>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -29,8 +35,21 @@ struct PendingChatCompatToolState {
     id: String,
     name: String,
     pending_arguments: String,
-    started: bool,
-    stopped: bool,
+    lifecycle: ToolCallLifecycle,
+}
+
+// An explicit state machine replaces the earlier pair of boolean flags so
+// transitions are observable and enforceable at a single call site. Each
+// tool-call index advances monotonically from `Discovered` (metadata
+// accumulating, block not yet opened) through `Opened` (ContentBlockStart
+// dispatched, arguments now streamable) to `Closed` (ContentBlockStop
+// dispatched; no further deltas are forwarded to the consumer).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+enum ToolCallLifecycle {
+    #[default]
+    Discovered,
+    Opened,
+    Closed,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -197,7 +216,7 @@ impl RuntimeEnvelopeNormalizer {
             ChatCompatPayload::Done => {
                 let envelopes = self.close_chat_compat_tool_blocks();
                 self.protocol_ingress.chat_compat_message_started = false;
-                self.protocol_ingress.chat_compat_tools.clear();
+                self.protocol_ingress.chat_compat_tool_lifecycles.clear();
                 envelopes
             }
             ChatCompatPayload::Chunk(chunk) => self.normalize_chat_compat_chunk(*chunk),
@@ -333,6 +352,7 @@ impl RuntimeEnvelopeNormalizer {
             let ChatCompatDelta {
                 role: _,
                 content,
+                reasoning_content,
                 refusal,
                 tool_calls,
             } = delta;
@@ -340,6 +360,17 @@ impl RuntimeEnvelopeNormalizer {
             if let Some(content) = content {
                 envelopes
                     .extend(self.apply_provider_stream_delta(0, ProviderBlockDelta::Text(content)));
+            }
+
+            // Mixed reasoning plus tool-call streams from chat-compatible
+            // servers expose the model's reasoning trace through a sibling
+            // field. The consumer surface is protocol-agnostic, so the
+            // reasoning payload is coalesced into the same transcript block
+            // as ordinary content deltas rather than exposing a new event.
+            if let Some(reasoning) = reasoning_content {
+                envelopes.extend(
+                    self.apply_provider_stream_delta(0, ProviderBlockDelta::Text(reasoning)),
+                );
             }
 
             if let Some(tool_calls) = tool_calls {
@@ -397,13 +428,21 @@ impl RuntimeEnvelopeNormalizer {
     ) -> Vec<RuntimeEnvelope> {
         let raw_index = tool_call.index.unwrap_or(0).min(MAX_TOOL_CALL_INDEX);
         let block_index = raw_index.saturating_add(1);
-        self.ensure_chat_compat_tool_slot(block_index);
+        let _ = (choice_index, tool_call.call_type);
 
-        let mut start_block = None;
-        let mut partial_json = None;
-        {
-            let state = &mut self.protocol_ingress.chat_compat_tools[block_index];
-            let _ = (choice_index, tool_call.call_type);
+        let (start_block, partial_json) = {
+            let state = self
+                .protocol_ingress
+                .chat_compat_tool_lifecycles
+                .entry(block_index)
+                .or_default();
+
+            if state.lifecycle == ToolCallLifecycle::Closed {
+                // A late delta for an already-finalised index must not
+                // resurrect the block; the consumer has been told the
+                // tool call is complete and cannot safely accept more.
+                return Vec::new();
+            }
 
             if let Some(id) = tool_call.id
                 && !id.is_empty()
@@ -421,24 +460,28 @@ impl RuntimeEnvelopeNormalizer {
                 }
             }
 
-            if !state.started && !state.name.is_empty() {
+            let start_block = (state.lifecycle == ToolCallLifecycle::Discovered
+                && !state.name.is_empty())
+            .then(|| {
                 let id = if state.id.is_empty() {
                     format!("toolu_chat_compat_{block_index}")
                 } else {
                     state.id.clone()
                 };
-                start_block = Some(ProviderContentBlock::ToolUse {
+                state.lifecycle = ToolCallLifecycle::Opened;
+                ProviderContentBlock::ToolUse {
                     id,
                     name: state.name.clone(),
                     input: empty_json_object(),
-                });
-                state.started = true;
-            }
+                }
+            });
 
-            if state.started && !state.pending_arguments.is_empty() {
-                partial_json = Some(std::mem::take(&mut state.pending_arguments));
-            }
-        }
+            let partial_json = (state.lifecycle == ToolCallLifecycle::Opened
+                && !state.pending_arguments.is_empty())
+            .then(|| std::mem::take(&mut state.pending_arguments));
+
+            (start_block, partial_json)
+        };
 
         let mut envelopes = Vec::new();
         if let Some(content_block) = start_block {
@@ -453,31 +496,18 @@ impl RuntimeEnvelopeNormalizer {
         envelopes
     }
 
-    fn ensure_chat_compat_tool_slot(&mut self, index: usize) {
-        let required = index.saturating_add(1);
-        if self.protocol_ingress.chat_compat_tools.len() < required {
-            self.protocol_ingress
-                .chat_compat_tools
-                .resize_with(required, PendingChatCompatToolState::default);
-        }
-    }
-
     fn close_chat_compat_tool_blocks(&mut self) -> Vec<RuntimeEnvelope> {
-        let mut to_close = Vec::new();
-        for (index, state) in self
+        let to_close: Vec<usize> = self
             .protocol_ingress
-            .chat_compat_tools
+            .chat_compat_tool_lifecycles
             .iter_mut()
-            .enumerate()
-        {
-            if index == 0 {
-                continue;
-            }
-            if state.started && !state.stopped {
-                state.stopped = true;
-                to_close.push(index);
-            }
-        }
+            .filter_map(|(index, state)| {
+                (state.lifecycle == ToolCallLifecycle::Opened).then(|| {
+                    state.lifecycle = ToolCallLifecycle::Closed;
+                    *index
+                })
+            })
+            .collect();
 
         let mut envelopes = Vec::new();
         for index in to_close {


### PR DESCRIPTION
## Summary

Chat-compatible tool-call normalization now closes the remaining late-delta holes at the internal API boundary and records the evidence for that boundary in the repo docs. `protocol_ingress` keeps sparse provider-block-index state, seals both discovered and opened tool-call slots at `finish_reason` / `[DONE]`, and drops post-termination deltas before they can reopen a block. `reasoning_content` continues to flow through transcript text, and the ratatui-native stack remains a consumer of accepted `RuntimeEvent` values rather than a parser of protocol fragments.

## Motivation

The point of this lane is not just to harden one parser bug. Public streaming protocols still emit partial tool-call state instead of a single finished call object: responses-style APIs stream `response.function_call_arguments.delta`, messages-style streams emit `input_json_delta.partial_json`, and chat-compatible servers commonly emit incremental tool-argument fragments plus a separate reasoning side channel. That evidence means the internal API boundary must own coalescence and ordering, otherwise downstream surfaces would have to recover protocol-specific lifecycle state on their own. The earlier dense-slot / boolean-flag implementation also left two hazards: sparse indices wasted structure space, and late deltas after `finish_reason` or `[DONE]` could re-enter the pipeline.

## Approach

- `src/runtime/json_handoff/protocol_ingress.rs` now keeps chat-compatible tool state in a sparse `BTreeMap<usize, PendingChatCompatToolState>` keyed on the provider block index derived from `min(tool_call.index, MAX_TOOL_CALL_INDEX) + 1`, preserving RFC 8259 array ordering while avoiding dense preallocation.
- A private `ToolCallLifecycle` enum replaces the previous boolean pair. `Discovered` entries are sealed at turn termination even if they never opened a tool block, `Opened` entries emit the expected close event, and a `chat_compat_stream_terminated` gate drops any post-`[DONE]` tool deltas before they can instantiate new state.
- `src/api/stream/chat_compat.rs` accepts the `reasoning_content` side channel so mixed reasoning plus tool-call streams continue to normalize into the existing transcript-text path instead of leaking a new protocol-specific consumer event.
- `src/api/stream/tests.rs` adds regressions for reasoning interleave, sparse indices, sealing a `Discovered` tool on `finish_reason`, and rejecting tool deltas after `[DONE]`.
- `docs/src/architecture.md` and `runtime-envelope-api-sse-normalization-plan.md` now record the external streaming evidence behind the consumer-only invariant, so the repo docs explain why tool-call parsing belongs at ingress instead of only stating that it does.

## Validation

- Earlier code iterations on this branch passed `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo nextest run -j 2`, and `bash scripts/check_forbidden_names.sh`; the corresponding PR checks were green before the docs follow-up.
- The docs follow-up commits passed `mdbook build`, `bash scripts/check_forbidden_names.sh`, and `make fmt-check` locally.
- Targeted regressions in `src/api/stream/tests.rs` now cover reasoning-content transcript surfacing, reasoning interleave across tool-call frames, sparse index allocation, sealing `Discovered` state at `finish_reason`, and dropping post-close / post-`[DONE]` deltas.
- Not verified locally for this update: commit-debug dry run, because the adjacent `../vexdraft/.venv` overlay is absent in the sandbox.

## Risks

- The ingress path now treats any tool delta after `finish_reason` or `[DONE]` as invalid and drops it silently. That matches the documented streaming contracts, but a non-conforming server that tries to resume a closed call will no longer leak extra arguments into the consumer surface.
- The doc update cites current public streaming event shapes. If upstream providers rename those events or change their delta structure, the rationale text will need a follow-up refresh even though the consumer-boundary invariant would still stand.
- No downstream behavior changed intentionally: the ratatui-native surface still receives accepted runtime events only, so the main regression risk remains at the ingress normalization layer and its tests.