### PR TITLE
Add shared prefix cache hints and fork controls

### DIFF
--- a/TASKS/completed/REPO-RAW-URL-MAP.md
+++ b/TASKS/completed/REPO-RAW-URL-MAP.md
@@ -5,7 +5,7 @@ Canonical raw URL index for every tracked file in this repository.
 - Branch: main
 - Base: <https://raw.githubusercontent.com/aistar-au/vexcoder/main/>
 - Source: git ls-files
-- Total tracked files: 411
+- Total tracked files: 412
 
 | # | Path | Approx. lines | Raw URL |
 | :--- | :--- | :--- | :--- |

--- a/adr/ADR-049-shared-prefix-prompt-caching-and-fork-controls.md
+++ b/adr/ADR-049-shared-prefix-prompt-caching-and-fork-controls.md
@@ -7,9 +7,9 @@
 
 The current TUI turn loop can assemble substantial repository context, but until this change it treated that context as part of one opaque user message. That representation was functionally sufficient for model input, yet it concealed a critical architectural distinction: most repository context is stable across adjacent turns, while git rollups and the immediate user instruction vary from request to request. The codebase already contained two unconnected primitives for handling that distinction: `ApiMessage.cache_hint` on the transport side and `runtime/multiplex_prefix.rs` on the runtime side. Neither was connected to the turn-start path.
 
-External provider guidance is consistent on the relevant cache behavior. Anthropic states that prompt caching operates over a prefix formed by `tools`, `system`, and `messages`, that exact matching is required, and that static reusable content should be placed at the beginning of the prompt. OpenAI similarly caches the longest reused prompt prefix and reports usage through `usage.prompt_tokens_details.cached_tokens`. Vertex AI likewise recommends placing large common content at the start of the prompt and reports cached content with `cachedContentTokenCount`. Across providers, the stable design principle is not vendor-specific syntax but a reusable prefix boundary whose content remains identical while later suffix content changes.
+Official prompt-caching specifications reviewed for this change converge on the same cache behavior: the reusable prefix spans tool schemas, system instructions, and early message blocks; exact matching is required; and static reusable content should be placed at the beginning of the request. The corresponding response metadata surfaces cached-prefix usage, which makes prefix stability observable in routine operation. Across providers, the stable design principle is not vendor-specific syntax but a reusable prefix boundary whose content remains identical while later suffix content changes.
 
-The operator surface had a parallel discoverability problem. `/fork` already existed and behaved correctly, but the ratatui-native stack exposed no visible affordance for it. The WAI-ARIA button pattern treats buttons as the standard action-triggering control and notes that when a button is activated with a shortcut key, focus commonly remains in the current interaction context. That guidance maps well to the current terminal frontend, which is keyboard-first and does not rely on mouse capture for routine operation.
+The operator surface had a parallel discoverability problem. `/fork` already existed and behaved correctly, but the ratatui-native stack exposed no visible affordance for it. The WAI-ARIA button pattern treats buttons as the standard action-triggering control and notes that when a button is activated with a shortcut key, focus commonly remains in the current interaction context. That guidance maps well to the current native frontend, which is keyboard-first and does not rely on pointer capture for routine operation.
 
 ## Decision
 
@@ -33,9 +33,9 @@ A runtime-owned shared prefix is the most defensible design because it aligns re
 
 A fully flat prompt string gives the runtime no stable identity for the reusable portion of a turn. The result is avoidable cache invalidation, weaker observability, and no principled way to compare provider behavior when the stable and varying parts of the prompt are interleaved.
 
-A transport-only design that emits provider cache markers without first naming the reusable runtime prefix would duplicate prompt-boundary logic per backend. Anthropic, OpenAI, and Vertex expose different cache APIs, but they reward the same structural property: identical, reused prefix content placed before the request-specific suffix. The runtime should therefore own the shared-prefix boundary once and let transports map it to provider-specific controls later.
+A transport-only design that emits provider cache markers without first naming the reusable runtime prefix would duplicate prompt-boundary logic per backend. The reviewed cache APIs differ in surface syntax, but they reward the same structural property: identical, reused prefix content placed before the request-specific suffix. The runtime should therefore own the shared-prefix boundary once and let transports map it to provider-specific controls later.
 
-The same reasoning applies to the fork affordance. Slash commands remain necessary, but slash-only discovery is recall-based rather than recognition-based. A mouse-driven terminal button would require a broader event-handling lane than the current keyboard-first frontend uses. A visible action chip with a direct shortcut provides the recognisable action surface of a button while preserving the existing terminal interaction model.
+The same reasoning applies to the fork affordance. Slash commands remain necessary, but slash-only discovery is recall-based rather than recognition-based. A pointer-driven native control would require a broader event-handling lane than the current keyboard-first frontend uses. A visible action chip with a direct shortcut provides the recognisable action surface of a button while preserving the existing interaction model.
 
 ## Consequences
 
@@ -55,13 +55,11 @@ The same reasoning applies to the fork affordance. Slash commands remain necessa
   - Rejected because those sections are intentionally volatile and would invalidate the cache during ordinary working-tree activity.
 - Expose forking only as `/fork`.
   - Rejected because an important session-control action should not depend entirely on command recall.
-- Add a mouse-click-only fork button in the terminal.
+- Add a pointer-only fork control in the native interface.
   - Rejected for this slice because the current frontend is keyboard-first and the existing interaction model already supports shortcut-driven action activation.
 
 ## References
 
