### PR TITLE
Add API observability and trace controls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-tracing-opentelemetry"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bedd2c385488b22a3a35b664fbc7f8e755d3ec6720848bc106b80cb5ae18fd7"
+dependencies = [
+ "axum",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "opentelemetry",
+ "opentelemetry-semantic-conventions",
+ "pin-project-lite",
+ "tower",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-opentelemetry-instrumentation-sdk",
+]
+
+[[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.17",
+ "instant",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1392,6 +1425,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "forwarded-header-value"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
+dependencies = [
+ "nonempty 0.7.0",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1477,6 +1520,12 @@ name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -1631,7 +1680,7 @@ dependencies = [
  "gix-worktree",
  "gix-worktree-state",
  "gix-worktree-stream",
- "nonempty",
+ "nonempty 0.12.0",
  "smallvec",
  "thiserror 2.0.18",
 ]
@@ -1740,7 +1789,7 @@ dependencies = [
  "gix-error",
  "gix-hash",
  "memmap2",
- "nonempty",
+ "nonempty 0.12.0",
 ]
 
 [[package]]
@@ -2018,7 +2067,7 @@ dependencies = [
  "gix-trace",
  "gix-worktree",
  "imara-diff 0.1.8",
- "nonempty",
+ "nonempty 0.12.0",
  "thiserror 2.0.18",
 ]
 
@@ -2150,7 +2199,7 @@ dependencies = [
  "gix-transport",
  "gix-utils",
  "maybe-async",
- "nonempty",
+ "nonempty 0.12.0",
  "thiserror 2.0.18",
  "winnow",
 ]
@@ -2218,7 +2267,7 @@ dependencies = [
  "gix-object",
  "gix-revwalk",
  "gix-trace",
- "nonempty",
+ "nonempty 0.12.0",
 ]
 
 [[package]]
@@ -2258,7 +2307,7 @@ dependencies = [
  "bstr",
  "gix-hash",
  "gix-lock",
- "nonempty",
+ "nonempty 0.12.0",
  "thiserror 2.0.18",
 ]
 
@@ -2449,6 +2498,29 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "governor"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9efcab3c1958580ff1f25a2a41be1668f7603d849bb63af523b208a3cc1223b8"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand 0.9.2",
+ "smallvec",
+ "spinning_top",
+ "web-time",
 ]
 
 [[package]]
@@ -2655,6 +2727,18 @@ checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
  "itoa",
+]
+
+[[package]]
+name = "http-api-problem"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "000bed434eb9b5dfb8ea5ed904f02ffc63aa0ac7ac034d480dc24fbb97b748d8"
+dependencies = [
+ "axum-core",
+ "http 1.4.0",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3026,6 +3110,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -3593,9 +3686,21 @@ dependencies = [
 
 [[package]]
 name = "nonempty"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
+
+[[package]]
+name = "nonempty"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "notify"
@@ -3846,6 +3951,40 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.2",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "option-ext"
@@ -4273,6 +4412,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4521,6 +4675,15 @@ dependencies = [
  "time",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -5190,6 +5353,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "sse-stream"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5764,6 +5936,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -5777,6 +5950,22 @@ name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tower_governor"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44de9b94d849d3c46e06a883d72d408c2de6403367b39df2b1c9d9e7b6736fe6"
+dependencies = [
+ "axum",
+ "forwarded-header-value",
+ "governor",
+ "http 1.4.0",
+ "pin-project",
+ "thiserror 2.0.18",
+ "tower",
+ "tracing",
+]
 
 [[package]]
 name = "tracing"
@@ -5834,6 +6023,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-opentelemetry-instrumentation-sdk"
+version = "0.32.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc2a7ad7b8bd011f482d1fdf95be20377cdd19f45aa9d1f9f902d746eddc3cad"
+dependencies = [
+ "http 1.4.0",
+ "opentelemetry",
+ "opentelemetry-semantic-conventions",
+ "tracing",
+ "tracing-opentelemetry",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5842,10 +6081,13 @@ dependencies = [
  "matchers",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -6060,6 +6302,8 @@ dependencies = [
  "assert_cmd",
  "async-compression",
  "axum",
+ "axum-tracing-opentelemetry",
+ "backoff",
  "base64 0.22.1",
  "bm25",
  "bstr",
@@ -6089,6 +6333,7 @@ dependencies = [
  "grep-searcher",
  "hickory-resolver",
  "http 1.4.0",
+ "http-api-problem",
  "httpdate",
  "human-panic",
  "hyper",
@@ -6105,6 +6350,9 @@ dependencies = [
  "notify",
  "oauth2",
  "open",
+ "opentelemetry",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
  "palette",
  "pathdiff",
  "portable-pty",
@@ -6134,8 +6382,10 @@ dependencies = [
  "toml 0.8.23",
  "tower",
  "tower-http",
+ "tower_governor",
  "tracing",
  "tracing-appender",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "tree-sitter",
  "tree-sitter-javascript",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,15 +29,20 @@ ratatui-macros = "0.7"
 aho-corasick = "1"
 anyhow = "1"
 axum = { version = "0.8", features = ["http1", "http2", "json", "tokio"] }
+axum-tracing-opentelemetry = "0.33"
 clap = { version = "4", features = ["derive"] }
 clap_complete = { version = "4" }
 bytes = "1"
 # 0.17 is the last release compatible with Rust 1.91 (MSRV); bump when MSRV advances.
 eventsource-client = { version = "0.17", default-features = false }
+backoff = { version = "0.4", default-features = false, features = ["tokio"] }
 fs2 = "0.4"
 futures = "0.3"
 hyper = { version = "1", features = ["http1", "http2", "server"] }
 http = "1"
+http-api-problem = { version = "0.60", default-features = false, features = [
+  "axum",
+] }
 hyper-util = { version = "0.1", features = [
   "http1",
   "http2",
@@ -91,10 +96,19 @@ tokio-rustls = "0.26"
 tokio-stream = "0.1"
 tokio-util = "0.7"
 toml = "0.8"
+opentelemetry = { version = "0.31", default-features = false, features = [
+  "trace",
+] }
+opentelemetry-semantic-conventions = "0.31"
+opentelemetry_sdk = { version = "0.31", default-features = false, features = [
+  "trace",
+] }
 tracing = "0.1"
+tracing-opentelemetry = { version = "0.32", default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false, features = [
   "env-filter",
   "fmt",
+  "json",
 ] }
 unicode-segmentation = "1"
 unicode-width = "0.2"
@@ -128,7 +142,15 @@ dunce = "1"
 base64 = "0.22"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 indexmap = { version = "2", features = ["serde"] }
-tower-http = { version = "0.6", default-features = false, features = ["trace"] }
+tower-http = { version = "0.6", default-features = false, features = [
+  "request-id",
+  "sensitive-headers",
+  "trace",
+] }
+tower_governor = { version = "0.8", default-features = false, features = [
+  "axum",
+  "tracing",
+] }
 regex-lite = "0.1"
 httpdate = "1"
 which = { version = "7", default-features = false }
@@ -236,6 +258,18 @@ reqwest = [
   "src/server/handlers/session.rs",
   "src/net/proxy.rs",
 ]
+axum-tracing-opentelemetry = ["src/server/http.rs"]
+backoff = ["src/api/eventsource.rs"]
+http-api-problem = ["src/server/util.rs"]
+opentelemetry = ["src/observability.rs", "src/api/client/mod.rs"]
+opentelemetry-semantic-conventions = [
+  "src/api/client/mod.rs",
+  "src/runtime/json_handoff/protocol_ingress.rs",
+]
+opentelemetry_sdk = ["src/observability.rs"]
+tower-http = ["src/server/http.rs", "src/observability.rs"]
+tower_governor = ["src/server/http.rs"]
+tracing-opentelemetry = ["src/observability.rs", "src/api/client/mod.rs"]
 # XML tool-call parser — the only call site for quick-xml's reader API.
 quick-xml = ["src/state/conversation/tool_call_parser.rs"]
 # tree-sitter grammar loading and query API — one indexing module.
@@ -300,10 +334,12 @@ fs2.workspace = true
 futures.workspace = true
 hyper.workspace = true
 http.workspace = true
+http-api-problem.workspace = true
 hyper-util.workspace = true
 ratatui.workspace = true
 reqwest.workspace = true
 async-compression.workspace = true
+backoff.workspace = true
 jsonwebtoken.workspace = true
 oauth2.workspace = true
 open.workspace = true
@@ -318,7 +354,11 @@ tokio-rustls.workspace = true
 tokio-stream.workspace = true
 tokio-util.workspace = true
 toml.workspace = true
+opentelemetry.workspace = true
+opentelemetry-semantic-conventions.workspace = true
+opentelemetry_sdk.workspace = true
 tracing.workspace = true
+tracing-opentelemetry.workspace = true
 tracing-subscriber.workspace = true
 unicode-segmentation.workspace = true
 unicode-width.workspace = true
@@ -341,6 +381,7 @@ color-eyre.workspace = true
 human-panic.workspace = true
 dialoguer.workspace = true
 dirs.workspace = true
+axum-tracing-opentelemetry.workspace = true
 tracing-appender.workspace = true
 similar.workspace = true
 
@@ -364,6 +405,7 @@ chrono.workspace = true
 # --- collections, HTTP middleware, text matching ---
 indexmap.workspace = true
 tower-http.workspace = true
+tower_governor.workspace = true
 regex-lite.workspace = true
 httpdate.workspace = true
 

--- a/TASKS/completed/REPO-RAW-URL-MAP.md
+++ b/TASKS/completed/REPO-RAW-URL-MAP.md
@@ -5,7 +5,7 @@ Canonical raw URL index for every tracked file in this repository.
 - Branch: main
 - Base: <https://raw.githubusercontent.com/aistar-au/vexcoder/main/>
 - Source: git ls-files
-- Total tracked files: 394
+- Total tracked files: 395
 
 | # | Path | Approx. lines | Raw URL |
 | :--- | :--- | :--- | :--- |
@@ -403,3 +403,4 @@ Canonical raw URL index for every tracked file in this repository.
 | 392 | `tests/signal_handling_tests.rs` | ~79 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/tests/signal_handling_tests.rs> |
 | 393 | `tests/stream_parser_tests.rs` | ~396 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/tests/stream_parser_tests.rs> |
 | 394 | `tests/tool_operator_tests.rs` | ~382 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/tests/tool_operator_tests.rs> |
+| 395 | `src/observability.rs` | ~273 | <https://raw.githubusercontent.com/aistar-au/vexcoder/main/src/observability.rs> |

--- a/deny.toml
+++ b/deny.toml
@@ -98,6 +98,14 @@ reason = "rustls-webpki 0.101.7 vulnerability (URI name constraint bypass) pulle
 id = "RUSTSEC-2026-0099"
 reason = "rustls-webpki 0.101.7 vulnerability (wildcard certificate name constraint bypass) pulled in transitively via hickory-resolver v0.24.4 → tokio-rustls. This codebase uses DoH only; the DNS resolution path does not verify wildcard name constraints against user-controlled certificates. Resolution: remove when hickory-resolver upgrades to rustls-webpki ≥0.102."
 
+[[advisories.ignore]]
+id = "RUSTSEC-2025-0012"
+reason = "backoff 0.4.0 is intentionally used for bounded local-startup connection retries on the CLI API transport path. The retry scope is local connect failures before any streaming response exists, and the dependency is not exposed across trust boundaries. Resolution: remove this exception when the requested retry lane migrates to a maintained equivalent such as backon without widening the transport surface."
+
+[[advisories.ignore]]
+id = "RUSTSEC-2024-0384"
+reason = "instant 0.1.13 is pulled transitively by backoff 0.4.0 for the same local-startup retry path. The crate is not used directly by this repository. Resolution: remove this exception when the bounded retry implementation moves off backoff and instant leaves the graph."
+
 # ---------------------------------------------------------------------------
 # 2. Dependency graph quality
 # ---------------------------------------------------------------------------

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -319,6 +319,10 @@ Model identifier sent to the API.
 
 Overrides protocol inference. Accepted values: `messages-v1`, `chat-compat`.
 
+The runtime still probes local endpoints and records the server-native protocol
+for transport diagnostics. Use this override only when a server needs an
+explicit wire-protocol pin instead of the discovered default.
+
 ### `VEX_MODEL_BACKEND`
 
 Overrides API-backend inference. Accepted values: `local-runtime`, `api-server`.
@@ -343,6 +347,10 @@ Overrides the working directory used for tool execution.
 ### `VEX_MODEL_HEADERS_JSON`
 
 Adds extra request headers as a JSON object.
+
+Operator-supplied headers are preserved when internal tracing is enabled. The
+runtime injects `x-request-id` and W3C trace context headers only when they are
+not already present.
 
 Example:
 
@@ -374,6 +382,27 @@ Controls the timeout used by context-related git commands.
 - Default: `2000`.
 - Applies to automatic git context when `VEX_CONTEXT_INCLUDE_GIT=1` and to the
   existing review helpers that call git through the shared runtime wrapper.
+
+## API tracing and startup retries
+
+- `--display-internal-telemetry` mirrors internal transport logs to stderr.
+- `--telemetry-json` switches those logs to NDJSON/JSONL output.
+- `VEX_INTERNAL_TELEMETRY_PATH` writes internal telemetry to a file instead of
+  stderr.
+- `VEX_TELEMETRY_FORMAT=json` is the environment equivalent of
+  `--telemetry-json`.
+- `VEX_TELEMETRY_ENVIRONMENT` and `VEX_TELEMETRY_TENANT_ID` add baggage fields
+  to request-scoped spans.
+
+When telemetry is enabled, the CLI installs a local OpenTelemetry tracer
+provider, propagates W3C `traceparent` and `baggage` headers on outbound model
+requests, and records structural payload summaries instead of raw prompts or tool
+arguments.
+
+Local API rate limiting applies only after bearer-token authorization succeeds.
+Authorized requests are bucketed per forwarded client IP when available and
+otherwise by an authorization-header-derived key, so unauthenticated callers do
+not consume the same limit bucket as valid local clients.
 
 ### `VEX_DISK_POLICY`
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -232,6 +232,37 @@ The full model endpoint URL.
   `stream = false` and normalizes the JSON response through the same API
   boundary instead of exposing a second downstream parser.
 
+### API tracing and startup retries
+
+For CLI troubleshooting, especially around `vex -p`, the transport layer now
+emits request-scoped tracing, propagates W3C trace context, and applies a
+short exponential backoff when a local endpoint is still starting up.
+
+- `vex --display-internal-telemetry -p "..."` mirrors internal telemetry to
+  stderr for one-shot runs without having to set `RUST_LOG` manually.
+- `vex --telemetry-json --display-internal-telemetry -p "..."` emits
+  newline-delimited JSON telemetry suitable for local collection by Vector,
+  Fluent Bit, or an OpenTelemetry collector.
+- `RUST_LOG=debug` enables structured transport, normalization, rate-limit,
+  and fallback spans for both interactive and one-shot runs.
+- `VEX_INTERNAL_TELEMETRY_PATH=/tmp/vex-internal.log` writes internal
+  telemetry to a dedicated non-blocking file sink instead of stderr.
+- `VEX_TELEMETRY_FORMAT=json` selects NDJSON output when telemetry is written
+  to a file-backed sink.
+- `VEX_TELEMETRY_ENVIRONMENT=staging` and `VEX_TELEMETRY_TENANT_ID=internal`
+  attach environment and tenant baggage to the current trace context.
+- `VEX_API_LOG_PATH=/tmp/vex-api.log` chooses where payload diagnostics are
+  written when payload logging is enabled.
+- `VEX_DEBUG_PAYLOAD=1` records outbound request payload summaries for API
+  debugging. Prompt text, tool arguments, and SSE payload bodies are reduced to
+  structural metadata rather than being written verbatim.
+- Request and server spans carry `traceparent`, `x-request-id`, and GenAI
+  semantic attributes so transport logs, tool lifecycle events, and runtime
+  normalization can be correlated under one request trace.
+- Local endpoint startup retries only cover initial connection failures before
+  a response stream exists. Once a streaming request is established, the CLI
+  does not replay it automatically.
+
 ### `VEX_MODEL_TOKEN`
 
 Bearer token for authenticated endpoints.

--- a/src/api/client/mod.rs
+++ b/src/api/client/mod.rs
@@ -2,6 +2,7 @@ use self::protocol_discovery::discover_protocol;
 use super::eventsource::create_event_stream;
 use super::logging::{debug_payload_enabled, emit_debug_payload};
 use crate::config::Config;
+use crate::observability::REQUEST_ID_HEADER;
 use crate::runtime::backend::{
     EventStream, ModelBackend, ModelBackendKind, ModelProtocol, ToolCallMode, ToolPolicy,
 };
@@ -9,10 +10,13 @@ use crate::types::{ApiMessage, Content, ContentBlock};
 use crate::util::{is_local_endpoint_url, preferred_plain_http_url_for_local_endpoint};
 use anyhow::Result;
 use anyhow::anyhow;
+use opentelemetry::KeyValue;
+use opentelemetry_semantic_conventions::attribute as semconv;
 use serde::Deserialize;
 use serde_json::Value;
 use serde_json::json;
 use std::sync::{Arc, RwLock};
+use tracing::Instrument;
 
 /// Server capabilities discovered from a local inference server.
 /// Populated by `poll_server_info()` once per session for local endpoints.
@@ -629,6 +633,66 @@ impl ApiClient {
             }
         }
 
+        let request_id = crate::observability::new_request_id();
+        headers.insert(
+            reqwest::header::HeaderName::from_static(REQUEST_ID_HEADER),
+            reqwest::header::HeaderValue::from_str(&request_id)
+                .map_err(|error| anyhow!("invalid x-request-id header: {error}"))?,
+        );
+        let payload_bytes = serde_json::to_vec(&payload)
+            .map(|body| body.len())
+            .unwrap_or_default();
+        let request_span = tracing::info_span!(
+            "model_api_request",
+            request_id = %request_id,
+            trace_id = tracing::field::Empty,
+            otel_span_id = tracing::field::Empty,
+            url = %crate::runtime::rewrite_url_for_logs(&request_url),
+            protocol = ?api_protocol,
+            model = %model,
+            local_endpoint = self.is_local_endpoint(),
+            tool_policy = ?self.tool_policy,
+            structured_tools = self.supports_structured_tool_protocol(),
+            payload_bytes,
+        );
+        crate::observability::attach_standard_baggage(
+            &request_span,
+            "model_api",
+            "inference_request",
+            Some(&request_id),
+            None,
+        );
+        let mut request_attributes = vec![
+            KeyValue::new(
+                semconv::GEN_AI_OPERATION_NAME,
+                gen_ai_operation_name(api_protocol),
+            ),
+            KeyValue::new(semconv::GEN_AI_REQUEST_MODEL, model.clone()),
+            KeyValue::new(semconv::GEN_AI_REQUEST_MAX_TOKENS, i64::from(max_tokens)),
+            KeyValue::new(semconv::GEN_AI_REQUEST_TEMPERATURE, self.temperature as f64),
+            KeyValue::new(semconv::GEN_AI_REQUEST_TOP_P, self.top_p as f64),
+            KeyValue::new(semconv::GEN_AI_SYSTEM, gen_ai_system_name(api_protocol)),
+            KeyValue::new(semconv::HTTP_REQUEST_METHOD, "POST"),
+        ];
+        if let Some(server_address) = request_server_address(&request_url) {
+            request_attributes.push(KeyValue::new(semconv::SERVER_ADDRESS, server_address));
+        }
+        crate::observability::set_span_attributes(&request_span, request_attributes);
+
+        tracing::info!(
+            target: "vex::http",
+            parent: &request_span,
+            request_id = %request_id,
+            url = %crate::runtime::rewrite_url_for_logs(&request_url),
+            protocol = ?api_protocol,
+            model = %model,
+            local_endpoint = self.is_local_endpoint(),
+            tool_policy = ?self.tool_policy,
+            structured_tools = self.supports_structured_tool_protocol(),
+            payload_bytes,
+            "dispatching model request"
+        );
+
         create_event_stream(
             self.http.clone(),
             &request_url,
@@ -638,7 +702,9 @@ impl ApiClient {
                 ApiProtocol::MessagesV1 => ModelProtocol::MessagesV1,
                 ApiProtocol::ChatCompat => ModelProtocol::ChatCompat,
             },
+            &request_id,
         )
+        .instrument(request_span)
         .await
     }
 
@@ -648,6 +714,27 @@ impl ApiClient {
             ApiProtocol::ChatCompat => adapt_to_chat_compat_url(&self.api_url),
         }
     }
+}
+
+fn gen_ai_operation_name(api_protocol: ApiProtocol) -> &'static str {
+    match api_protocol {
+        ApiProtocol::MessagesV1 => "respond",
+        ApiProtocol::ChatCompat => "chat",
+    }
+}
+
+fn gen_ai_system_name(api_protocol: ApiProtocol) -> &'static str {
+    match api_protocol {
+        ApiProtocol::ChatCompat => "_OTHER",
+        ApiProtocol::MessagesV1 => "_OTHER",
+    }
+}
+
+fn request_server_address(request_url: &str) -> Option<String> {
+    request_url
+        .parse::<http::Uri>()
+        .ok()
+        .and_then(|uri| uri.host().map(str::to_string))
 }
 
 fn configured_api_client_base_url(config: &Config) -> Option<String> {
@@ -683,21 +770,40 @@ impl ModelBackend for ApiClient {
 
 pub(crate) fn map_api_request_error(error: reqwest::Error, request_url: &str) -> anyhow::Error {
     let local_http_hint = local_plain_http_hint(request_url);
+    let rewritten_url = crate::runtime::rewrite_url_for_logs(request_url);
 
     if error.is_connect() && is_local_endpoint_url(request_url) {
+        tracing::warn!(
+            target: "vex::http",
+            url = %rewritten_url,
+            error = %error,
+            "cannot reach local API endpoint"
+        );
         return anyhow!(
-            "cannot reach local API endpoint '{}': {}. Start your local server or update VEX_MODEL_URL.{}",
+            "cannot reach local API endpoint '{}': {}. Start your local server or update VEX_MODEL_URL. The CLI retries short-lived local startup connection failures automatically before failing. For transport diagnostics, rerun with --display-internal-telemetry or set RUST_LOG=debug.{}",
             request_url,
             error,
             local_http_hint
         );
     }
     if error.is_connect() {
+        tracing::warn!(
+            target: "vex::http",
+            url = %rewritten_url,
+            error = %error,
+            "cannot reach remote API endpoint"
+        );
         return anyhow!("cannot reach API endpoint '{}': {}", request_url, error);
     }
     if error.is_timeout() {
+        tracing::warn!(
+            target: "vex::http",
+            url = %rewritten_url,
+            error = %error,
+            "API request timed out"
+        );
         return anyhow!(
-            "API request to '{}' timed out: {}.{}",
+            "API request to '{}' timed out: {}. The endpoint accepted the connection but did not answer before the configured timeout. For transport diagnostics, rerun with --display-internal-telemetry or set RUST_LOG=debug.{}",
             request_url,
             error,
             local_http_hint

--- a/src/api/client/mod.rs
+++ b/src/api/client/mod.rs
@@ -639,9 +639,9 @@ impl ApiClient {
             reqwest::header::HeaderValue::from_str(&request_id)
                 .map_err(|error| anyhow!("invalid x-request-id header: {error}"))?,
         );
-        let payload_bytes = serde_json::to_vec(&payload)
-            .map(|body| body.len())
-            .unwrap_or_default();
+        let serialized_payload = serde_json::to_string(&payload)
+            .map_err(|error| anyhow!("failed to serialize API request payload: {error}"))?;
+        let payload_bytes = serialized_payload.len();
         let request_span = tracing::info_span!(
             "model_api_request",
             request_id = %request_id,
@@ -678,6 +678,7 @@ impl ApiClient {
             request_attributes.push(KeyValue::new(semconv::SERVER_ADDRESS, server_address));
         }
         crate::observability::set_span_attributes(&request_span, request_attributes);
+        crate::observability::inject_span_context_headers(&request_span, &mut headers);
 
         tracing::info!(
             target: "vex::http",
@@ -697,6 +698,7 @@ impl ApiClient {
             self.http.clone(),
             &request_url,
             &payload,
+            serialized_payload,
             &headers,
             match api_protocol {
                 ApiProtocol::MessagesV1 => ModelProtocol::MessagesV1,

--- a/src/api/client/tests.rs
+++ b/src/api/client/tests.rs
@@ -1267,6 +1267,30 @@ fn test_map_api_status_error_server_500() {
     assert!(msg.contains("out of memory"), "got: {msg}");
 }
 
+#[tokio::test]
+async fn test_map_api_request_error_local_connect_mentions_retry_and_telemetry() {
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+
+    let request_url = format!("http://{addr}/v1/messages");
+    let error = reqwest::Client::new()
+        .post(&request_url)
+        .send()
+        .await
+        .expect_err("request should fail once the listener is dropped");
+
+    let msg = map_api_request_error(error, &request_url).to_string();
+    assert!(
+        msg.contains("retries short-lived local startup connection failures"),
+        "got: {msg}"
+    );
+    assert!(msg.contains("--display-internal-telemetry"), "got: {msg}");
+    assert!(msg.contains("RUST_LOG=debug"), "got: {msg}");
+}
+
 // ── Rate-limit / Retry-After header detection ───────────────────────
 
 #[test]

--- a/src/api/eventsource.rs
+++ b/src/api/eventsource.rs
@@ -8,8 +8,10 @@
 use crate::api::client::{map_api_request_error, map_api_status_error};
 use crate::api::stream::StreamParser;
 use crate::runtime::backend::EventStream;
-use crate::runtime::{ModelProtocol, RuntimeEnvelope};
+use crate::runtime::{ModelProtocol, RuntimeEnvelope, RuntimeEvent, TokenUsageEnvelope};
 use anyhow::{Context, Result, anyhow};
+use backoff::ExponentialBackoffBuilder;
+use backoff::backoff::Backoff;
 use bytes::Bytes;
 use eventsource_client::{Client as _, ClientBuilder, ReconnectOptions, SSE};
 use futures::{StreamExt, stream};
@@ -18,12 +20,19 @@ use launchdarkly_sdk_transport::{
 };
 use serde_json::{Value, json};
 use std::collections::VecDeque;
-use std::time::Duration;
+use std::future::Future;
+use std::time::{Duration, Instant};
 
 #[cfg(test)]
 const LOCAL_STREAM_START_TIMEOUT: Duration = Duration::from_millis(50);
 #[cfg(not(test))]
 const LOCAL_STREAM_START_TIMEOUT: Duration = Duration::from_secs(5);
+#[cfg(test)]
+const LOCAL_CONNECT_RETRY_MAX_ELAPSED: Duration = Duration::from_millis(250);
+#[cfg(not(test))]
+const LOCAL_CONNECT_RETRY_MAX_ELAPSED: Duration = Duration::from_secs(2);
+const LOCAL_CONNECT_RETRY_INITIAL_INTERVAL: Duration = Duration::from_millis(100);
+const LOCAL_CONNECT_RETRY_MAX_INTERVAL: Duration = Duration::from_millis(400);
 
 pub(crate) async fn create_event_stream(
     http: reqwest::Client,
@@ -31,7 +40,9 @@ pub(crate) async fn create_event_stream(
     payload: &serde_json::Value,
     headers: &reqwest::header::HeaderMap,
     protocol: ModelProtocol,
+    request_id: &str,
 ) -> Result<EventStream> {
+    let request_start = Instant::now();
     let mut builder = ClientBuilder::for_url(request_url)
         .map_err(|error| {
             anyhow!(
@@ -64,12 +75,23 @@ pub(crate) async fn create_event_stream(
 
     let client = builder.build_with_transport(ReqwestEventSourceTransport {
         client: http.clone(),
+        request_id: request_id.to_string(),
     });
     let mut state = EventStreamState {
         upstream: client.stream(),
         parser: StreamParser::new(),
         pending: VecDeque::new(),
         request_url: request_url.to_string(),
+        request_id: request_id.to_string(),
+        protocol_name: protocol_name(protocol),
+        started_at: request_start,
+        envelope_count: 0,
+        tool_call_starts: 0,
+        tool_call_completions: 0,
+        tool_call_failures: 0,
+        last_usage: None,
+        final_status: None,
+        summary_emitted: false,
     };
 
     let first_event = if crate::util::is_local_endpoint_url(request_url) {
@@ -79,8 +101,10 @@ pub(crate) async fn create_event_stream(
             Err(_) => {
                 tracing::warn!(
                     target: "vex::http",
+                    request_id = %request_id,
                     url = %crate::runtime::rewrite_url_for_logs(request_url),
                     timeout_ms = LOCAL_STREAM_START_TIMEOUT.as_millis(),
+                    elapsed_ms = request_start.elapsed().as_millis() as u64,
                     "local streaming request emitted no initial SSE event; retrying as non-streaming JSON"
                 );
                 return create_non_stream_fallback_stream(
@@ -89,6 +113,8 @@ pub(crate) async fn create_event_stream(
                     payload,
                     headers,
                     protocol,
+                    request_id,
+                    "no_initial_sse_event",
                 )
                 .await;
             }
@@ -105,6 +131,14 @@ pub(crate) async fn create_event_stream(
     });
 
     if let Some(first_event) = first_event {
+        tracing::debug!(
+            target: "vex::http",
+            request_id = %request_id,
+            url = %crate::runtime::rewrite_url_for_logs(request_url),
+            protocol = ?protocol,
+            elapsed_ms = request_start.elapsed().as_millis() as u64,
+            "streaming response established"
+        );
         Ok(Box::pin(stream::iter(vec![Ok(first_event)]).chain(tail)))
     } else {
         Ok(Box::pin(tail))
@@ -117,18 +151,40 @@ async fn create_non_stream_fallback_stream(
     payload: &serde_json::Value,
     headers: &reqwest::header::HeaderMap,
     protocol: ModelProtocol,
+    request_id: &str,
+    fallback_reason: &'static str,
 ) -> Result<EventStream> {
+    let fallback_start = Instant::now();
+    let request_url_for_logs = crate::runtime::rewrite_url_for_logs(request_url);
     let mut request_headers = headers.clone();
     request_headers.insert(
         reqwest::header::ACCEPT,
         reqwest::header::HeaderValue::from_static("application/json"),
     );
+    let fallback_payload = non_stream_payload(payload);
 
-    let response = http
-        .post(request_url)
-        .headers(request_headers)
-        .json(&non_stream_payload(payload))
-        .send()
+    tracing::info!(
+        target: "vex::http",
+        request_id = %request_id,
+        url = %request_url_for_logs,
+        fallback_reason = fallback_reason,
+        protocol = ?protocol,
+        "issuing non-streaming fallback request"
+    );
+
+    let response =
+        retry_local_connect_errors(request_url, request_id, "non_stream_fallback", || {
+            let http = http.clone();
+            let request_headers = request_headers.clone();
+            let fallback_payload = fallback_payload.clone();
+            async move {
+                http.post(request_url)
+                    .headers(request_headers)
+                    .json(&fallback_payload)
+                    .send()
+                    .await
+            }
+        })
         .await
         .map_err(|error| map_api_request_error(error, request_url))?;
 
@@ -143,6 +199,18 @@ async fn create_non_stream_fallback_stream(
         .await
         .unwrap_or_else(|error| format!("<failed to read non-streaming response body: {error}>"));
 
+    tracing::info!(
+        target: "vex::http",
+        request_id = %request_id,
+        url = %request_url_for_logs,
+        status = status.as_u16(),
+        fallback_reason = fallback_reason,
+        latency_ms = fallback_start.elapsed().as_millis() as u64,
+        body_bytes = body.len(),
+        retry_after = retry_after.as_deref().unwrap_or("none"),
+        "received non-streaming fallback response"
+    );
+
     if !status.is_success() {
         return Err(map_api_status_error(
             status,
@@ -152,13 +220,13 @@ async fn create_non_stream_fallback_stream(
         ));
     }
 
-    let request_url_for_logs = crate::runtime::rewrite_url_for_logs(request_url);
-    let envelopes = normalize_non_stream_response(protocol, &body).with_context(|| {
-        format!(
-            "failed to normalize non-streaming fallback response from '{}'",
-            request_url_for_logs
-        )
-    })?;
+    let envelopes =
+        normalize_non_stream_response(protocol, &body, request_id).with_context(|| {
+            format!(
+                "failed to normalize non-streaming fallback response from '{}'",
+                request_url_for_logs
+            )
+        })?;
 
     Ok(Box::pin(stream::iter(envelopes.into_iter().map(Ok))))
 }
@@ -174,7 +242,15 @@ fn non_stream_payload(payload: &serde_json::Value) -> serde_json::Value {
 fn normalize_non_stream_response(
     protocol: ModelProtocol,
     body: &str,
+    request_id: &str,
 ) -> Result<Vec<RuntimeEnvelope>> {
+    tracing::debug!(
+        target: "vex::protocol",
+        request_id = %request_id,
+        protocol = ?protocol,
+        response_bytes = body.len(),
+        "normalizing non-streaming fallback response"
+    );
     let response: Value =
         serde_json::from_str(body).with_context(|| "response body was not valid JSON")?;
     let mut parser = StreamParser::new();
@@ -329,6 +405,13 @@ fn normalize_non_stream_response(
     }
 
     envelopes.extend(parser.finish());
+    tracing::debug!(
+        target: "vex::protocol",
+        request_id = %request_id,
+        protocol = ?protocol,
+        envelope_count = envelopes.len(),
+        "completed non-streaming fallback normalization"
+    );
     Ok(envelopes)
 }
 
@@ -356,6 +439,16 @@ struct EventStreamState {
     parser: StreamParser,
     pending: VecDeque<RuntimeEnvelope>,
     request_url: String,
+    request_id: String,
+    protocol_name: &'static str,
+    started_at: Instant,
+    envelope_count: u64,
+    tool_call_starts: u64,
+    tool_call_completions: u64,
+    tool_call_failures: u64,
+    last_usage: Option<TokenUsageEnvelope>,
+    final_status: Option<String>,
+    summary_emitted: bool,
 }
 
 fn finish_pending_events(state: &mut EventStreamState) -> Option<RuntimeEnvelope> {
@@ -363,16 +456,72 @@ fn finish_pending_events(state: &mut EventStreamState) -> Option<RuntimeEnvelope
     state.pending.pop_front()
 }
 
+fn observe_envelope(state: &mut EventStreamState, envelope: &RuntimeEnvelope) {
+    state.envelope_count += 1;
+    match &envelope.event {
+        RuntimeEvent::ToolCallStarted { .. } => state.tool_call_starts += 1,
+        RuntimeEvent::ToolCallCompleted { .. } => state.tool_call_completions += 1,
+        RuntimeEvent::ToolCallFailed { .. } => state.tool_call_failures += 1,
+        RuntimeEvent::UsageUpdated { usage } => state.last_usage = Some(usage.clone()),
+        RuntimeEvent::TurnEnd { status, usage, .. } => {
+            state.final_status = Some(status.clone());
+            if let Some(usage) = usage {
+                state.last_usage = Some(usage.clone());
+            }
+        }
+        RuntimeEvent::Error { code, .. } => {
+            state.final_status = Some(format!("error:{code}"));
+        }
+        _ => {}
+    }
+}
+
+fn emit_stream_summary(state: &mut EventStreamState, outcome: &'static str) {
+    if state.summary_emitted {
+        return;
+    }
+    state.summary_emitted = true;
+
+    let usage = state.last_usage.as_ref();
+    tracing::info!(
+        target: "vex::http",
+        request_id = %state.request_id,
+        url = %crate::runtime::rewrite_url_for_logs(&state.request_url),
+        protocol = state.protocol_name,
+        outcome,
+        elapsed_ms = state.started_at.elapsed().as_millis() as u64,
+        envelope_count = state.envelope_count,
+        tool_call_starts = state.tool_call_starts,
+        tool_call_completions = state.tool_call_completions,
+        tool_call_failures = state.tool_call_failures,
+        final_status = state.final_status.as_deref().unwrap_or("unknown"),
+        usage_input_tokens = usage.map(|usage| usage.input).unwrap_or_default(),
+        usage_output_tokens = usage.map(|usage| usage.output).unwrap_or_default(),
+        usage_estimated = usage.map(|usage| usage.estimated).unwrap_or(false),
+        "stream lifecycle summary"
+    );
+}
+
+fn protocol_name(protocol: ModelProtocol) -> &'static str {
+    match protocol {
+        ModelProtocol::MessagesV1 => "messages-v1",
+        ModelProtocol::ChatCompat => "chat-compat",
+    }
+}
+
 async fn next_stream_event(state: &mut EventStreamState) -> Result<Option<RuntimeEnvelope>> {
     loop {
         if let Some(event) = state.pending.pop_front() {
+            observe_envelope(state, &event);
             return Ok(Some(event));
         }
 
         let Some(item) = state.upstream.next().await else {
             if let Some(event) = finish_pending_events(state) {
+                observe_envelope(state, &event);
                 return Ok(Some(event));
             }
+            emit_stream_summary(state, "stream_closed");
             return Ok(None);
         };
 
@@ -387,8 +536,10 @@ async fn next_stream_event(state: &mut EventStreamState) -> Result<Option<Runtim
             }
             Err(eventsource_client::Error::Eof) => {
                 if let Some(event) = finish_pending_events(state) {
+                    observe_envelope(state, &event);
                     return Ok(Some(event));
                 }
+                emit_stream_summary(state, "stream_eof");
                 return Ok(None);
             }
             Err(eventsource_client::Error::UnexpectedResponse(response, body)) => {
@@ -400,6 +551,15 @@ async fn next_stream_event(state: &mut EventStreamState) -> Result<Option<Runtim
                 let status = reqwest::StatusCode::from_u16(response.status())
                     .unwrap_or(reqwest::StatusCode::INTERNAL_SERVER_ERROR);
                 let body = read_error_body(body.into_stream()).await;
+                tracing::warn!(
+                    target: "vex::http",
+                    request_id = %state.request_id,
+                    url = %crate::runtime::rewrite_url_for_logs(&state.request_url),
+                    status = status.as_u16(),
+                    body_bytes = body.len(),
+                    "streaming endpoint returned an unexpected response"
+                );
+                emit_stream_summary(state, "unexpected_response");
                 return Err(map_api_status_error(
                     status,
                     &body,
@@ -408,12 +568,28 @@ async fn next_stream_event(state: &mut EventStreamState) -> Result<Option<Runtim
                 ));
             }
             Err(eventsource_client::Error::Transport(error)) => {
+                tracing::warn!(
+                    target: "vex::http",
+                    request_id = %state.request_id,
+                    url = %crate::runtime::rewrite_url_for_logs(&state.request_url),
+                    error = %error,
+                    "streaming transport error"
+                );
+                emit_stream_summary(state, "transport_error");
                 return Err(anyhow!(error.to_string()));
             }
             Err(eventsource_client::Error::TimedOut) => {
+                tracing::warn!(
+                    target: "vex::http",
+                    request_id = %state.request_id,
+                    url = %crate::runtime::rewrite_url_for_logs(&state.request_url),
+                    "streaming request timed out"
+                );
+                emit_stream_summary(state, "stream_timeout");
                 return Err(anyhow!("API request to '{}' timed out", state.request_url));
             }
             Err(error) => {
+                emit_stream_summary(state, "stream_error");
                 return Err(anyhow!(
                     "SSE stream from '{}' failed: {}",
                     state.request_url,
@@ -453,41 +629,65 @@ async fn read_error_body(mut stream: TransportByteStream) -> String {
 #[derive(Clone)]
 struct ReqwestEventSourceTransport {
     client: reqwest::Client,
+    request_id: String,
 }
 
 impl HttpTransport for ReqwestEventSourceTransport {
     fn request(&self, request: http::Request<Option<Bytes>>) -> ResponseFuture {
         let client = self.client.clone();
+        let request_id = self.request_id.clone();
 
         Box::pin(async move {
             let (parts, body) = request.into_parts();
             let request_url = parts.uri.to_string();
             let revised_request_url = crate::runtime::rewrite_url_for_logs(&request_url);
+            let method = parts.method.clone();
+            let headers = parts.headers.clone();
+            let request_body = body.clone();
 
             tracing::debug!(
                 target: "vex::http",
+                request_id = %request_id,
                 method = %parts.method,
                 url = %revised_request_url,
                 "sending streaming request"
             );
 
-            let mut reqwest_request = client.request(parts.method, request_url.clone());
-            for (name, value) in &parts.headers {
-                reqwest_request = reqwest_request.header(name, value);
-            }
-            if let Some(body) = body {
-                reqwest_request = reqwest_request.body(body);
-            }
-
-            let response = reqwest_request.send().await.map_err(|error| {
-                TransportError::new(std::io::Error::other(
-                    map_api_request_error(error, &request_url).to_string(),
-                ))
-            })?;
+            let response =
+                retry_local_connect_errors(&request_url, &request_id, "streaming_request", || {
+                    let client = client.clone();
+                    let method = method.clone();
+                    let headers = headers.clone();
+                    let request_url = request_url.clone();
+                    let request_body = request_body.clone();
+                    async move {
+                        let mut reqwest_request = client.request(method, request_url);
+                        for (name, value) in &headers {
+                            reqwest_request = reqwest_request.header(name, value);
+                        }
+                        if let Some(body) = request_body {
+                            reqwest_request = reqwest_request.body(body);
+                        }
+                        reqwest_request.send().await
+                    }
+                })
+                .await
+                .map_err(|error| {
+                    TransportError::new(std::io::Error::other(
+                        map_api_request_error(error, &request_url).to_string(),
+                    ))
+                })?;
 
             let status = response.status();
             let headers = response.headers().clone();
             let request_url_for_stream = request_url.clone();
+            tracing::debug!(
+                target: "vex::http",
+                request_id = %request_id,
+                url = %revised_request_url,
+                status = status.as_u16(),
+                "streaming request connected"
+            );
             let body: TransportByteStream = Box::pin(response.bytes_stream().map(move |item| {
                 item.map_err(|error| {
                     TransportError::new(std::io::Error::other(
@@ -503,6 +703,80 @@ impl HttpTransport for ReqwestEventSourceTransport {
 
             response_builder.body(body).map_err(TransportError::new)
         })
+    }
+}
+
+fn local_connect_retry_backoff() -> backoff::ExponentialBackoff {
+    let mut builder = ExponentialBackoffBuilder::new();
+    builder
+        .with_initial_interval(LOCAL_CONNECT_RETRY_INITIAL_INTERVAL)
+        .with_multiplier(2.0)
+        .with_max_interval(LOCAL_CONNECT_RETRY_MAX_INTERVAL)
+        .with_max_elapsed_time(Some(LOCAL_CONNECT_RETRY_MAX_ELAPSED));
+    builder.build()
+}
+
+async fn retry_local_connect_errors<T, Op, Fut>(
+    request_url: &str,
+    request_id: &str,
+    operation_name: &'static str,
+    mut operation: Op,
+) -> std::result::Result<T, reqwest::Error>
+where
+    Op: FnMut() -> Fut,
+    Fut: Future<Output = std::result::Result<T, reqwest::Error>>,
+{
+    if !crate::util::is_local_endpoint_url(request_url) {
+        return operation().await;
+    }
+
+    let rewritten_url = crate::runtime::rewrite_url_for_logs(request_url);
+    let mut attempt = 0_u32;
+    let mut backoff = local_connect_retry_backoff();
+
+    loop {
+        attempt += 1;
+        tracing::debug!(
+            target: "vex::http",
+            request_id = %request_id,
+            url = %rewritten_url,
+            operation = operation_name,
+            attempt,
+            "sending local request attempt"
+        );
+
+        match operation().await {
+            Ok(result) => {
+                if attempt > 1 {
+                    tracing::info!(
+                        target: "vex::http",
+                        request_id = %request_id,
+                        url = %rewritten_url,
+                        operation = operation_name,
+                        attempts = attempt,
+                        "local API endpoint became available after startup retries"
+                    );
+                }
+                return Ok(result);
+            }
+            Err(error) if error.is_connect() => {
+                let Some(delay) = backoff.next_backoff() else {
+                    return Err(error);
+                };
+                let next_delay_ms = delay.as_millis() as u64;
+                tracing::warn!(
+                    target: "vex::http",
+                    request_id = %request_id,
+                    url = %rewritten_url,
+                    operation = operation_name,
+                    error = %error,
+                    next_delay_ms,
+                    "local API endpoint not ready; retrying connect failure with backoff"
+                );
+                tokio::time::sleep(delay).await;
+            }
+            Err(error) => return Err(error),
+        }
     }
 }
 
@@ -526,6 +800,16 @@ mod tests {
             parser,
             pending: VecDeque::new(),
             request_url: "https://example.test/sse".to_string(),
+            request_id: "req-test-eof".to_string(),
+            protocol_name: "messages-v1",
+            started_at: Instant::now(),
+            envelope_count: 0,
+            tool_call_starts: 0,
+            tool_call_completions: 0,
+            tool_call_failures: 0,
+            last_usage: None,
+            final_status: None,
+            summary_emitted: false,
         };
 
         let event = next_stream_event(&mut state).await.unwrap().unwrap();

--- a/src/api/eventsource.rs
+++ b/src/api/eventsource.rs
@@ -38,6 +38,7 @@ pub(crate) async fn create_event_stream(
     http: reqwest::Client,
     request_url: &str,
     payload: &serde_json::Value,
+    serialized_payload: String,
     headers: &reqwest::header::HeaderMap,
     protocol: ModelProtocol,
     request_id: &str,
@@ -54,7 +55,7 @@ pub(crate) async fn create_event_stream(
         // Intentional deviation from the browser EventSource interface: the
         // upstream APIs require POST bodies for streamed generation.
         .method("POST".to_string())
-        .body(payload.to_string())
+        .body(serialized_payload)
         // Reconnect stays disabled for POST streaming requests. Replaying a
         // partial generation would not be idempotent and could duplicate work.
         .reconnect(ReconnectOptions::reconnect(false).build());
@@ -710,6 +711,7 @@ fn local_connect_retry_backoff() -> backoff::ExponentialBackoff {
     let mut builder = ExponentialBackoffBuilder::new();
     builder
         .with_initial_interval(LOCAL_CONNECT_RETRY_INITIAL_INTERVAL)
+        .with_randomization_factor(0.0)
         .with_multiplier(2.0)
         .with_max_interval(LOCAL_CONNECT_RETRY_MAX_INTERVAL)
         .with_max_elapsed_time(Some(LOCAL_CONNECT_RETRY_MAX_ELAPSED));
@@ -784,7 +786,11 @@ where
 mod tests {
     use super::*;
     use crate::runtime::RuntimeEvent;
+    use axum::Router;
+    use axum::routing::get;
     use futures::stream;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[tokio::test]
     async fn eof_still_flushes_provider_normalized_turn_end() {
@@ -816,5 +822,133 @@ mod tests {
 
         assert!(matches!(event.event, RuntimeEvent::TurnEnd { .. }));
         assert!(next_stream_event(&mut state).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn retry_local_connect_errors_retries_connect_failures_for_local_endpoints() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+
+        let server = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+            axum::serve(
+                listener,
+                Router::new().route("/health", get(|| async { "ok" })),
+            )
+            .await
+            .unwrap();
+        });
+
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_millis(50))
+            .build()
+            .unwrap();
+        let result = retry_local_connect_errors(
+            &format!("http://{addr}/v1/messages"),
+            "req-local-retry",
+            "test_connect_retry",
+            || {
+                let client = client.clone();
+                let attempts = Arc::clone(&attempts);
+                async move {
+                    attempts.fetch_add(1, Ordering::SeqCst);
+                    client.get(format!("http://{addr}/health")).send().await
+                }
+            },
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "expected retry to eventually succeed: {result:?}"
+        );
+        assert!(attempts.load(Ordering::SeqCst) > 1);
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn retry_local_connect_errors_does_not_retry_non_local_connect_errors() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_millis(20))
+            .build()
+            .unwrap();
+
+        let result = retry_local_connect_errors(
+            "https://model.example.internal/v1/messages",
+            "req-remote-connect",
+            "test_remote_no_retry",
+            || {
+                let client = client.clone();
+                let attempts = Arc::clone(&attempts);
+                async move {
+                    attempts.fetch_add(1, Ordering::SeqCst);
+                    client.get("http://127.0.0.1:9/health").send().await
+                }
+            },
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn retry_local_connect_errors_does_not_retry_non_connect_errors() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let client = reqwest::Client::new();
+
+        let result = retry_local_connect_errors(
+            "http://127.0.0.1:8000/v1/messages",
+            "req-local-non-connect",
+            "test_builder_error",
+            || {
+                let client = client.clone();
+                let attempts = Arc::clone(&attempts);
+                async move {
+                    attempts.fetch_add(1, Ordering::SeqCst);
+                    client.get("http://[").send().await
+                }
+            },
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn retry_local_connect_errors_stops_after_max_elapsed_time() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let start = Instant::now();
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_millis(20))
+            .build()
+            .unwrap();
+
+        let result = retry_local_connect_errors(
+            "http://127.0.0.1:9/v1/messages",
+            "req-local-timeout",
+            "test_max_elapsed",
+            || {
+                let client = client.clone();
+                let attempts = Arc::clone(&attempts);
+                async move {
+                    attempts.fetch_add(1, Ordering::SeqCst);
+                    client.get("http://127.0.0.1:9/health").send().await
+                }
+            },
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+        assert!(start.elapsed() >= LOCAL_CONNECT_RETRY_INITIAL_INTERVAL);
+        assert!(start.elapsed() < LOCAL_CONNECT_RETRY_MAX_ELAPSED);
     }
 }

--- a/src/api/logging.rs
+++ b/src/api/logging.rs
@@ -148,20 +148,16 @@ fn summarize_sse_payload(json_data: &str) -> Value {
     }
 }
 
-fn emit_log_message(message: &str) {
+fn emit_log_value(value: &Value) {
+    let encoded = serde_json::to_string(value)
+        .unwrap_or_else(|_| "{\"event\":\"api.log.encode_failed\"}".to_string());
     if let Some(path) = resolve_log_path()
-        && append_log_file(&path, message).is_ok()
+        && append_log_file(&path, &format!("{encoded}\n")).is_ok()
     {
         return;
     }
 
-    eprintln!("{message}");
-}
-
-fn emit_log_value(value: &Value) {
-    let encoded = serde_json::to_string(value)
-        .unwrap_or_else(|_| "{\"event\":\"api.log.encode_failed\"}".to_string());
-    emit_log_message(&format!("{encoded}\n"));
+    eprintln!("{encoded}");
 }
 
 fn resolve_log_path() -> Option<String> {
@@ -280,5 +276,30 @@ mod tests {
             content.contains("\"contains_tool_calls\":true"),
             "got: {content}"
         );
+    }
+
+    #[test]
+    fn test_emit_log_value_writes_single_ndjson_record_per_line() {
+        let env_lock = crate::test_support::ENV_LOCK.blocking_lock();
+        let _guard = crate::test_support::EnvRestore::capture(&env_lock, API_LOG_PATH_ENV);
+        let temp = tempfile::NamedTempFile::new().unwrap();
+        crate::test_support::test_set_var(
+            &env_lock,
+            API_LOG_PATH_ENV,
+            temp.path().to_string_lossy().to_string(),
+        );
+
+        emit_debug_payload(
+            "http://127.0.0.1:8000/v1/messages",
+            &json!({"messages": []}),
+        );
+        emit_debug_payload(
+            "http://127.0.0.1:8000/v1/messages",
+            &json!({"messages": []}),
+        );
+
+        let content = std::fs::read_to_string(temp.path()).unwrap();
+        assert!(!content.contains("\n\n"), "got: {content:?}");
+        assert_eq!(content.lines().count(), 2, "got: {content:?}");
     }
 }

--- a/src/api/logging.rs
+++ b/src/api/logging.rs
@@ -1,4 +1,4 @@
-use serde_json::Value;
+use serde_json::{Value, json};
 use std::fs::OpenOptions;
 use std::io::{IsTerminal, Write};
 use std::path::PathBuf;
@@ -14,11 +14,11 @@ pub fn debug_payload_enabled() -> bool {
 }
 
 pub fn emit_debug_payload(request_url: &str, payload: &Value) {
-    let formatted_payload = serde_json::to_string_pretty(payload)
-        .unwrap_or_else(|_| "<payload serialization error>".to_string());
-    let message =
-        format!("VEX_API DEBUG payload_request url={request_url}\npayload:\n{formatted_payload}\n");
-    emit_log_message(&message);
+    emit_log_value(&json!({
+        "event": "api.payload_request",
+        "url": request_url,
+        "payload_summary": summarize_debug_payload(payload),
+    }));
 }
 
 pub fn emit_sse_parse_error(
@@ -26,11 +26,126 @@ pub fn emit_sse_parse_error(
     json_data: &str,
     parse_error: &serde_json::Error,
 ) {
-    let message = format!(
-        "VEX_API ERROR sse_parse_failed error={parse_error}\nevent_type={}\ndata:\n{json_data}\n",
-        event_type.unwrap_or("<none>")
-    );
-    emit_log_message(&message);
+    emit_log_value(&json!({
+        "event": "api.sse_parse_failed",
+        "event_type": event_type.unwrap_or("<none>"),
+        "error": parse_error.to_string(),
+        "data_summary": summarize_sse_payload(json_data),
+    }));
+}
+
+fn summarize_debug_payload(payload: &Value) -> Value {
+    let message_roles = payload
+        .get("messages")
+        .and_then(Value::as_array)
+        .map(|messages| summarize_message_roles(messages))
+        .unwrap_or_default();
+    let message_count = payload
+        .get("messages")
+        .and_then(Value::as_array)
+        .map(|messages| messages.len())
+        .unwrap_or(0);
+    let redacted_message_chars = payload
+        .get("messages")
+        .and_then(Value::as_array)
+        .map(|messages| messages.iter().map(redacted_value_chars).sum::<usize>())
+        .unwrap_or(0);
+    let tool_names = payload
+        .get("tools")
+        .and_then(Value::as_array)
+        .map(|tools| {
+            tools
+                .iter()
+                .filter_map(extract_tool_name)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let stop_count = payload
+        .get("stop")
+        .and_then(Value::as_array)
+        .map(|stop| stop.len())
+        .unwrap_or(0);
+    let mut top_level_keys = payload
+        .as_object()
+        .map(|object| object.keys().cloned().collect::<Vec<_>>())
+        .unwrap_or_default();
+    top_level_keys.sort();
+
+    json!({
+        "model": payload.get("model").and_then(Value::as_str).unwrap_or("unknown"),
+        "stream": payload.get("stream").and_then(Value::as_bool).unwrap_or(false),
+        "top_level_keys": top_level_keys,
+        "message_count": message_count,
+        "message_roles": message_roles,
+        "redacted_message_chars": redacted_message_chars,
+        "system_prompt_present": payload.get("system").is_some(),
+        "tool_count": tool_names.len(),
+        "tool_names": tool_names,
+        "stop_count": stop_count,
+        "has_reasoning_effort": payload.get("reasoning_effort").is_some(),
+        "max_tokens": payload.get("max_tokens").cloned().unwrap_or(Value::Null),
+        "temperature": payload.get("temperature").cloned().unwrap_or(Value::Null),
+        "top_p": payload.get("top_p").cloned().unwrap_or(Value::Null),
+    })
+}
+
+fn summarize_message_roles(messages: &[Value]) -> serde_json::Map<String, Value> {
+    let mut counts = serde_json::Map::new();
+    for message in messages {
+        let role = message
+            .get("role")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+            .to_string();
+        let next = counts.get(&role).and_then(Value::as_u64).unwrap_or(0) + 1;
+        counts.insert(role, Value::from(next));
+    }
+    counts
+}
+
+fn redacted_value_chars(value: &Value) -> usize {
+    match value {
+        Value::Null => 0,
+        Value::Bool(_) | Value::Number(_) => 0,
+        Value::String(text) => text.chars().count(),
+        Value::Array(values) => values.iter().map(redacted_value_chars).sum(),
+        Value::Object(map) => map.values().map(redacted_value_chars).sum(),
+    }
+}
+
+fn extract_tool_name(tool: &Value) -> Option<String> {
+    tool.get("name")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            tool.get("function")
+                .and_then(|function| function.get("name"))
+                .and_then(Value::as_str)
+        })
+        .map(str::to_string)
+}
+
+fn summarize_sse_payload(json_data: &str) -> Value {
+    match serde_json::from_str::<Value>(json_data) {
+        Ok(value) => {
+            let mut top_level_keys = value
+                .as_object()
+                .map(|object| object.keys().cloned().collect::<Vec<_>>())
+                .unwrap_or_default();
+            top_level_keys.sort();
+            json!({
+                "kind": "json",
+                "top_level_keys": top_level_keys,
+                "redacted_chars": redacted_value_chars(&value),
+                "contains_tool_calls": json_data.contains("\"tool_calls\""),
+            })
+        }
+        Err(_) => json!({
+            "kind": "non_json",
+            "bytes": json_data.len(),
+            "contains_tool_calls": json_data.contains("\"tool_calls\""),
+            "contains_tool_use": json_data.contains("\"tool_use\""),
+        }),
+    }
 }
 
 fn emit_log_message(message: &str) {
@@ -41,6 +156,12 @@ fn emit_log_message(message: &str) {
     }
 
     eprintln!("{message}");
+}
+
+fn emit_log_value(value: &Value) {
+    let encoded = serde_json::to_string(value)
+        .unwrap_or_else(|_| "{\"event\":\"api.log.encode_failed\"}".to_string());
+    emit_log_message(&format!("{encoded}\n"));
 }
 
 fn resolve_log_path() -> Option<String> {
@@ -93,6 +214,71 @@ mod tests {
         assert_eq!(
             default_log_path(),
             std::env::temp_dir().join(DEFAULT_API_LOG_FILENAME)
+        );
+    }
+
+    #[test]
+    fn test_emit_debug_payload_redacts_prompt_text() {
+        let env_lock = crate::test_support::ENV_LOCK.blocking_lock();
+        let _guard = crate::test_support::EnvRestore::capture(&env_lock, API_LOG_PATH_ENV);
+        let temp = tempfile::NamedTempFile::new().unwrap();
+        crate::test_support::test_set_var(
+            &env_lock,
+            API_LOG_PATH_ENV,
+            temp.path().to_string_lossy().to_string(),
+        );
+
+        emit_debug_payload(
+            "http://127.0.0.1:8000/v1/messages",
+            &json!({
+                "model": "local/test",
+                "messages": [{
+                    "role": "user",
+                    "content": "super secret prompt text"
+                }],
+                "tools": [{"function": {"name": "read_file"}}],
+                "stream": true,
+            }),
+        );
+
+        let content = std::fs::read_to_string(temp.path()).unwrap();
+        assert!(
+            !content.contains("super secret prompt text"),
+            "got: {content}"
+        );
+        assert!(content.contains("\"message_count\":1"), "got: {content}");
+        assert!(
+            content.contains("\"tool_names\":[\"read_file\"]"),
+            "got: {content}"
+        );
+    }
+
+    #[test]
+    fn test_emit_sse_parse_error_redacts_event_data() {
+        let env_lock = crate::test_support::ENV_LOCK.blocking_lock();
+        let _guard = crate::test_support::EnvRestore::capture(&env_lock, API_LOG_PATH_ENV);
+        let temp = tempfile::NamedTempFile::new().unwrap();
+        crate::test_support::test_set_var(
+            &env_lock,
+            API_LOG_PATH_ENV,
+            temp.path().to_string_lossy().to_string(),
+        );
+        let parse_error = serde_json::from_str::<Value>("{").unwrap_err();
+
+        emit_sse_parse_error(
+            Some("content_block_delta"),
+            "{\"tool_calls\":[{\"function\":{\"arguments\":\"super secret arguments\"}}]",
+            &parse_error,
+        );
+
+        let content = std::fs::read_to_string(temp.path()).unwrap();
+        assert!(
+            !content.contains("super secret arguments"),
+            "got: {content}"
+        );
+        assert!(
+            content.contains("\"contains_tool_calls\":true"),
+            "got: {content}"
         );
     }
 }

--- a/src/batch_mode.rs
+++ b/src/batch_mode.rs
@@ -23,7 +23,9 @@ use crate::turn_evidence::{
     note_changed_files_from_tool_call,
 };
 use crate::usage::TurnTokens;
+use opentelemetry::KeyValue;
 use std::path::PathBuf;
+use tracing::Instrument;
 
 // ── Output format ─────────────────────────────────────────────────────────────
 
@@ -533,92 +535,120 @@ pub async fn run_batch(task: String, opts: BatchRunOpts, config: &Config) -> Res
         .as_ref()
         .map(|state| state.id.clone())
         .unwrap_or_else(uuid_task_id);
-    let (sandbox, sandbox_warning) = resolve_configured_sandbox(&config.sandbox)?;
-    let (instructions_text, instructions_path) = resolve_batch_project_instructions(config);
-    let (client, notes_warning) = build_api_client_with_notes(config)?;
-    let mcp_registry = McpRegistry::connect_all_blocking(&config.mcp_servers)?;
-    crate::state::warm_codebase_index_with_config(&config.working_dir, &config.search);
-    let client = client
-        .with_project_instructions(instructions_text)
-        .with_extra_tool_definitions(
-            mcp_registry
-                .as_ref()
-                .map(|registry| registry.tool_definitions())
-                .unwrap_or_default(),
-        );
-    if let Some(warning) = notes_warning {
-        eprintln!("{warning}");
-    }
-    if let Some(warning) = sandbox_warning {
-        eprintln!("{warning}");
-    }
-    let operator = ToolOperator::new(config.working_dir.clone());
-    let conversation = ConversationManager::new_with_hooks(client, operator, config.hooks.clone())
-        .with_search_config(config.search.clone())
-        .with_sandbox(sandbox)
-        .with_mcp_registry(mcp_registry)
-        .with_compaction_config(config.compaction.clone());
-
-    let (update_tx, mut update_rx) = mpsc::unbounded_channel::<UiUpdate>();
-    let mut ctx = RuntimeContext::new(conversation, update_tx, CancellationToken::new());
-    let mut mode = BatchMode::new(
-        task_id.clone(),
-        opts,
-        config.notes_path.clone(),
-        instructions_path,
+    let batch_span = tracing::info_span!(
+        "batch_run",
+        task_id = %task_id,
+        trace_id = tracing::field::Empty,
+        otel_span_id = tracing::field::Empty,
+        max_turns = opts.max_turns.unwrap_or_default(),
+        output_format = ?opts.format,
+    );
+    crate::observability::attach_standard_baggage(
+        &batch_span,
+        "cli",
+        "batch",
+        None,
+        Some(&task_id),
+    );
+    crate::observability::set_span_attributes(
+        &batch_span,
+        [
+            KeyValue::new("task.id", task_id.clone()),
+            KeyValue::new("vex.batch.output_format", format!("{:?}", opts.format)),
+        ],
     );
 
-    // Submit the initial task.
-    mode.on_user_input(task, &mut ctx);
+    async move {
+        let (sandbox, sandbox_warning) = resolve_configured_sandbox(&config.sandbox)?;
+        let (instructions_text, instructions_path) = resolve_batch_project_instructions(config);
+        let (client, notes_warning) = build_api_client_with_notes(config)?;
+        let mcp_registry = McpRegistry::connect_all_blocking(&config.mcp_servers)?;
+        crate::state::warm_codebase_index_with_config(&config.working_dir, &config.search);
+        let client = client
+            .with_project_instructions(instructions_text)
+            .with_extra_tool_definitions(
+                mcp_registry
+                    .as_ref()
+                    .map(|registry| registry.tool_definitions())
+                    .unwrap_or_default(),
+            );
+        if let Some(warning) = notes_warning {
+            eprintln!("{warning}");
+        }
+        if let Some(warning) = sandbox_warning {
+            eprintln!("{warning}");
+        }
+        let operator = ToolOperator::new(config.working_dir.clone());
+        let conversation =
+            ConversationManager::new_with_hooks(client, operator, config.hooks.clone())
+                .with_search_config(config.search.clone())
+                .with_sandbox(sandbox)
+                .with_mcp_registry(mcp_registry)
+                .with_compaction_config(config.compaction.clone());
 
-    if mode.is_done() {
+        let (update_tx, mut update_rx) = mpsc::unbounded_channel::<UiUpdate>();
+        let mut ctx = RuntimeContext::new(conversation, update_tx, CancellationToken::new());
+        let mut mode = BatchMode::new(
+            task_id.clone(),
+            opts,
+            config.notes_path.clone(),
+            instructions_path,
+        );
+
+        // Submit the initial task.
+        mode.on_user_input(task, &mut ctx);
+
+        if mode.is_done() {
+            ctx.shutdown_resources().await;
+            return Ok(BatchResult {
+                status: mode.status,
+                output_lines: mode.output_lines,
+                turn_count: mode.current_turn,
+                task_id,
+            });
+        }
+
+        // Progress spinner for headless/batch runs.
+        let spinner = if console::Term::stderr().is_term() {
+            let pb = indicatif::ProgressBar::new_spinner();
+            pb.set_style(
+                indicatif::ProgressStyle::default_spinner()
+                    .template("{spinner:.magenta} {msg}")
+                    .expect("valid template"),
+            );
+            pb.set_message("working…");
+            pb.enable_steady_tick(std::time::Duration::from_millis(100));
+            Some(pb)
+        } else {
+            None
+        };
+
+        // Drain updates until the mode reports done.
+        while let Some(update) = update_rx.recv().await {
+            mode.on_model_update(update, &mut ctx);
+            if let Some(ref pb) = spinner {
+                pb.set_message(format!("turn {} · working…", mode.current_turn));
+            }
+            if mode.is_done() {
+                break;
+            }
+        }
+
+        if let Some(pb) = spinner {
+            pb.finish_and_clear();
+        }
+
         ctx.shutdown_resources().await;
-        return Ok(BatchResult {
+
+        Ok(BatchResult {
             status: mode.status,
             output_lines: mode.output_lines,
             turn_count: mode.current_turn,
             task_id,
-        });
+        })
     }
-
-    // Progress spinner for headless/batch runs.
-    let spinner = if console::Term::stderr().is_term() {
-        let pb = indicatif::ProgressBar::new_spinner();
-        pb.set_style(
-            indicatif::ProgressStyle::default_spinner()
-                .template("{spinner:.magenta} {msg}")
-                .expect("valid template"),
-        );
-        pb.set_message("working…");
-        pb.enable_steady_tick(std::time::Duration::from_millis(100));
-        Some(pb)
-    } else {
-        None
-    };
-
-    // Drain updates until the mode reports done.
-    while let Some(update) = update_rx.recv().await {
-        mode.on_model_update(update, &mut ctx);
-        if let Some(ref pb) = spinner {
-            pb.set_message(format!("turn {} · working…", mode.current_turn));
-        }
-        if mode.is_done() {
-            break;
-        }
-    }
-
-    if let Some(pb) = spinner {
-        pb.finish_and_clear();
-    }
-
-    ctx.shutdown_resources().await;
-
-    Ok(BatchResult {
-        status: mode.status,
-        output_lines: mode.output_lines,
-        turn_count: mode.current_turn,
-        task_id,
-    })
+    .instrument(batch_span)
+    .await
 }
 
 // ── Test helpers ───────────────────────────────────────────────────────────────

--- a/src/bin/vex.rs
+++ b/src/bin/vex.rs
@@ -6,6 +6,7 @@ use std::io::{IsTerminal, Read};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use tabled::{Table, Tabled};
+use tracing::Instrument;
 use vexcoder::app::{
     run_tui_session, task_graph_rollup_path, todos_rollup_path, write_projection_rollup,
 };
@@ -178,10 +179,29 @@ async fn run_print(
     config: Config,
     resume_state: Option<TaskState>,
 ) -> Result<ExitCode> {
-    let full_prompt = match read_stdin_if_piped() {
+    let stdin_content = read_stdin_if_piped();
+    let stdin_attached = stdin_content.is_some();
+    let full_prompt = match stdin_content {
         Some(stdin_content) => format!("{stdin_content}\n{prompt}"),
         None => prompt,
     };
+    let request_id = vexcoder::observability::new_request_id();
+    let print_span = tracing::info_span!(
+        "cli_print_request",
+        request_id = %request_id,
+        trace_id = tracing::field::Empty,
+        otel_span_id = tracing::field::Empty,
+        prompt_chars = full_prompt.chars().count(),
+        stdin_attached,
+        output_format = "text",
+    );
+    vexcoder::observability::attach_standard_baggage(
+        &print_span,
+        "cli",
+        "print",
+        Some(&request_id),
+        resume_state.as_ref().map(|state| state.id.as_str()),
+    );
 
     let opts = BatchRunOpts {
         max_turns: Some(1),
@@ -190,7 +210,9 @@ async fn run_print(
         resume_state,
     };
 
-    let result = run_batch(full_prompt, opts, &config).await?;
+    let result = run_batch(full_prompt, opts, &config)
+        .instrument(print_span)
+        .await?;
     print!("{}", result.output_lines.join("\n"));
 
     Ok(exit_code_for_status(result.status))
@@ -366,26 +388,13 @@ async fn main() -> Result<ExitCode> {
     let (_, eyre_hook) = color_eyre::config::HookBuilder::default().into_hooks();
     let _ = eyre_hook.install();
 
-    let _log_guard = if std::env::var_os("RUST_LOG").is_some() {
-        let file_appender = tracing_appender::rolling::daily(
-            dirs::state_dir()
-                .or_else(dirs::data_local_dir)
-                .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
-                .join("vex")
-                .join("logs"),
-            "vex.log",
-        );
-        let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
-        tracing_subscriber::fmt()
-            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-            .with_writer(non_blocking)
-            .init();
-        Some(guard)
-    } else {
-        None
-    };
-
     let cli = Cli::parse();
+    let _telemetry_guard = vexcoder::observability::init_cli_observability(
+        vexcoder::observability::CliTelemetryOptions {
+            display_internal_telemetry: cli.display_internal_telemetry,
+            telemetry_json: cli.telemetry_json,
+        },
+    )?;
     let chat_compat = cli.chat_compat;
     let tool_policy = if cli.plan {
         ToolPolicy::Plan

--- a/src/bin/vex/cli.rs
+++ b/src/bin/vex/cli.rs
@@ -24,6 +24,14 @@ pub(super) struct Cli {
     #[arg(short = 'p', long = "print")]
     pub(super) print_prompt: Option<String>,
 
+    /// Emit internal transport and normalization telemetry to stderr.
+    #[arg(long = "display-internal-telemetry")]
+    pub(super) display_internal_telemetry: bool,
+
+    /// Format internal telemetry as newline-delimited JSON.
+    #[arg(long = "telemetry-json")]
+    pub(super) telemetry_json: bool,
+
     /// Use the chat/completions API format instead of the default messages/v1 format.
     /// Required when connecting to endpoints that use the chat/completions schema
     /// instead of the messages/v1 schema.

--- a/src/bin/vex/tests.rs
+++ b/src/bin/vex/tests.rs
@@ -128,6 +128,20 @@ fn test_migrate_config_cli_parses_output_flag() {
 }
 
 #[test]
+fn test_cli_parses_internal_telemetry_flags() {
+    let cli = Cli::parse_from([
+        "vex",
+        "--display-internal-telemetry",
+        "--telemetry-json",
+        "-p",
+        "Reply with exactly ok.",
+    ]);
+    assert!(cli.display_internal_telemetry);
+    assert!(cli.telemetry_json);
+    assert_eq!(cli.print_prompt.as_deref(), Some("Reply with exactly ok."));
+}
+
+#[test]
 fn test_emit_migrate_config_output_writes_requested_file() {
     let temp = tempfile::tempdir().unwrap();
     let output_path = temp.path().join("migrate.toml");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod init;
 pub(crate) mod local_api;
 pub mod mcp;
 pub mod net;
+pub mod observability;
 pub mod pr_summary;
 pub mod privacy;
 pub mod prompts;

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -1,8 +1,11 @@
 use anyhow::{Context as AnyhowContext, Result};
 use opentelemetry::baggage::BaggageExt;
+use opentelemetry::propagation::Injector;
 use opentelemetry::trace::TraceContextExt;
+use opentelemetry::trace::TracerProvider as _;
 use opentelemetry::{Context, KeyValue, global, propagation::TextMapCompositePropagator};
 use opentelemetry_sdk::propagation::{BaggagePropagator, TraceContextPropagator};
+use opentelemetry_sdk::trace::SdkTracerProvider;
 use std::fs::OpenOptions;
 use std::path::PathBuf;
 use tracing::Span;
@@ -38,6 +41,7 @@ pub struct CliTelemetryOptions {
 
 pub struct TelemetryGuards {
     _writer_guard: WorkerGuard,
+    tracer_provider: SdkTracerProvider,
 }
 
 pub fn new_request_id() -> String {
@@ -54,7 +58,9 @@ pub fn init_cli_observability(options: CliTelemetryOptions) -> Result<Option<Tel
     let env_filter = resolve_env_filter(options)?;
     let telemetry_format = resolve_telemetry_format(options)?;
     let (writer, writer_guard) = build_telemetry_writer(options.display_internal_telemetry)?;
-    let tracer = global::tracer("vexcoder.internal");
+    let tracer_provider = SdkTracerProvider::builder().build();
+    global::set_tracer_provider(tracer_provider.clone());
+    let tracer = tracer_provider.tracer("vexcoder.internal");
     let otel_layer = tracing_opentelemetry::layer()
         .with_context_activation(true)
         .with_tracer(tracer);
@@ -96,7 +102,14 @@ pub fn init_cli_observability(options: CliTelemetryOptions) -> Result<Option<Tel
 
     Ok(Some(TelemetryGuards {
         _writer_guard: writer_guard,
+        tracer_provider,
     }))
+}
+
+impl Drop for TelemetryGuards {
+    fn drop(&mut self) {
+        let _ = self.tracer_provider.shutdown();
+    }
 }
 
 pub fn attach_standard_baggage(
@@ -145,6 +158,17 @@ pub fn record_trace_context_fields(span: &Span) {
         "otel_span_id",
         tracing::field::display(span_context.span_id()),
     );
+}
+
+pub fn inject_span_context_headers(span: &Span, headers: &mut reqwest::header::HeaderMap) {
+    let context = span.context();
+    inject_context_headers(&context, headers);
+}
+
+fn inject_context_headers(context: &Context, headers: &mut reqwest::header::HeaderMap) {
+    global::get_text_map_propagator(|propagator| {
+        propagator.inject_context(context, &mut HeaderInjector { headers });
+    });
 }
 
 pub fn telemetry_environment_label() -> String {
@@ -250,9 +274,29 @@ fn telemetry_tenant_id() -> Option<String> {
         .filter(|value| !value.is_empty())
 }
 
+struct HeaderInjector<'a> {
+    headers: &'a mut reqwest::header::HeaderMap,
+}
+
+impl Injector for HeaderInjector<'_> {
+    fn set(&mut self, key: &str, value: String) {
+        let Ok(name) = reqwest::header::HeaderName::from_bytes(key.as_bytes()) else {
+            return;
+        };
+        if self.headers.contains_key(&name) {
+            return;
+        }
+        let Ok(value) = reqwest::header::HeaderValue::from_str(&value) else {
+            return;
+        };
+        self.headers.insert(name, value);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use opentelemetry::trace::{SpanContext, SpanId, TraceFlags, TraceId, TraceState};
 
     #[test]
     fn test_default_telemetry_log_path_uses_log_filename() {
@@ -268,6 +312,40 @@ mod tests {
         assert_eq!(
             resolve_telemetry_format(CliTelemetryOptions::default()).unwrap(),
             TelemetryFormat::Json
+        );
+    }
+
+    #[test]
+    fn test_inject_context_headers_preserves_existing_headers() {
+        install_w3c_propagation();
+
+        let parent = Context::new()
+            .with_remote_span_context(SpanContext::new(
+                TraceId::from_hex("0123456789abcdef0123456789abcdef").unwrap(),
+                SpanId::from_hex("0123456789abcdef").unwrap(),
+                TraceFlags::SAMPLED,
+                true,
+                TraceState::default(),
+            ))
+            .with_baggage(vec![KeyValue::new("request.id", "req-123".to_string())]);
+
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            reqwest::header::HeaderName::from_static("traceparent"),
+            reqwest::header::HeaderValue::from_static("existing-traceparent"),
+        );
+
+        inject_context_headers(&parent, &mut headers);
+
+        assert_eq!(
+            headers
+                .get("traceparent")
+                .and_then(|value| value.to_str().ok()),
+            Some("existing-traceparent")
+        );
+        assert_eq!(
+            headers.get("baggage").and_then(|value| value.to_str().ok()),
+            Some("request.id=req-123")
         );
     }
 }

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -1,0 +1,273 @@
+use anyhow::{Context as AnyhowContext, Result};
+use opentelemetry::baggage::BaggageExt;
+use opentelemetry::trace::TraceContextExt;
+use opentelemetry::{Context, KeyValue, global, propagation::TextMapCompositePropagator};
+use opentelemetry_sdk::propagation::{BaggagePropagator, TraceContextPropagator};
+use std::fs::OpenOptions;
+use std::path::PathBuf;
+use tracing::Span;
+use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+pub const REQUEST_ID_HEADER: &str = "x-request-id";
+pub const DISPLAY_INTERNAL_TELEMETRY_FLAG: &str = "--display-internal-telemetry";
+pub const TELEMETRY_FORMAT_ENV: &str = "VEX_TELEMETRY_FORMAT";
+pub const TELEMETRY_PATH_ENV: &str = "VEX_INTERNAL_TELEMETRY_PATH";
+pub const TELEMETRY_ENVIRONMENT_ENV: &str = "VEX_TELEMETRY_ENVIRONMENT";
+pub const TELEMETRY_TENANT_ENV: &str = "VEX_TELEMETRY_TENANT_ID";
+
+const DEFAULT_TELEMETRY_FILTER: &str =
+    "vex=debug,vexcoder=debug,tower_http=info,axum_tracing_opentelemetry=info";
+const DEFAULT_TELEMETRY_FILENAME: &str = "internal-telemetry.log";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TelemetryFormat {
+    Text,
+    Json,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CliTelemetryOptions {
+    pub display_internal_telemetry: bool,
+    pub telemetry_json: bool,
+}
+
+pub struct TelemetryGuards {
+    _writer_guard: WorkerGuard,
+}
+
+pub fn new_request_id() -> String {
+    uuid::Uuid::new_v4().as_hyphenated().to_string()
+}
+
+pub fn init_cli_observability(options: CliTelemetryOptions) -> Result<Option<TelemetryGuards>> {
+    if !telemetry_requested(options) {
+        return Ok(None);
+    }
+
+    install_w3c_propagation();
+
+    let env_filter = resolve_env_filter(options)?;
+    let telemetry_format = resolve_telemetry_format(options)?;
+    let (writer, writer_guard) = build_telemetry_writer(options.display_internal_telemetry)?;
+    let tracer = global::tracer("vexcoder.internal");
+    let otel_layer = tracing_opentelemetry::layer()
+        .with_context_activation(true)
+        .with_tracer(tracer);
+    let registry = tracing_subscriber::registry()
+        .with(env_filter)
+        .with(otel_layer);
+
+    match telemetry_format {
+        TelemetryFormat::Text => registry
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_writer(writer)
+                    .with_target(true)
+                    .with_thread_ids(true)
+                    .with_thread_names(true)
+                    .with_span_events(FmtSpan::CLOSE),
+            )
+            .try_init()
+            .map_err(|error| {
+                anyhow::anyhow!("failed to initialize text telemetry subscriber: {error}")
+            })?,
+        TelemetryFormat::Json => registry
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_writer(writer)
+                    .with_target(true)
+                    .with_thread_ids(true)
+                    .with_thread_names(true)
+                    .with_span_events(FmtSpan::CLOSE)
+                    .json()
+                    .with_current_span(true)
+                    .with_span_list(true),
+            )
+            .try_init()
+            .map_err(|error| {
+                anyhow::anyhow!("failed to initialize JSON telemetry subscriber: {error}")
+            })?,
+    }
+
+    Ok(Some(TelemetryGuards {
+        _writer_guard: writer_guard,
+    }))
+}
+
+pub fn attach_standard_baggage(
+    span: &Span,
+    surface: &str,
+    workflow: &str,
+    request_id: Option<&str>,
+    task_id: Option<&str>,
+) {
+    let mut baggage = vec![
+        KeyValue::new("vex.surface", surface.to_string()),
+        KeyValue::new("vex.workflow", workflow.to_string()),
+        KeyValue::new("deployment.environment.name", telemetry_environment_label()),
+    ];
+
+    if let Some(request_id) = request_id {
+        baggage.push(KeyValue::new("request.id", request_id.to_string()));
+    }
+    if let Some(task_id) = task_id {
+        baggage.push(KeyValue::new("task.id", task_id.to_string()));
+    }
+    if let Some(tenant_id) = telemetry_tenant_id() {
+        baggage.push(KeyValue::new("tenant.id", tenant_id));
+    }
+
+    let parent_context = Context::current().with_baggage(baggage);
+    let _ = span.set_parent(parent_context);
+    record_trace_context_fields(span);
+}
+
+pub fn set_span_attributes(span: &Span, attributes: impl IntoIterator<Item = KeyValue>) {
+    for attribute in attributes {
+        span.set_attribute(attribute.key, attribute.value);
+    }
+    record_trace_context_fields(span);
+}
+
+pub fn record_trace_context_fields(span: &Span) {
+    let span_context = span.context().span().span_context().clone();
+    if !span_context.is_valid() {
+        return;
+    }
+
+    span.record("trace_id", tracing::field::display(span_context.trace_id()));
+    span.record(
+        "otel_span_id",
+        tracing::field::display(span_context.span_id()),
+    );
+}
+
+pub fn telemetry_environment_label() -> String {
+    std::env::var(TELEMETRY_ENVIRONMENT_ENV)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "local".to_string())
+}
+
+fn telemetry_requested(options: CliTelemetryOptions) -> bool {
+    options.display_internal_telemetry
+        || std::env::var_os("RUST_LOG").is_some()
+        || std::env::var_os(TELEMETRY_PATH_ENV).is_some()
+        || std::env::var_os(TELEMETRY_FORMAT_ENV).is_some()
+}
+
+fn install_w3c_propagation() {
+    global::set_text_map_propagator(TextMapCompositePropagator::new(vec![
+        Box::new(TraceContextPropagator::new()),
+        Box::new(BaggagePropagator::new()),
+    ]));
+}
+
+fn resolve_env_filter(options: CliTelemetryOptions) -> Result<EnvFilter> {
+    if std::env::var_os("RUST_LOG").is_some() {
+        return EnvFilter::try_from_default_env()
+            .map_err(|error| anyhow::anyhow!("invalid RUST_LOG filter: {error}"));
+    }
+
+    let fallback = if options.display_internal_telemetry {
+        DEFAULT_TELEMETRY_FILTER
+    } else {
+        "info"
+    };
+    EnvFilter::try_new(fallback)
+        .map_err(|error| anyhow::anyhow!("invalid fallback telemetry filter '{fallback}': {error}"))
+}
+
+fn resolve_telemetry_format(options: CliTelemetryOptions) -> Result<TelemetryFormat> {
+    if options.telemetry_json {
+        return Ok(TelemetryFormat::Json);
+    }
+
+    match std::env::var(TELEMETRY_FORMAT_ENV) {
+        Ok(value) => match value.trim().to_ascii_lowercase().as_str() {
+            "json" | "ndjson" | "jsonl" => Ok(TelemetryFormat::Json),
+            "text" | "pretty" => Ok(TelemetryFormat::Text),
+            other => Err(anyhow::anyhow!(
+                "invalid {} value '{}': expected text or json",
+                TELEMETRY_FORMAT_ENV,
+                other
+            )),
+        },
+        Err(_) => Ok(TelemetryFormat::Text),
+    }
+}
+
+fn build_telemetry_writer(display_internal_telemetry: bool) -> Result<(NonBlocking, WorkerGuard)> {
+    if display_internal_telemetry {
+        return Ok(tracing_appender::non_blocking(std::io::stderr()));
+    }
+
+    let path = telemetry_log_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "failed to create telemetry log directory '{}'",
+                parent.display()
+            )
+        })?;
+    }
+    let file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .with_context(|| format!("failed to open telemetry log file '{}'", path.display()))?;
+    Ok(tracing_appender::non_blocking(file))
+}
+
+fn telemetry_log_path() -> PathBuf {
+    std::env::var(TELEMETRY_PATH_ENV)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(default_telemetry_log_path)
+}
+
+fn default_telemetry_log_path() -> PathBuf {
+    dirs::state_dir()
+        .or_else(dirs::data_local_dir)
+        .unwrap_or_else(std::env::temp_dir)
+        .join("vex")
+        .join("logs")
+        .join(DEFAULT_TELEMETRY_FILENAME)
+}
+
+fn telemetry_tenant_id() -> Option<String> {
+    std::env::var(TELEMETRY_TENANT_ENV)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_telemetry_log_path_uses_log_filename() {
+        assert!(default_telemetry_log_path().ends_with(DEFAULT_TELEMETRY_FILENAME));
+    }
+
+    #[test]
+    fn test_resolve_telemetry_format_accepts_json_aliases() {
+        let env_lock = crate::test_support::ENV_LOCK.blocking_lock();
+        let _guard = crate::test_support::EnvRestore::capture(&env_lock, TELEMETRY_FORMAT_ENV);
+
+        crate::test_support::test_set_var(&env_lock, TELEMETRY_FORMAT_ENV, "jsonl");
+        assert_eq!(
+            resolve_telemetry_format(CliTelemetryOptions::default()).unwrap(),
+            TelemetryFormat::Json
+        );
+    }
+}

--- a/src/runtime/json_handoff/protocol_ingress.rs
+++ b/src/runtime/json_handoff/protocol_ingress.rs
@@ -9,6 +9,8 @@ use crate::api::stream::provider::{ProviderDelta, ProviderStreamEvent};
 use crate::state::{StreamBlock, ToolStatus};
 use crate::types::{ApiUsage, StreamChunkMetadata};
 use crate::usage::TurnTokens;
+use opentelemetry::KeyValue;
+use opentelemetry_semantic_conventions::attribute as semconv;
 use serde::Deserialize;
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -136,6 +138,35 @@ enum ProviderBlockDelta {
     ToolArguments(String),
 }
 
+fn provider_block_kind(block: &ProviderContentBlock) -> &'static str {
+    match block {
+        ProviderContentBlock::Text { .. } => "text",
+        ProviderContentBlock::ToolUse { .. } => "tool_use",
+        ProviderContentBlock::ToolResult => "tool_result",
+        ProviderContentBlock::Thinking { .. } => "thinking",
+        ProviderContentBlock::ThinkingData { .. } => "thinking_data",
+        ProviderContentBlock::ServerToolUse { .. } => "server_tool_use",
+        ProviderContentBlock::WebSearchToolResult => "web_search_tool_result",
+    }
+}
+
+fn provider_delta_kind(delta: &ProviderBlockDelta) -> &'static str {
+    match delta {
+        ProviderBlockDelta::Text(_) => "text",
+        ProviderBlockDelta::ToolArguments(_) => "tool_arguments",
+    }
+}
+
+fn annotate_current_tool_span(tool_name: &str, tool_call_id: &str) {
+    crate::observability::set_span_attributes(
+        &tracing::Span::current(),
+        [
+            KeyValue::new(semconv::GEN_AI_TOOL_NAME, tool_name.to_string()),
+            KeyValue::new(semconv::GEN_AI_TOOL_CALL_ID, tool_call_id.to_string()),
+        ],
+    );
+}
+
 impl RuntimeEnvelopeNormalizer {
     pub(crate) fn finish_protocol_ingress_turn(&mut self) -> Vec<RuntimeEnvelope> {
         if !self.protocol_ingress.turn_started {
@@ -152,6 +183,21 @@ impl RuntimeEnvelopeNormalizer {
 
         let usage =
             token_usage_from_turn_tokens(std::mem::take(&mut self.protocol_ingress.turn_tokens));
+        if let Some(usage) = &usage {
+            crate::observability::set_span_attributes(
+                &tracing::Span::current(),
+                [
+                    KeyValue::new(
+                        semconv::GEN_AI_USAGE_INPUT_TOKENS,
+                        i64::try_from(usage.input).unwrap_or(i64::MAX),
+                    ),
+                    KeyValue::new(
+                        semconv::GEN_AI_USAGE_OUTPUT_TOKENS,
+                        i64::try_from(usage.output).unwrap_or(i64::MAX),
+                    ),
+                ],
+            );
+        }
         envelopes.extend(self.normalize_ui_update(
             &super::UiUpdate::TurnComplete,
             Some(TurnEndContext {
@@ -223,6 +269,10 @@ impl RuntimeEnvelopeNormalizer {
     ) -> Vec<RuntimeEnvelope> {
         match payload {
             ChatCompatPayload::Done => {
+                tracing::trace!(
+                    target: "vex::protocol",
+                    "chat-compatible stream terminated with [DONE]"
+                );
                 let envelopes = self.close_chat_compat_tool_blocks();
                 self.protocol_ingress.chat_compat_message_started = false;
                 self.protocol_ingress.chat_compat_stream_terminated = true;
@@ -251,6 +301,7 @@ impl RuntimeEnvelopeNormalizer {
             return Vec::new();
         }
 
+        tracing::trace!(target: "vex::protocol", "protocol ingress turn started");
         let envelope = self.start_turn(1, None);
         self.protocol_ingress.turn_started = true;
         vec![envelope]
@@ -261,6 +312,17 @@ impl RuntimeEnvelopeNormalizer {
         index: usize,
         content_block: ProviderContentBlock,
     ) -> Vec<RuntimeEnvelope> {
+        if let ProviderContentBlock::ToolUse { id, name, .. }
+        | ProviderContentBlock::ServerToolUse { id, name, .. } = &content_block
+        {
+            annotate_current_tool_span(name, id);
+        }
+        tracing::trace!(
+            target: "vex::protocol",
+            index,
+            block_kind = provider_block_kind(&content_block),
+            "opening provider stream block"
+        );
         let Some((block, initial_delta)) = provider_stream_block(&content_block) else {
             return Vec::new();
         };
@@ -300,9 +362,17 @@ impl RuntimeEnvelopeNormalizer {
             ));
         }
 
+        let delta_kind = provider_delta_kind(&block_delta);
         let delta = match block_delta {
             ProviderBlockDelta::Text(delta) | ProviderBlockDelta::ToolArguments(delta) => delta,
         };
+        tracing::trace!(
+            target: "vex::protocol",
+            index,
+            delta_kind,
+            delta_bytes = delta.len(),
+            "applying provider stream delta"
+        );
         envelopes.extend(
             self.normalize_ui_update(&super::UiUpdate::StreamBlockDelta { index, delta }, None),
         );
@@ -314,6 +384,11 @@ impl RuntimeEnvelopeNormalizer {
             return Vec::new();
         }
 
+        tracing::trace!(
+            target: "vex::protocol",
+            index,
+            "closing provider stream block"
+        );
         self.normalize_ui_update(&super::UiUpdate::StreamBlockComplete { index }, None)
     }
 
@@ -401,6 +476,15 @@ impl RuntimeEnvelopeNormalizer {
                 envelopes.extend(self.emit_provider_metadata(metadata));
             }
 
+            if let Some(finish_reason) = finish_reason.as_deref() {
+                crate::observability::set_span_attributes(
+                    &tracing::Span::current(),
+                    [KeyValue::new(
+                        semconv::GEN_AI_RESPONSE_FINISH_REASONS,
+                        finish_reason.to_string(),
+                    )],
+                );
+            }
             if finish_reason.is_some() {
                 envelopes.extend(self.close_chat_compat_tool_blocks());
             }
@@ -425,6 +509,11 @@ impl RuntimeEnvelopeNormalizer {
             return Vec::new();
         }
 
+        tracing::trace!(
+            target: "vex::protocol",
+            role = role.as_deref().unwrap_or("unknown"),
+            "observed chat-compatible message start"
+        );
         self.protocol_ingress.chat_compat_message_started = true;
         // Only a fresh `role` announcement resets the termination gate raised
         // by the previous `[DONE]`. Bare id/model echoes that arrive after
@@ -445,6 +534,11 @@ impl RuntimeEnvelopeNormalizer {
         tool_call: ChatCompatToolCallDelta,
     ) -> Vec<RuntimeEnvelope> {
         if self.protocol_ingress.chat_compat_stream_terminated {
+            tracing::trace!(
+                target: "vex::protocol",
+                choice_index = choice_index.unwrap_or_default(),
+                "ignoring late chat-compatible tool delta after stream termination"
+            );
             // Once `[DONE]` has been observed the stream is finalised; late
             // tool-call frames must not instantiate fresh lifecycle state via
             // `entry(..).or_default()`. A new message start is required before
@@ -537,9 +631,20 @@ impl RuntimeEnvelopeNormalizer {
 
         let mut envelopes = Vec::new();
         if let Some(content_block) = start_block {
+            tracing::trace!(
+                target: "vex::protocol",
+                block_index,
+                "opening chat-compatible tool block"
+            );
             envelopes.extend(self.open_provider_stream_block(block_index, content_block));
         }
         if let Some(partial_json) = partial_json {
+            tracing::trace!(
+                target: "vex::protocol",
+                block_index,
+                partial_bytes = partial_json.len(),
+                "applying chat-compatible tool arguments delta"
+            );
             envelopes.extend(self.apply_provider_stream_delta(
                 block_index,
                 ProviderBlockDelta::ToolArguments(partial_json),
@@ -573,6 +678,11 @@ impl RuntimeEnvelopeNormalizer {
 
         let mut envelopes = Vec::new();
         for index in to_close {
+            tracing::trace!(
+                target: "vex::protocol",
+                index,
+                "closing chat-compatible tool block"
+            );
             envelopes.extend(self.close_provider_stream_block(index));
         }
         envelopes

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -11,12 +11,14 @@ use hyper_util::server::conn::auto::Builder as HyperConnectionBuilder;
 use hyper_util::service::TowerToHyperService;
 use opentelemetry::KeyValue;
 use opentelemetry_semantic_conventions::attribute as semconv;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio_rustls::TlsAcceptor;
 use tokio_util::sync::CancellationToken;
 use tower_governor::governor::GovernorConfigBuilder;
-use tower_governor::key_extractor::GlobalKeyExtractor;
+use tower_governor::key_extractor::KeyExtractor;
 use tower_governor::{GovernorError, GovernorLayer};
 use tower_http::request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer};
 use tower_http::sensitive_headers::SetSensitiveRequestHeadersLayer;
@@ -92,7 +94,7 @@ pub fn build_router_with_state(state: LocalApiState) -> Router {
 pub fn build_http_router(state: LocalApiState, auth: HttpSurfaceSettings) -> Router {
     let expected_header = Arc::<str>::from(format!("Bearer {}", auth.bearer_token));
     let hsts_enabled = auth.hsts_enabled;
-    let mut governor = GovernorConfigBuilder::default().key_extractor(GlobalKeyExtractor);
+    let mut governor = GovernorConfigBuilder::default().key_extractor(AuthorizedClientKeyExtractor);
     governor.per_second(LOCAL_API_RATE_LIMIT_PER_SECOND);
     governor.burst_size(LOCAL_API_RATE_LIMIT_BURST);
     let governor = governor
@@ -131,31 +133,21 @@ pub fn build_http_router(state: LocalApiState, auth: HttpSurfaceSettings) -> Rou
                 semconv::HTTP_REQUEST_METHOD,
                 request.method().as_str().to_string(),
             )];
-            if let Some(server_address) = request
-                .headers()
-                .get("host")
-                .and_then(|value| value.to_str().ok())
-            {
-                attributes.push(KeyValue::new(
-                    semconv::SERVER_ADDRESS,
-                    server_address.to_string(),
-                ));
+            if let Some((server_address, server_port)) = request_host_parts(request) {
+                attributes.push(KeyValue::new(semconv::SERVER_ADDRESS, server_address));
+                if let Some(server_port) = server_port {
+                    attributes.push(KeyValue::new(semconv::SERVER_PORT, i64::from(server_port)));
+                }
             }
             crate::observability::set_span_attributes(&span, attributes);
             span
         })
         .on_response(
             |response: &Response, latency: Duration, span: &tracing::Span| {
-                let request_id = response
-                    .headers()
-                    .get(REQUEST_ID_HEADER)
-                    .and_then(|value| value.to_str().ok())
-                    .unwrap_or("missing");
                 tracing::info!(
                     parent: span,
                     status = response.status().as_u16(),
                     latency_ms = latency.as_millis() as u64,
-                    request_id = %request_id,
                     "completed local API request"
                 );
             },
@@ -169,13 +161,13 @@ pub fn build_http_router(state: LocalApiState, auth: HttpSurfaceSettings) -> Rou
             );
         });
     build_router_with_state(state)
+        .layer(GovernorLayer::new(governor).error_handler(governor_error_response))
         .layer(middleware::from_fn(move |request, next| {
             let expected_header = Arc::clone(&expected_header);
             async move {
                 authorize_http_request(request, next, expected_header, hsts_enabled).await
             }
         }))
-        .layer(GovernorLayer::new(governor).error_handler(governor_error_response))
         .layer(trace_layer)
         .layer(SetSensitiveRequestHeadersLayer::new(std::iter::once(
             header::AUTHORIZATION,
@@ -184,6 +176,62 @@ pub fn build_http_router(state: LocalApiState, auth: HttpSurfaceSettings) -> Rou
         .layer(OtelInResponseLayer)
         .layer(PropagateRequestIdLayer::x_request_id())
         .layer(SetRequestIdLayer::x_request_id(MakeRequestUuid))
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct AuthorizedClientKeyExtractor;
+
+impl KeyExtractor for AuthorizedClientKeyExtractor {
+    type Key = String;
+
+    fn name(&self) -> &'static str {
+        "authorized client"
+    }
+
+    fn extract<T>(&self, req: &http::Request<T>) -> Result<Self::Key, GovernorError> {
+        if let Some(ip) = forwarded_client_ip(req.headers()) {
+            return Ok(format!("ip:{ip}"));
+        }
+
+        authorized_header_hash(req.headers())
+            .map(|hash| format!("auth:{hash:016x}"))
+            .ok_or(GovernorError::UnableToExtractKey)
+    }
+}
+
+fn forwarded_client_ip(headers: &http::HeaderMap) -> Option<std::net::IpAddr> {
+    headers
+        .get("x-forwarded-for")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| {
+            value
+                .split(',')
+                .find_map(|segment| segment.trim().parse::<std::net::IpAddr>().ok())
+        })
+        .or_else(|| {
+            headers
+                .get("x-real-ip")
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| value.parse::<std::net::IpAddr>().ok())
+        })
+}
+
+fn authorized_header_hash(headers: &http::HeaderMap) -> Option<u64> {
+    let authorization = headers
+        .get(header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())?;
+    let mut hasher = DefaultHasher::new();
+    authorization.hash(&mut hasher);
+    Some(hasher.finish())
+}
+
+fn request_host_parts<T>(request: &Request<T>) -> Option<(String, Option<u16>)> {
+    let authority = request
+        .headers()
+        .get("host")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<http::uri::Authority>().ok())?;
+    Some((authority.host().to_string(), authority.port_u16()))
 }
 
 fn governor_error_response(error: GovernorError) -> http::Response<Body> {

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -1,16 +1,25 @@
 use anyhow::{Context, Result};
 use axum::Router;
+use axum::body::Body;
 use axum::extract::DefaultBodyLimit;
 use axum::middleware::{self, Next};
-use axum::response::Response;
+use axum::response::{IntoResponse, Response};
 use axum::routing::{get, patch, post};
+use axum_tracing_opentelemetry::middleware::{OtelAxumLayer, OtelInResponseLayer};
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use hyper_util::server::conn::auto::Builder as HyperConnectionBuilder;
 use hyper_util::service::TowerToHyperService;
+use opentelemetry::KeyValue;
+use opentelemetry_semantic_conventions::attribute as semconv;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio_rustls::TlsAcceptor;
 use tokio_util::sync::CancellationToken;
+use tower_governor::governor::GovernorConfigBuilder;
+use tower_governor::key_extractor::GlobalKeyExtractor;
+use tower_governor::{GovernorError, GovernorLayer};
+use tower_http::request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer};
+use tower_http::sensitive_headers::SetSensitiveRequestHeadersLayer;
 use tower_http::trace::TraceLayer;
 
 use super::handlers::{
@@ -28,6 +37,10 @@ use crate::app::runtime_tokio::{net::TcpListener, select, spawn};
 use crate::config::Config;
 use crate::http_facade::{HeaderValue, Request, StatusCode, header};
 use crate::local_api::LocalApiState;
+use crate::observability::REQUEST_ID_HEADER;
+
+const LOCAL_API_RATE_LIMIT_PER_SECOND: u64 = 120;
+const LOCAL_API_RATE_LIMIT_BURST: u32 = 240;
 
 #[cfg(test)]
 pub fn build_router(config: Config) -> Router {
@@ -79,6 +92,82 @@ pub fn build_router_with_state(state: LocalApiState) -> Router {
 pub fn build_http_router(state: LocalApiState, auth: HttpSurfaceSettings) -> Router {
     let expected_header = Arc::<str>::from(format!("Bearer {}", auth.bearer_token));
     let hsts_enabled = auth.hsts_enabled;
+    let mut governor = GovernorConfigBuilder::default().key_extractor(GlobalKeyExtractor);
+    governor.per_second(LOCAL_API_RATE_LIMIT_PER_SECOND);
+    governor.burst_size(LOCAL_API_RATE_LIMIT_BURST);
+    let governor = governor
+        .use_headers()
+        .finish()
+        .expect("local API governor config must be valid");
+    let trace_layer = TraceLayer::new_for_http()
+        .make_span_with(|request: &Request<_>| {
+            let request_id = request
+                .headers()
+                .get(REQUEST_ID_HEADER)
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or("missing");
+            let traceparent = request
+                .headers()
+                .get("traceparent")
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or("missing");
+            let span = tracing::info_span!(
+                "local_api_http_request",
+                method = %request.method(),
+                path = %request.uri().path(),
+                request_id = %request_id,
+                traceparent = %traceparent,
+                trace_id = tracing::field::Empty,
+                otel_span_id = tracing::field::Empty,
+            );
+            crate::observability::attach_standard_baggage(
+                &span,
+                "local_api",
+                "http_request",
+                Some(request_id),
+                None,
+            );
+            let mut attributes = vec![KeyValue::new(
+                semconv::HTTP_REQUEST_METHOD,
+                request.method().as_str().to_string(),
+            )];
+            if let Some(server_address) = request
+                .headers()
+                .get("host")
+                .and_then(|value| value.to_str().ok())
+            {
+                attributes.push(KeyValue::new(
+                    semconv::SERVER_ADDRESS,
+                    server_address.to_string(),
+                ));
+            }
+            crate::observability::set_span_attributes(&span, attributes);
+            span
+        })
+        .on_response(
+            |response: &Response, latency: Duration, span: &tracing::Span| {
+                let request_id = response
+                    .headers()
+                    .get(REQUEST_ID_HEADER)
+                    .and_then(|value| value.to_str().ok())
+                    .unwrap_or("missing");
+                tracing::info!(
+                    parent: span,
+                    status = response.status().as_u16(),
+                    latency_ms = latency.as_millis() as u64,
+                    request_id = %request_id,
+                    "completed local API request"
+                );
+            },
+        )
+        .on_failure(|error, latency: Duration, span: &tracing::Span| {
+            tracing::warn!(
+                parent: span,
+                latency_ms = latency.as_millis() as u64,
+                failure = ?error,
+                "local API request failed"
+            );
+        });
     build_router_with_state(state)
         .layer(middleware::from_fn(move |request, next| {
             let expected_header = Arc::clone(&expected_header);
@@ -86,7 +175,58 @@ pub fn build_http_router(state: LocalApiState, auth: HttpSurfaceSettings) -> Rou
                 authorize_http_request(request, next, expected_header, hsts_enabled).await
             }
         }))
-        .layer(TraceLayer::new_for_http())
+        .layer(GovernorLayer::new(governor).error_handler(governor_error_response))
+        .layer(trace_layer)
+        .layer(SetSensitiveRequestHeadersLayer::new(std::iter::once(
+            header::AUTHORIZATION,
+        )))
+        .layer(OtelAxumLayer::default())
+        .layer(OtelInResponseLayer)
+        .layer(PropagateRequestIdLayer::x_request_id())
+        .layer(SetRequestIdLayer::x_request_id(MakeRequestUuid))
+}
+
+fn governor_error_response(error: GovernorError) -> http::Response<Body> {
+    let (status, reason, headers) = match error {
+        GovernorError::TooManyRequests { wait_time, headers } => {
+            tracing::warn!(
+                target: "vex::http",
+                wait_time_secs = wait_time,
+                "local API rate limit exceeded"
+            );
+            (StatusCode::TOO_MANY_REQUESTS, "rate_limited", headers)
+        }
+        GovernorError::UnableToExtractKey => {
+            tracing::error!(
+                target: "vex::http",
+                "local API rate limiter could not extract a key"
+            );
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "rate_limit_key_unavailable",
+                None,
+            )
+        }
+        GovernorError::Other { code, msg, headers } => {
+            tracing::warn!(
+                target: "vex::http",
+                status = code.as_u16(),
+                message = msg.as_deref().unwrap_or("unknown"),
+                "local API rate limiter returned a custom error"
+            );
+            (
+                StatusCode::from_u16(code.as_u16()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+                "rate_limit_error",
+                headers,
+            )
+        }
+    };
+
+    let mut response = ProblemDetailsResponse::from_reason(status, reason).into_response();
+    if let Some(headers) = headers {
+        response.headers_mut().extend(headers);
+    }
+    response
 }
 
 async fn authorize_http_request(
@@ -115,7 +255,6 @@ async fn authorize_http_request(
 }
 
 fn unauthorized_response() -> Response {
-    use axum::response::IntoResponse;
     ProblemDetailsResponse::from_reason(StatusCode::UNAUTHORIZED, "unauthorized").into_response()
 }
 
@@ -159,7 +298,11 @@ async fn serve_plain_listener(
                         _ = shutdown.cancelled() => {}
                         result = connection => {
                             if let Err(error) = result {
-                                eprintln!("[local api] connection error: {error}");
+                                tracing::warn!(
+                                    target: "vex::http",
+                                    error = %error,
+                                    "local API connection error"
+                                );
                             }
                         }
                     }
@@ -188,7 +331,11 @@ async fn serve_tls_listener(
                     let tls_stream = match acceptor.accept(stream).await {
                         Ok(stream) => stream,
                         Err(error) => {
-                            eprintln!("[local api] tls accept failed: {error}");
+                            tracing::warn!(
+                                target: "vex::http",
+                                error = %error,
+                                "local API TLS accept failed"
+                            );
                             return;
                         }
                     };
@@ -199,7 +346,11 @@ async fn serve_tls_listener(
                         _ = shutdown.cancelled() => {}
                         result = connection => {
                             if let Err(error) = result {
-                                eprintln!("[local api] tls connection error: {error}");
+                                tracing::warn!(
+                                    target: "vex::http",
+                                    error = %error,
+                                    "local API TLS connection error"
+                                );
                             }
                         }
                     }

--- a/src/server/tests/core.rs
+++ b/src/server/tests/core.rs
@@ -313,6 +313,10 @@ async fn test_http_router_requires_bearer_token() {
         unauthorized.headers().contains_key("x-request-id"),
         "unauthorized responses must carry x-request-id"
     );
+    assert!(
+        !unauthorized.headers().contains_key("x-ratelimit-limit"),
+        "unauthorized responses should bypass the authorized rate-limit bucket"
+    );
 
     let authorized = router
         .oneshot(

--- a/src/server/tests/core.rs
+++ b/src/server/tests/core.rs
@@ -309,6 +309,10 @@ async fn test_http_router_requires_bearer_token() {
         .await
         .unwrap();
     assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+    assert!(
+        unauthorized.headers().contains_key("x-request-id"),
+        "unauthorized responses must carry x-request-id"
+    );
 
     let authorized = router
         .oneshot(
@@ -321,6 +325,14 @@ async fn test_http_router_requires_bearer_token() {
         .await
         .unwrap();
     assert_eq!(authorized.status(), StatusCode::OK);
+    assert!(
+        authorized.headers().contains_key("x-request-id"),
+        "authorized responses must carry x-request-id"
+    );
+    assert!(
+        authorized.headers().contains_key("x-ratelimit-limit"),
+        "authorized responses must carry rate-limit headers"
+    );
 }
 
 #[tokio::test]

--- a/src/server/util.rs
+++ b/src/server/util.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result, anyhow, bail};
-use axum::Json;
 use axum::response::{IntoResponse, Response};
+use http_api_problem::HttpApiProblem;
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use std::io::BufReader;
@@ -191,12 +191,16 @@ impl ProblemDetailsResponse {
 
 impl IntoResponse for ProblemDetailsResponse {
     fn into_response(self) -> Response {
-        let mut response = (self.status, Json(self.details)).into_response();
-        response.headers_mut().insert(
-            crate::http_facade::header::CONTENT_TYPE,
-            crate::http_facade::HeaderValue::from_static("application/problem+json"),
-        );
-        response
+        let mut problem = HttpApiProblem::new(self.status)
+            .type_url(self.details.r#type)
+            .title(self.details.title);
+        if let Some(detail) = self.details.detail {
+            problem = problem.detail(detail);
+        }
+        if let Some(instance) = self.details.instance {
+            problem = problem.instance(instance);
+        }
+        problem.into_response()
     }
 }
 


### PR DESCRIPTION
## Summary

- install a shared observability bootstrap with a real local tracer provider, W3C trace propagation, structural payload summaries, and NDJSON-friendly internal telemetry output
- tighten the local API middleware with authorized-client rate limiting, correct `server.address` and `server.port` span fields, and cleaner request lifecycle logging
- add focused retry, propagation, logging, and authorization regression coverage and refresh the operator documentation for telemetry and protocol overrides

## Motivation

Transport troubleshooting on the model API path needs correlated request data across CLI calls, outbound model requests, SSE fallback behavior, and the local API surface. Review feedback on this lane also identified correctness gaps around trace propagation, limiter scope, duplicate serialization work, and NDJSON emission that needed to be fixed before merge.

## Approach

- initialize `SdkTracerProvider` in the shared telemetry bootstrap, shut it down on drop, and inject W3C `traceparent` and `baggage` headers without overwriting operator-supplied request headers
- reuse the actual serialized outbound payload for both transport and `payload_bytes`, add deterministic local-connect retry coverage, and keep internal telemetry output one-record-per-line
- bucket authorized local API requests by forwarded client identity, bypass the main limiter for unauthorized traffic, and document the telemetry controls plus protocol-override guidance for `vex -p`

## Validation

- cargo check
- cargo fmt --check
- cargo test retry_local_connect_errors -- --nocapture
- cargo test test_inject_context_headers_preserves_existing_headers -- --nocapture
- cargo test test_emit_log_value_writes_single_ndjson_record_per_line -- --nocapture
- cargo test test_http_router_requires_bearer_token -- --nocapture
- mdbook build docs
- cargo test --all-targets
- bash scripts/check_forbidden_names.sh
- make deps-deny
- make gate-fast

## Risks

This change is isolated to the observability bootstrap, model transport logging, and local API middleware. The remaining runtime risk is the separate transport-follow-up lane for protocol fallback and normalization behavior; this branch improves the diagnostics for that work without changing the higher-level fallback policy itself.