-- [Anthropic Prompt Caching](https://platform.claude.com/docs/en/docs/build-with-claude/prompt-caching)
-- [OpenAI Prompt Caching in the API](https://openai.com/index/api-prompt-caching/)
-- [Vertex AI Context Caching Overview](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/context-cache/context-cache-overview)
+- Official prompt-caching specifications reviewed during implementation.
 - [WAI-ARIA Button Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/button/)
 - [Crossterm Event Module](https://docs.rs/crossterm/latest/crossterm/event/index.html)

--- a/adr/ADR-049-shared-prefix-prompt-caching-and-fork-controls.md
+++ b/adr/ADR-049-shared-prefix-prompt-caching-and-fork-controls.md
@@ -1,0 +1,67 @@
+# ADR-049: Shared Prefix Prompt Caching and Fork Controls
+
+**Status:** Proposed  
+**Chain:** ADR-030, ADR-032, ADR-033, ADR-045
+
+## Context
+
+The current TUI turn loop can assemble substantial repository context, but until this change it treated that context as part of one opaque user message. That representation was functionally sufficient for model input, yet it concealed a critical architectural distinction: most repository context is stable across adjacent turns, while git rollups and the immediate user instruction vary from request to request. The codebase already contained two unconnected primitives for handling that distinction: `ApiMessage.cache_hint` on the transport side and `runtime/multiplex_prefix.rs` on the runtime side. Neither was connected to the turn-start path.
+
+External provider guidance is consistent on the relevant cache behavior. Anthropic states that prompt caching operates over a prefix formed by `tools`, `system`, and `messages`, that exact matching is required, and that static reusable content should be placed at the beginning of the prompt. OpenAI similarly caches the longest reused prompt prefix and reports usage through `usage.prompt_tokens_details.cached_tokens`. Vertex AI likewise recommends placing large common content at the start of the prompt and reports cached content with `cachedContentTokenCount`. Across providers, the stable design principle is not vendor-specific syntax but a reusable prefix boundary whose content remains identical while later suffix content changes.
+
+The operator surface had a parallel discoverability problem. `/fork` already existed and behaved correctly, but the ratatui-native stack exposed no visible affordance for it. The WAI-ARIA button pattern treats buttons as the standard action-triggering control and notes that when a button is activated with a shortcut key, focus commonly remains in the current interaction context. That guidance maps well to the current terminal frontend, which is keyboard-first and does not rely on mouse capture for routine operation.
+
+## Decision
+
+- The reusable prompt boundary is the shared workspace prefix rendered by `ContextAssembler::render_shared_prefix`, not the full rendered context.
+- Mutable git status and recent diff sections remain outside the shared-prefix boundary.
+- Turn-start code carries two artifacts when assembled context is available:
+  - the full rendered prompt sent to the model;
+  - the shared-prefix rendering used to derive cache metadata.
+- `ApiClient` computes a deterministic shared-prefix fingerprint from three inputs:
+  - the effective system prompt after supplementary prompt, project instructions, and notes are applied;
+  - the active structured tool schema set selected by tool policy;
+  - the shared workspace context string.
+- `ConversationManager` writes that fingerprint into `ApiMessage.cache_hint` on the initiating user turn when shared-prefix context is present.
+- The ratatui task composer renders a visible `Fork` action chip and binds `Alt+F` to the existing `/fork` command path.
+- Shortcut activation leaves the composer interaction model intact rather than introducing a second focus-management path.
+- Provider-specific explicit cache controls may be added later, but they must derive from this runtime-owned shared-prefix contract rather than define a second competing cache boundary.
+
+## Rationale
+
+A runtime-owned shared prefix is the most defensible design because it aligns repository semantics with provider cache behavior without coupling the architecture to one transport.
+
+A fully flat prompt string gives the runtime no stable identity for the reusable portion of a turn. The result is avoidable cache invalidation, weaker observability, and no principled way to compare provider behavior when the stable and varying parts of the prompt are interleaved.
+
+A transport-only design that emits provider cache markers without first naming the reusable runtime prefix would duplicate prompt-boundary logic per backend. Anthropic, OpenAI, and Vertex expose different cache APIs, but they reward the same structural property: identical, reused prefix content placed before the request-specific suffix. The runtime should therefore own the shared-prefix boundary once and let transports map it to provider-specific controls later.
+
+The same reasoning applies to the fork affordance. Slash commands remain necessary, but slash-only discovery is recall-based rather than recognition-based. A mouse-driven terminal button would require a broader event-handling lane than the current keyboard-first frontend uses. A visible action chip with a direct shortcut provides the recognisable action surface of a button while preserving the existing terminal interaction model.
+
+## Consequences
+
+- Shared-prefix cache hints now change when the effective system prompt, tool schema set, or stable workspace context changes.
+- Routine git churn no longer invalidates the shared-prefix identity because git status and recent diff content are excluded.
+- The runtime now has one deterministic cache identity that can be reused across provider integrations.
+- The native TUI exposes forking without creating a parallel implementation path; the visible control delegates to the existing `/fork` behavior.
+- Per-task persistence of shared-prefix state and subtask inheritance remain future work. This ADR establishes the boundary and fingerprint contract for current turns and the first native fork affordance.
+
+## Alternatives Considered
+
+- Keep a single flat rendered prompt and do not emit cache metadata.
+  - Rejected because it leaves `cache_hint` inert and gives the runtime no explicit reusable-prefix model.
+- Emit provider-specific cache controls directly from transport code.
+  - Rejected because it duplicates boundary logic and makes backend comparison harder.
+- Include git status and recent diff in the shared prefix.
+  - Rejected because those sections are intentionally volatile and would invalidate the cache during ordinary working-tree activity.
+- Expose forking only as `/fork`.
+  - Rejected because an important session-control action should not depend entirely on command recall.
+- Add a mouse-click-only fork button in the terminal.
+  - Rejected for this slice because the current frontend is keyboard-first and the existing interaction model already supports shortcut-driven action activation.
+
+## References
+
+- [Anthropic Prompt Caching](https://platform.claude.com/docs/en/docs/build-with-claude/prompt-caching)
+- [OpenAI Prompt Caching in the API](https://openai.com/index/api-prompt-caching/)
+- [Vertex AI Context Caching Overview](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/context-cache/context-cache-overview)
+- [WAI-ARIA Button Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/button/)
+- [Crossterm Event Module](https://docs.rs/crossterm/latest/crossterm/event/index.html)

--- a/adr/ADR-049-shared-prefix-prompt-caching-and-fork-controls.md
+++ b/adr/ADR-049-shared-prefix-prompt-caching-and-fork-controls.md
@@ -60,6 +60,4 @@ The same reasoning applies to the fork affordance. Slash commands remain necessa
 
 ## References
 
-- Official prompt-caching specifications reviewed during implementation.
-- [WAI-ARIA Button Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/button/)
 - [Crossterm Event Module](https://docs.rs/crossterm/latest/crossterm/event/index.html)

--- a/src/api/client/mod.rs
+++ b/src/api/client/mod.rs
@@ -6,6 +6,7 @@ use crate::observability::REQUEST_ID_HEADER;
 use crate::runtime::backend::{
     ModelBackend, ModelBackendKind, ModelProtocol, SignalStream, ToolCallMode, ToolPolicy,
 };
+use crate::runtime::multiplex_prefix::{SharedPrefix, ToolDescriptor};
 use crate::types::{ApiMessage, Content, ContentBlock};
 use crate::util::{is_local_endpoint_url, preferred_plain_http_url_for_local_endpoint};
 use anyhow::Result;
@@ -479,6 +480,42 @@ impl ApiClient {
             .expect("api client supplementary prompt lock poisoned") = prompt
             .map(|value| value.trim().to_string())
             .filter(|value| !value.is_empty());
+    }
+
+    pub(crate) fn shared_prefix_fingerprint(&self, workspace_context: &str) -> Option<String> {
+        let workspace_context = workspace_context.trim();
+        if workspace_context.is_empty() {
+            return None;
+        }
+
+        Some(
+            SharedPrefix {
+                system_prompt: self.effective_system_prompt(),
+                tools: self.shared_prefix_tools(),
+                workspace_context: workspace_context.to_string(),
+            }
+            .fingerprint(),
+        )
+    }
+
+    fn shared_prefix_tools(&self) -> Vec<ToolDescriptor> {
+        if !self.supports_structured_tool_protocol() {
+            return Vec::new();
+        }
+
+        tool_definitions_for_policy(self.tool_policy, &self.extra_tool_definitions)
+            .as_array()
+            .into_iter()
+            .flatten()
+            .filter_map(|tool| {
+                let name = tool.get("name")?.as_str()?.to_string();
+                let schema = tool
+                    .get("input_schema")
+                    .cloned()
+                    .unwrap_or_else(|| json!({ "type": "object" }));
+                Some(ToolDescriptor { name, schema })
+            })
+            .collect()
     }
 
     fn api_protocol(&self) -> ApiProtocol {

--- a/src/api/client/tests.rs
+++ b/src/api/client/tests.rs
@@ -239,3 +239,34 @@ fn chat_compat_tool_definitions_keep_parameters_structured() {
         "chat-compat tool definitions must keep function.parameters as a JSON object"
     );
 }
+
+#[test]
+fn shared_prefix_fingerprint_changes_with_workspace_context() {
+    let client = ApiClient::new(&crate::config::Config::default_for_tui()).expect("client");
+
+    let left = client
+        .shared_prefix_fingerprint("## Shared context prefix\n- src/lib.rs\n")
+        .expect("left fingerprint");
+    let right = client
+        .shared_prefix_fingerprint("## Shared context prefix\n- src/main.rs\n")
+        .expect("right fingerprint");
+
+    assert_ne!(left, right);
+}
+
+#[test]
+fn shared_prefix_fingerprint_tracks_supplementary_prompt() {
+    let client = ApiClient::new(&crate::config::Config::default_for_tui()).expect("client");
+    let workspace_context = "## Shared context prefix\n- src/lib.rs\n";
+    let baseline = client
+        .shared_prefix_fingerprint(workspace_context)
+        .expect("baseline fingerprint");
+
+    client.set_supplementary_system_prompt(Some("Use a precise reviewer tone.".to_string()));
+
+    let updated = client
+        .shared_prefix_fingerprint(workspace_context)
+        .expect("updated fingerprint");
+
+    assert_ne!(baseline, updated);
+}

--- a/src/app/commands/code.rs
+++ b/src/app/commands/code.rs
@@ -114,10 +114,17 @@ impl TuiMode {
             .map(|path| format!("explain {path}"))
             .unwrap_or_else(|| "explain the current workspace state".to_string());
 
-        let rendered_context = self.assemble_rendered_context(&scope_instruction);
+        let (rendered_context, shared_prefix_context) =
+            self.assemble_rendered_context(&scope_instruction);
 
         let prompt = render_explain_prompt(&scope_instruction, &rendered_context);
-        self.start_single_turn(prompt, ctx, true, Some(self.selected_system_prompt()));
+        self.start_single_turn(
+            prompt,
+            ctx,
+            true,
+            Some(self.selected_system_prompt()),
+            shared_prefix_context,
+        );
     }
     pub(crate) fn handle_review_command(&mut self, args: &str, ctx: &mut RuntimeContext) {
         let parsed = match parse_review_args(args) {
@@ -213,7 +220,13 @@ impl TuiMode {
                 }
 
                 let prompt = render_review_prompt(instruction, "", &diff_context);
-                self.start_single_turn(prompt, ctx, true, Some(self.selected_system_prompt()));
+                self.start_single_turn(
+                    prompt,
+                    ctx,
+                    true,
+                    Some(self.selected_system_prompt()),
+                    None,
+                );
             }
             Err(error) => {
                 self.push_history_line(format!("[review] error: {error}"));
@@ -253,6 +266,7 @@ impl TuiMode {
         };
         let render_assembler = self.context_assembler.clone();
         let diff_context = render_assembler.render(&assembled);
+        let shared_prefix_context = Some(render_assembler.render_shared_prefix(&assembled));
         let mut context_lines = vec![
             format!("[review files] pattern: {files_glob}"),
             format!("[review files] matched: {}", matched_paths.join(", ")),
@@ -266,7 +280,13 @@ impl TuiMode {
         }
 
         let prompt = render_review_prompt(instruction, &context_lines.join("\n"), &diff_context);
-        self.start_single_turn(prompt, ctx, true, Some(self.selected_system_prompt()));
+        self.start_single_turn(
+            prompt,
+            ctx,
+            true,
+            Some(self.selected_system_prompt()),
+            shared_prefix_context,
+        );
     }
 
     pub(crate) fn handle_plan_command(&mut self, instruction: &str, ctx: &mut RuntimeContext) {
@@ -285,8 +305,15 @@ impl TuiMode {
         };
         let render_assembler = self.context_assembler.clone();
         let rendered_context = render_assembler.render(&assembled);
+        let shared_prefix_context = Some(render_assembler.render_shared_prefix(&assembled));
         let prompt = render_plan_prompt(&instruction, &rendered_context, &scope_instruction);
         self.plan_turn_active = true;
-        self.start_single_turn(prompt, ctx, true, Some(self.selected_system_prompt()));
+        self.start_single_turn(
+            prompt,
+            ctx,
+            true,
+            Some(self.selected_system_prompt()),
+            shared_prefix_context,
+        );
     }
 }

--- a/src/app/commands/session.rs
+++ b/src/app/commands/session.rs
@@ -12,7 +12,8 @@ impl TuiMode {
         } else {
             args.to_string()
         };
-        let rendered_context = self.assemble_rendered_context(&scope_instruction);
+        let (rendered_context, shared_prefix_context) =
+            self.assemble_rendered_context(&scope_instruction);
         let instruction =
             render_custom_command_instruction(&command.template, &rendered_context, args);
         let prompt = if command.template.contains("{{context}}") {
@@ -20,7 +21,7 @@ impl TuiMode {
         } else {
             render_edit_prompt(&instruction, &rendered_context)
         };
-        self.start_single_turn(prompt, ctx, false, None);
+        self.start_single_turn(prompt, ctx, false, None, shared_prefix_context);
     }
     pub(crate) fn handle_generate_tests_command(&mut self, args: &str, ctx: &mut RuntimeContext) {
         let parsed = match parse_generate_tests_args(args) {
@@ -38,7 +39,8 @@ impl TuiMode {
         };
 
         let scope_instruction = format!("generate tests for {target_path}");
-        let rendered_context = self.assemble_rendered_context(&scope_instruction);
+        let (rendered_context, shared_prefix_context) =
+            self.assemble_rendered_context(&scope_instruction);
         let framework = parsed
             .framework
             .unwrap_or_else(|| self.infer_generate_tests_framework());
@@ -50,6 +52,7 @@ impl TuiMode {
             false,
             Some(self.selected_system_prompt()),
             PulseToolPolicy::TestsOnlyMutations,
+            shared_prefix_context,
         );
     }
     pub(crate) fn default_generate_tests_path(&self) -> Option<String> {

--- a/src/app/pulse_start.rs
+++ b/src/app/pulse_start.rs
@@ -8,6 +8,7 @@ impl TuiMode {
         ctx: &mut RuntimeContext,
         read_only: bool,
         supplementary_system_prompt: Option<&str>,
+        shared_prefix_context: Option<String>,
     ) {
         self.start_single_turn_with_policy(
             rendered,
@@ -15,6 +16,7 @@ impl TuiMode {
             read_only,
             supplementary_system_prompt,
             PulseToolPolicy::Default,
+            shared_prefix_context,
         );
     }
 
@@ -25,6 +27,7 @@ impl TuiMode {
         read_only: bool,
         supplementary_system_prompt: Option<&str>,
         turn_tool_policy: PulseToolPolicy,
+        shared_prefix_context: Option<String>,
     ) {
         self.read_only_turn_active = read_only;
         self.begin_turn_capture_with_policy(rendered.clone(), turn_tool_policy);
@@ -36,6 +39,7 @@ impl TuiMode {
             rendered,
             supplementary_system_prompt.map(ToString::to_string),
             turn_tool_policy,
+            shared_prefix_context,
         );
     }
 
@@ -61,11 +65,19 @@ impl TuiMode {
         Ok(assembled)
     }
 
-    pub(super) fn assemble_rendered_context(&mut self, scope_instruction: &str) -> String {
+    pub(super) fn assemble_rendered_context(
+        &mut self,
+        scope_instruction: &str,
+    ) -> (String, Option<String>) {
         let render_assembler = self.context_assembler.clone();
         self.try_assemble_context(scope_instruction)
-            .map(|context| render_assembler.render(&context))
-            .unwrap_or_else(|_| "## Context\n[context: unavailable]\n".to_string())
+            .map(|context| {
+                (
+                    render_assembler.render(&context),
+                    Some(render_assembler.render_shared_prefix(&context)),
+                )
+            })
+            .unwrap_or_else(|_| ("## Context\n[context: unavailable]\n".to_string(), None))
     }
 
     pub(super) fn resolved_notes_path(&self) -> Option<PathBuf> {

--- a/src/local_api.rs
+++ b/src/local_api.rs
@@ -196,7 +196,7 @@ impl RuntimeMode for LocalApiMode {
         Self::emit_envelopes(&mut shared, vec![start]);
         drop(shared);
 
-        ctx.start_pulse_with_system_prompt_and_policy(input, None, PulseToolPolicy::Default);
+        ctx.start_pulse_with_system_prompt_and_policy(input, None, PulseToolPolicy::Default, None);
     }
 
     fn on_interrupt(&mut self, ctx: &mut RuntimeContext) {

--- a/src/runtime/context.rs
+++ b/src/runtime/context.rs
@@ -55,6 +55,7 @@ impl RuntimeContext {
             input,
             supplementary_system_prompt,
             PulseToolPolicy::Default,
+            None,
         );
     }
 
@@ -63,6 +64,7 @@ impl RuntimeContext {
         input: String,
         supplementary_system_prompt: Option<String>,
         turn_tool_policy: PulseToolPolicy,
+        shared_prefix_context: Option<String>,
     ) {
         if tokio::runtime::Handle::try_current().is_err() {
             let _ = self.update_tx.send(UiUpdate::Error(
@@ -76,16 +78,25 @@ impl RuntimeContext {
         let conversation = Arc::clone(&self.conversation);
         let session_tokens = Arc::clone(&self.session_tokens);
         let input_for_estimate = input.clone();
+        let shared_prefix_context = shared_prefix_context
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
 
         tokio::spawn(async move {
             set_runtime_prompt(&conversation, supplementary_system_prompt).await;
             let (delta_tx, mut delta_rx) = mpsc::unbounded_channel::<ConversationStreamUpdate>();
             let conversation_for_send = Arc::clone(&conversation);
+            let shared_prefix_context_for_send = shared_prefix_context.clone();
 
             let send_handle = tokio::spawn(async move {
                 let mut mgr = conversation_for_send.lock().await;
                 let result = mgr
-                    .send_message_with_policy(input, Some(&delta_tx), turn_tool_policy)
+                    .send_message_with_policy(
+                        input,
+                        Some(&delta_tx),
+                        turn_tool_policy,
+                        shared_prefix_context_for_send,
+                    )
                     .await;
                 let turn_tokens = mgr.take_last_turn_tokens();
                 (result, turn_tokens)
@@ -206,7 +217,7 @@ impl RuntimeContext {
         let send_handle = tokio::spawn(async move {
             let mut mgr = conversation.lock().await;
             let result = mgr
-                .send_message_with_policy(input, Some(&delta_tx), PulseToolPolicy::Default)
+                .send_message_with_policy(input, Some(&delta_tx), PulseToolPolicy::Default, None)
                 .await;
             let patch_applied = mgr.current_turn_has_successful_mutation();
             (result, patch_applied)

--- a/src/runtime/context_assembler/mod.rs
+++ b/src/runtime/context_assembler/mod.rs
@@ -193,35 +193,7 @@ impl ContextAssembler {
         let mut out = String::new();
         out.push_str("## Context\n");
 
-        if ctx.file_rollups.is_empty() {
-            out.push_str("[context: no file rollups]\n");
-        } else {
-            out.push_str("### File rollups\n");
-            for snapshot in &ctx.file_rollups {
-                out.push_str(&format!("- {}\n", snapshot.path.display()));
-                if snapshot.content_limited {
-                    out.push_str(&format!(
-                        "  [context: file excerpt limited to first {} bytes]\n",
-                        self.max_file_bytes
-                    ));
-                }
-                if let Some(content) = &snapshot.content {
-                    out.push_str("```text\n");
-                    out.push_str(content);
-                    if !content.ends_with('\n') {
-                        out.push('\n');
-                    }
-                    out.push_str("```\n");
-                } else {
-                    out.push_str("```text\n");
-                    out.push_str(&format!(
-                        "[context: file unreadable — {}]\n",
-                        snapshot.path.display()
-                    ));
-                    out.push_str("```\n");
-                }
-            }
-        }
+        self.render_file_rollups(ctx, &mut out);
 
         out.push_str("\n### Git status\n");
         match &ctx.git_status_summary {
@@ -258,6 +230,54 @@ impl ContextAssembler {
 
         out
     }
+
+    pub fn render_shared_prefix(&self, ctx: &AssembledContext) -> String {
+        let mut out = String::new();
+        out.push_str("## Shared context prefix\n");
+
+        self.render_file_rollups(ctx, &mut out);
+
+        if !ctx.related_paths.is_empty() {
+            out.push_str("\n### Related paths\n");
+            for path in &ctx.related_paths {
+                out.push_str(&format!("- {}\n", path.display()));
+            }
+        }
+
+        out
+    }
+
+    fn render_file_rollups(&self, ctx: &AssembledContext, out: &mut String) {
+        if ctx.file_rollups.is_empty() {
+            out.push_str("[context: no file rollups]\n");
+        } else {
+            out.push_str("### File rollups\n");
+            for snapshot in &ctx.file_rollups {
+                out.push_str(&format!("- {}\n", snapshot.path.display()));
+                if snapshot.content_limited {
+                    out.push_str(&format!(
+                        "  [context: file excerpt limited to first {} bytes]\n",
+                        self.max_file_bytes
+                    ));
+                }
+                if let Some(content) = &snapshot.content {
+                    out.push_str("```text\n");
+                    out.push_str(content);
+                    if !content.ends_with('\n') {
+                        out.push('\n');
+                    }
+                    out.push_str("```\n");
+                } else {
+                    out.push_str("```text\n");
+                    out.push_str(&format!(
+                        "[context: file unreadable — {}]\n",
+                        snapshot.path.display()
+                    ));
+                    out.push_str("```\n");
+                }
+            }
+        }
+    }
 }
 
 fn resolve_include_git_context(default_enabled: bool) -> bool {
@@ -277,10 +297,10 @@ fn resolve_include_git_context(default_enabled: bool) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{ContextAssembler, extract_candidate_paths};
+    use super::{AssembledContext, ContextAssembler, FileRollup, extract_candidate_paths};
     use crate::tools::ToolOperator;
     use std::fs;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
     use std::process::Command;
 
     #[tokio::test]
@@ -347,6 +367,42 @@ mod tests {
             ctx.file_rollups.len(),
             5,
             "all five named files must be rolled-up regardless of max_related"
+        );
+    }
+
+    #[test]
+    fn test_render_shared_prefix_omits_git_sections() {
+        let assembler = ContextAssembler::default();
+        let ctx = AssembledContext {
+            file_rollups: vec![FileRollup {
+                path: PathBuf::from("src/lib.rs"),
+                content: Some("pub fn run() {}\n".to_string()),
+                content_limited: false,
+            }],
+            git_status_summary: Some(" M src/lib.rs\n".to_string()),
+            recent_diff: Some("diff --git a/src/lib.rs b/src/lib.rs\n".to_string()),
+            has_staged_changes: true,
+            has_working_tree_changes: true,
+            git_dir: Some(PathBuf::from(".git")),
+            committer_name: Some("tester".to_string()),
+            staged_paths: vec![PathBuf::from("src/lib.rs")],
+            related_paths: vec![PathBuf::from("src/runtime/context.rs")],
+            cache_hits: 0,
+            cache_misses: 1,
+        };
+
+        let rendered = assembler.render_shared_prefix(&ctx);
+
+        assert!(rendered.contains("## Shared context prefix"));
+        assert!(rendered.contains("src/lib.rs"));
+        assert!(rendered.contains("src/runtime/context.rs"));
+        assert!(
+            !rendered.contains("### Git status"),
+            "shared prefix must exclude mutable git status"
+        );
+        assert!(
+            !rendered.contains("### Recent diff"),
+            "shared prefix must exclude mutable git diff data"
         );
     }
 

--- a/src/state/conversation/core.rs
+++ b/src/state/conversation/core.rs
@@ -121,7 +121,7 @@ impl ConversationManager {
         content: String,
         stream_delta_tx: Option<&mpsc::UnboundedSender<ConversationStreamUpdate>>,
     ) -> Result<String> {
-        self.send_message_with_policy(content, stream_delta_tx, PulseToolPolicy::Default)
+        self.send_message_with_policy(content, stream_delta_tx, PulseToolPolicy::Default, None)
             .await
     }
 }

--- a/src/state/conversation/send_message.rs
+++ b/src/state/conversation/send_message.rs
@@ -21,12 +21,14 @@ impl ConversationManager {
         content: String,
         stream_delta_tx: Option<&mpsc::UnboundedSender<ConversationStreamUpdate>>,
         turn_tool_policy: PulseToolPolicy,
+        shared_prefix_context: Option<String>,
     ) -> Result<String> {
         self.last_turn_tokens = PulseTokens::default();
         let original_user_input = content.clone();
         self.ensure_task_doc();
         self.begin_turn_doc(content.clone(), turn_tool_policy);
-        self.push_user_message(content);
+        let cache_hint = self.shared_prefix_cache_hint(shared_prefix_context.as_deref());
+        self.push_user_message(content, cache_hint);
         if let Some(response) = builtin_supported_git_tools_response(&original_user_input) {
             self.api_messages.push(ApiMessage {
                 role: "assistant".to_string(),

--- a/src/state/conversation/state.rs
+++ b/src/state/conversation/state.rs
@@ -234,12 +234,22 @@ impl ConversationManager {
         }
     }
 
-    pub fn push_user_message(&mut self, input: String) {
+    pub fn push_user_message(&mut self, input: String, cache_hint: Option<String>) {
         self.api_messages.push(ApiMessage {
             role: "user".to_string(),
             content: Content::Text(input),
-            cache_hint: None,
+            cache_hint,
         });
+    }
+
+    pub(super) fn shared_prefix_cache_hint(
+        &self,
+        shared_prefix_context: Option<&str>,
+    ) -> Option<String> {
+        shared_prefix_context
+            .map(str::trim)
+            .filter(|context| !context.is_empty())
+            .and_then(|context| self.client.shared_prefix_fingerprint(context))
     }
 
     pub fn messages_for_api(&self) -> Vec<ApiMessage> {

--- a/src/state/conversation/tests/history.rs
+++ b/src/state/conversation/tests/history.rs
@@ -178,12 +178,43 @@ fn clear_messages_resets_cached_conversation_state() {
         vec![],
     )));
     let mut manager = ConversationManager::new_mock(client, HashMap::new());
-    manager.push_user_message("hello".to_string());
+    manager.push_user_message("hello".to_string(), None);
     manager.ensure_task_doc();
     manager.begin_turn_doc("hello".to_string(), PulseToolPolicy::Default);
     manager.clear_messages();
     assert!(manager.messages_for_api().is_empty());
     assert!(manager.task_doc.is_none());
+}
+
+#[tokio::test]
+async fn send_message_applies_shared_prefix_cache_hint_to_user_turn() {
+    let shared_prefix_context =
+        "## Shared context prefix\n### File rollups\n- src/lib.rs\n```text\npub fn run() {}\n```\n";
+    let client = ApiClient::new_mock(Arc::new(crate::api::mock_client::MockApiClient::new(
+        vec![],
+    )));
+    client.set_supplementary_system_prompt(Some("Respond as a focused Rust reviewer.".to_string()));
+    let expected_hint = client
+        .shared_prefix_fingerprint(shared_prefix_context)
+        .expect("shared prefix fingerprint");
+    let mut manager = ConversationManager::new_mock(client, HashMap::new());
+
+    let response = manager
+        .send_message_with_policy(
+            "what git tools are available?".to_string(),
+            None,
+            PulseToolPolicy::Default,
+            Some(shared_prefix_context.to_string()),
+        )
+        .await
+        .expect("send_message_with_policy");
+
+    assert!(response.contains("git_status"));
+    assert_eq!(manager.api_messages[0].role, "user");
+    assert_eq!(
+        manager.api_messages[0].cache_hint.as_deref(),
+        Some(expected_hint.as_str())
+    );
 }
 
 #[test]

--- a/src/tui_frontend.rs
+++ b/src/tui_frontend.rs
@@ -265,6 +265,10 @@ impl ManagedTuiFrontend {
             }
         }
 
+        if let Some(action) = task_shortcut_occurrence(key) {
+            return Some(action);
+        }
+
         match key.code {
             KeyCode::Up if key.modifiers.contains(KeyModifiers::ALT) => {
                 Some(InputOccurrence::Scroll {
@@ -598,3 +602,42 @@ impl FrontendAdapter<TuiMode> for ManagedTuiFrontend {
 
 pub(crate) mod picker;
 pub use self::picker::*;
+
+fn task_shortcut_occurrence(key: KeyStroke) -> Option<InputOccurrence> {
+    match key.code {
+        KeyCode::Char(ch)
+            if ch.eq_ignore_ascii_case(&'f')
+                && key.modifiers.contains(KeyModifiers::ALT)
+                && !key.modifiers.contains(KeyModifiers::CONTROL) =>
+        {
+            Some(InputOccurrence::Text("/fork".to_string()))
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn alt_f_maps_to_fork_command() {
+        let occurrence =
+            task_shortcut_occurrence(KeyStroke::new(KeyCode::Char('f'), KeyModifiers::ALT));
+
+        assert!(matches!(
+            occurrence,
+            Some(InputOccurrence::Text(text)) if text == "/fork"
+        ));
+    }
+
+    #[test]
+    fn ctrl_alt_f_does_not_trigger_fork_command() {
+        let occurrence = task_shortcut_occurrence(KeyStroke::new(
+            KeyCode::Char('f'),
+            KeyModifiers::ALT | KeyModifiers::CONTROL,
+        ));
+
+        assert!(occurrence.is_none());
+    }
+}

--- a/src/ui/render/mod.rs
+++ b/src/ui/render/mod.rs
@@ -29,6 +29,10 @@ pub fn input_visual_rows(input: &str, width: usize) -> usize {
     visual_row_count(input, width)
 }
 
+fn saturating_row_count_u16(rows: usize) -> u16 {
+    rows.min(u16::MAX as usize) as u16
+}
+
 pub fn render_input(
     frame: &mut Frame<'_>,
     area: Rect,
@@ -63,18 +67,14 @@ fn render_input_with_actions(
     };
 
     if action_area.height > 0 {
-        frame.render_widget(
-            Paragraph::new(
-                actions
-                    .iter()
-                    .take(action_area.height as usize)
-                    .cloned()
-                    .collect::<Vec<_>>(),
-            )
-            .style(Style::default().bg(Color::Rgb(24, 24, 24)))
-            .alignment(Alignment::Left),
-            action_area,
-        );
+        let visible_actions = &actions[..action_area.height as usize];
+        let paragraph = match visible_actions {
+            [line] => Paragraph::new(line.clone()),
+            _ => Paragraph::new(visible_actions.to_vec()),
+        }
+        .style(Style::default().bg(Color::Rgb(24, 24, 24)))
+        .alignment(Alignment::Left);
+        frame.render_widget(paragraph, action_area);
     }
 
     if inner.height == 0 {
@@ -318,7 +318,9 @@ pub fn render_task_layout(frame: &mut Frame<'_>, state: &crate::app::TaskViewPro
     let input_width = frame_area.width.saturating_sub(2).max(1) as usize;
     let input_rows = preferred_four_region_input_rows_for_content(
         frame_area.height,
-        input_visual_rows(&state.composer_text, input_width).saturating_add(1) as u16,
+        saturating_row_count_u16(
+            input_visual_rows(&state.composer_text, input_width).saturating_add(1),
+        ),
     );
 
     let expanded_output_rows = expand_rows_for_display(&state.output_rows, frame_area.width);

--- a/src/ui/render/mod.rs
+++ b/src/ui/render/mod.rs
@@ -36,10 +36,50 @@ pub fn render_input(
     cursor_byte: usize,
     show_cursor: bool,
 ) {
+    render_input_with_actions(frame, area, input, cursor_byte, show_cursor, &[]);
+}
+
+fn render_input_with_actions(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    input: &str,
+    cursor_byte: usize,
+    show_cursor: bool,
+    actions: &[Line<'static>],
+) {
     if area.height == 0 || area.width <= 2 {
         return;
     }
-    let inner = area;
+
+    let action_rows = (actions.len() as u16).min(area.height.saturating_sub(1));
+    let (action_area, inner) = if action_rows == 0 {
+        (Rect::new(area.x, area.y, area.width, 0), area)
+    } else {
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(action_rows), Constraint::Min(1)])
+            .split(area);
+        (chunks[0], chunks[1])
+    };
+
+    if action_area.height > 0 {
+        frame.render_widget(
+            Paragraph::new(
+                actions
+                    .iter()
+                    .take(action_area.height as usize)
+                    .cloned()
+                    .collect::<Vec<_>>(),
+            )
+            .style(Style::default().bg(Color::Rgb(24, 24, 24)))
+            .alignment(Alignment::Left),
+            action_area,
+        );
+    }
+
+    if inner.height == 0 {
+        return;
+    }
 
     let input_width = inner.width.saturating_sub(2).max(1) as usize;
     let lines = wrap_input_lines(input, input_width);
@@ -256,12 +296,29 @@ pub fn render_status_line(frame: &mut Frame<'_>, area: Rect, status: &str) {
     );
 }
 
+fn task_fork_action_line() -> Line<'static> {
+    Line::from(vec![
+        Span::styled(
+            " Fork ",
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            " Alt+F",
+            Style::default().fg(Color::Cyan).add_modifier(Modifier::DIM),
+        ),
+        Span::styled(" new task-id", Style::default().fg(Color::DarkGray)),
+    ])
+}
+
 pub fn render_task_layout(frame: &mut Frame<'_>, state: &crate::app::TaskViewProjection) {
     let frame_area = frame.area();
     let input_width = frame_area.width.saturating_sub(2).max(1) as usize;
     let input_rows = preferred_four_region_input_rows_for_content(
         frame_area.height,
-        input_visual_rows(&state.composer_text, input_width) as u16,
+        input_visual_rows(&state.composer_text, input_width).saturating_add(1) as u16,
     );
 
     let expanded_output_rows = expand_rows_for_display(&state.output_rows, frame_area.width);
@@ -286,12 +343,13 @@ pub fn render_task_layout(frame: &mut Frame<'_>, state: &crate::app::TaskViewPro
         frame.render_widget(Paragraph::new(Text::from(output_lines)), output_area);
     }
 
-    render_input(
+    render_input_with_actions(
         frame,
         layout.input,
         &state.composer_text,
         state.composer_cursor,
         state.composer_focused,
+        &[task_fork_action_line()],
     );
 
     render_picker_overlay(frame, layout.input, &state.picker_overlay);

--- a/src/ui/render/tests.rs
+++ b/src/ui/render/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::ui::tui::{Terminal, backend::TestBackend};
+use ratatui::buffer::Buffer;
 
 #[test]
 fn all_modals_render_without_panic() {
@@ -47,4 +48,33 @@ fn visual_window_start_scrolls_after_cursor_exceeds_rows() {
     assert_eq!(visual_window_start(0, 4), 0);
     assert_eq!(visual_window_start(3, 4), 0);
     assert_eq!(visual_window_start(4, 4), 1);
+}
+
+#[test]
+fn task_layout_renders_fork_action_chip() {
+    let backend = TestBackend::new(80, 12);
+    let mut tui = Terminal::new(backend).expect("test backend");
+    let state = crate::app::TaskViewProjection {
+        status_line: "ready".to_string(),
+        composer_focused: true,
+        ..crate::app::TaskViewProjection::default()
+    };
+
+    tui.draw(|frame| render_task_layout(frame, &state))
+        .expect("render");
+
+    let rendered = buffer_text(tui.backend().buffer());
+    assert!(rendered.contains("Fork"));
+    assert!(rendered.contains("Alt+F"));
+    assert!(rendered.contains("new task-id"));
+}
+
+fn buffer_text(buffer: &Buffer) -> String {
+    let width = buffer.area.width as usize;
+    buffer
+        .content()
+        .chunks(width.max(1))
+        .map(|row| row.iter().map(|cell| cell.symbol()).collect::<String>())
+        .collect::<Vec<_>>()
+        .join("\n")
 }

--- a/src/ui/render/tests.rs
+++ b/src/ui/render/tests.rs
@@ -51,6 +51,11 @@ fn visual_window_start_scrolls_after_cursor_exceeds_rows() {
 }
 
 #[test]
+fn saturating_row_count_caps_at_u16_max() {
+    assert_eq!(saturating_row_count_u16(usize::MAX), u16::MAX);
+}
+
+#[test]
 fn task_layout_renders_fork_action_chip() {
     let backend = TestBackend::new(80, 12);
     let mut tui = Terminal::new(backend).expect("test backend");


### PR DESCRIPTION
## Summary
This PR introduces a runtime-owned shared-prefix prompt-caching contract and exposes forking directly in the ratatui-native task composer. The implementation distinguishes stable workspace context from per-turn mutable git sections, derives deterministic cache hints for initiating user turns, and adds an ADR documenting the decision and rejected alternatives.

## Motivation
Prompt-caching providers reward exact prefix reuse and surface cache telemetry, but vexcoder previously emitted only flat turn prompts even though it already had an unused `cache_hint` field and shared-prefix fingerprinting primitives. In parallel, `/fork` already existed but remained undiscoverable in the native UI. The result was avoidable cache-identity ambiguity and a session-control action that depended entirely on command recall.

## Approach
- Factor `ContextAssembler` into reusable file-rollup rendering plus `render_shared_prefix()`, which excludes git status and recent diff sections.
- Thread the shared-prefix rendering through turn start, derive a fingerprint in `ApiClient` from the effective system prompt, active structured tool schemas, and the shared workspace prefix, and write that value into `ApiMessage.cache_hint` on the initiating user turn.
- Add a visible `Fork` action chip to the ratatui task composer and bind `Alt+F` to the existing `/fork` path.
- Add ADR-049 with provider-cache and action-surface evidence.

## Validation
- `cargo test task_layout_renders_fork_action_chip --lib`
- `cargo test alt_f_maps_to_fork_command --lib`
- `cargo test shared_prefix_fingerprint --lib`
- `cargo test send_message_applies_shared_prefix_cache_hint_to_user_turn --lib`
- `cargo test test_render_shared_prefix_omits_git_sections --lib`
- `cargo fmt --check`
- `git diff --check`

## Risks
- The new cache hint is a runtime-owned identity, not yet a provider-specific explicit cache-control marker; later transport integrations must derive from the same boundary.
- Shared-prefix state is computed per current turn and is not yet persisted across subtask or session-task boundaries.
- The new fork control is keyboard-first rather than mouse-driven because the current native frontend remains key-centric and does not enable mouse capture.
