### PR TITLE
Add filtered codebase_search queries

### DIFF
--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -306,7 +306,7 @@ session/capability auto-approval grant).
 | `find_files` | Find files by name pattern (glob) within the workspace. |
 | `list_dir` | Non-recursive directory listing. Workspace-confined and `.gitignore`-aware. Optional `path` (defaults to workspace root); optional `max_entries` (default 200, hard cap 500). |
 | `glob_files` | Workspace-wide glob matching. `.gitignore`-aware with bounded results. Required `pattern` (supports `*`, `**`, `?`, `[abc]`, `[a-z]`, `[^x]`); optional `max_results` (default 50, hard cap 200). |
-| `codebase_search` | Search the structural index for functions, types, and code patterns by name or keyword. Returns ranked code snippets with file paths and line numbers. When embeddings are configured, also performs semantic reranking. Prefer this over `read_file` for exploring unfamiliar code. |
+| `codebase_search` | Search the structural index for functions, types, and code patterns by name, phrase, or filtered query. Supports quoted phrases plus `+required`, `-excluded`, `path:`, `kind:`, and `lang:` filters. Returns ranked code snippets with file paths and line numbers. When embeddings are configured, also performs semantic reranking. Prefer this over `read_file` for exploring unfamiliar code. |
 | `git_status` | Show git repository status. |
 | `git_diff` | Show git diff output. |
 
@@ -323,9 +323,19 @@ session/capability auto-approval grant).
 ### Search ranking
 
 `codebase_search` uses a Tree-sitter-based structural index that extracts
-functions, structs, enums, impls, traits, modules, constants, and type
-aliases from Rust source files. The index is built at session start and
+functions, structs, classes, interfaces, enums, impls, traits, modules,
+constants, and type aliases from supported Rust, Python, TypeScript/TSX,
+and JavaScript source files. The index is built at session start and
 updated incrementally on file writes.
+
+Query syntax supports:
+
+- Quoted phrases for exact multi-word matches, such as `"process request"`
+- `+required` terms that must appear in the candidate result
+- `-excluded` terms that remove matching candidates
+- `path:` filters to confine matches to specific files or directories
+- `kind:` filters such as `kind:function` or `kind:struct`
+- `lang:` filters such as `lang:rust`, `lang:python`, or `lang:typescript`
 
 Results are scored by:
 

--- a/src/api/client/mod.rs
+++ b/src/api/client/mod.rs
@@ -256,7 +256,7 @@ Repeat this loop until the task is complete; do not stop early after a single to
 For requests that mention specific files/paths or code edits, do not answer with planning text; emit a tool call first.\n\
 Never claim a file was read/written/renamed/searched unless the corresponding tool call succeeded.\n\
 Do not narrate intended actions without calling the tool call.\n\
-Use codebase_search to find functions, types, and code patterns before reading files. Only use read_file with offset/limit when you know the exact location.\n\
+Use codebase_search to find functions, types, and code patterns before reading files. Use quoted phrases and path:/kind:/lang: filters when they sharpen the search. Only use read_file with offset/limit when you know the exact location.\n\
 Prefer search_files for targeted string matches and avoid full-file reads unless required.\n\
 Use list_files/search_files/read_file before saying a file is missing or present.\n\
 For repository summaries or unfamiliar codebases, start with list_files at the workspace root and/or codebase_search; do not call read_file until you have an explicit non-empty path.\n\

--- a/src/api/client/tools.rs
+++ b/src/api/client/tools.rs
@@ -255,11 +255,11 @@ pub(super) fn tool_definitions() -> &'static Value {
                 },
                 {
                     "name": "codebase_search",
-                    "description": "Search the codebase for functions, types, and code patterns by name or keyword. Returns ranked code snippets with file paths and line numbers, and when embeddings are configured it also performs semantic reranking backed by a persisted index under .vex/index/. Prefer this over read_file for exploring unfamiliar code or producing a quick repo overview.",
+                    "description": "Search the codebase for functions, types, and code patterns by name, phrase, or filtered query. Supports quoted phrases plus `+required`, `-excluded`, `path:`, `kind:`, and `lang:` filters. Returns ranked code snippets with file paths and line numbers, and when embeddings are configured it also performs semantic reranking backed by a persisted index under .vex/index/. Prefer this over read_file for exploring unfamiliar code or producing a quick repo overview.",
                     "input_schema": {
                         "type": "object",
                         "properties": {
-                            "query": { "type": "string", "description": "Natural language or identifier search query" },
+                            "query": { "type": "string", "description": "Identifier, phrase, or filtered query using quoted phrases, +required, -excluded, path:, kind:, and lang: filters" },
                             "max_results": { "type": "integer", "description": "Maximum results to return (default 10)", "minimum": 1, "maximum": 50 }
                         },
                         "required": ["query"]

--- a/src/app/slash_commands.rs
+++ b/src/app/slash_commands.rs
@@ -489,7 +489,9 @@ pub(super) fn builtin_tool_usage_hint(name: &str) -> &'static str {
         "glob_files" => "find files by name pattern across the workspace",
         "find_files" => "build a selected file list before reading content",
         "search" | "search_content" => "scan exact text or regex hits across files",
-        "codebase_search" => "rank functions, types, and filtered code snippets before opening files",
+        "codebase_search" => {
+            "rank functions, types, and filtered code snippets before opening files"
+        }
         "read_file" => "read exact paths once discovery yields a selected target",
         "write_file" | "edit_file" | "apply_patch" | "rename_file" => {
             "make targeted workspace mutations"

--- a/src/app/slash_commands.rs
+++ b/src/app/slash_commands.rs
@@ -489,7 +489,7 @@ pub(super) fn builtin_tool_usage_hint(name: &str) -> &'static str {
         "glob_files" => "find files by name pattern across the workspace",
         "find_files" => "build a selected file list before reading content",
         "search" | "search_content" => "scan exact text or regex hits across files",
-        "codebase_search" => "rank functions, types, and code snippets before opening files",
+        "codebase_search" => "rank functions, types, and filtered code snippets before opening files",
         "read_file" => "read exact paths once discovery yields a selected target",
         "write_file" | "edit_file" | "apply_patch" | "rename_file" => {
             "make targeted workspace mutations"

--- a/src/tools/search.rs
+++ b/src/tools/search.rs
@@ -21,6 +21,114 @@ pub struct SearchResult {
     pub snippet: String,
 }
 
+#[derive(Debug, Default)]
+struct ParsedQuery {
+    terms: Vec<String>,
+    required_terms: Vec<String>,
+    excluded_terms: Vec<String>,
+    path_filters: Vec<String>,
+    kind_filters: Vec<String>,
+    lang_filters: Vec<String>,
+}
+
+impl ParsedQuery {
+    fn parse(query: &str) -> Self {
+        let mut parsed = Self::default();
+
+        for token in tokenize_query(query) {
+            let trimmed = token.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            if let Some(path_filter) = trimmed.strip_prefix("path:") {
+                let lowered = path_filter.trim().to_ascii_lowercase();
+                if !lowered.is_empty() {
+                    parsed.path_filters.push(lowered);
+                }
+                continue;
+            }
+
+            if let Some(kind_filter) = trimmed.strip_prefix("kind:") {
+                if let Some(normalized) = normalize_kind_filter(kind_filter) {
+                    parsed.kind_filters.push(normalized);
+                }
+                continue;
+            }
+
+            if let Some(lang_filter) = trimmed.strip_prefix("lang:") {
+                if let Some(normalized) = normalize_lang_filter(lang_filter) {
+                    parsed.lang_filters.push(normalized);
+                }
+                continue;
+            }
+
+            let (bucket, term) = if let Some(term) = trimmed.strip_prefix('+') {
+                (&mut parsed.required_terms, term)
+            } else if let Some(term) = trimmed.strip_prefix('-') {
+                (&mut parsed.excluded_terms, term)
+            } else {
+                (&mut parsed.terms, trimmed)
+            };
+
+            let normalized = term.trim().to_ascii_lowercase();
+            if !normalized.is_empty() {
+                bucket.push(normalized);
+            }
+        }
+
+        parsed
+    }
+
+    fn positive_query_text(&self) -> String {
+        self.terms
+            .iter()
+            .chain(self.required_terms.iter())
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    fn has_positive_terms(&self) -> bool {
+        !self.terms.is_empty() || !self.required_terms.is_empty()
+    }
+}
+
+#[derive(Debug)]
+struct ChunkSearchFields {
+    name_lower: String,
+    scope_lower: Option<String>,
+    source_lower: String,
+    path_lower: String,
+    kind_lower: String,
+    lang_lower: Option<&'static str>,
+}
+
+impl ChunkSearchFields {
+    fn from_chunk(chunk: &IndexChunk) -> Self {
+        Self {
+            name_lower: chunk.name.to_ascii_lowercase(),
+            scope_lower: chunk.parent_scope.as_ref().map(|scope| scope.to_ascii_lowercase()),
+            source_lower: chunk.source.to_ascii_lowercase(),
+            path_lower: chunk.path.to_ascii_lowercase(),
+            kind_lower: chunk.kind.label().to_ascii_lowercase(),
+            lang_lower: detect_chunk_language(&chunk.path),
+        }
+    }
+
+    fn matches_term(&self, term: &str) -> bool {
+        self.name_lower.contains(term)
+            || self.path_lower.contains(term)
+            || self.kind_lower.contains(term)
+            || self.source_lower.contains(term)
+            || self
+                .scope_lower
+                .as_deref()
+                .is_some_and(|scope| scope.contains(term))
+            || self.lang_lower.is_some_and(|lang| lang == term)
+    }
+}
+
 fn max_results_default() -> usize {
     std::env::var("VEX_SEARCH_MAX_RESULTS")
         .ok()
@@ -47,31 +155,43 @@ pub fn codebase_search(
         return Vec::new();
     }
 
-    let query_lower = query.to_ascii_lowercase();
-    let query_words: Vec<&str> = query_lower.split_whitespace().collect();
+    let parsed_query = ParsedQuery::parse(query);
+    let positive_query = parsed_query.positive_query_text();
 
     let scored: Vec<(f64, usize)> = index
         .iter()
         .enumerate()
         .filter_map(|(i, chunk)| {
-            let score = score_chunk(chunk, &query_lower, &query_words);
+            let score = score_chunk(chunk, &parsed_query, &positive_query);
             if score > 0.0 { Some((score, i)) } else { None }
         })
         .collect();
 
-    let engine = build_bm25_engine(index);
-    let bm25_scores: HashMap<usize, f64> = engine
-        .search(&query_lower, None)
-        .into_iter()
-        .filter_map(|r| {
-            let w = r.score as f64 * 10.0;
-            if w > 0.0 {
-                Some((r.document.id, w))
-            } else {
-                None
-            }
-        })
-        .collect();
+    let bm25_scores: HashMap<usize, f64> = if positive_query.is_empty() {
+        HashMap::new()
+    } else {
+        let engine = build_bm25_engine(index);
+        engine
+            .search(&positive_query, None)
+            .into_iter()
+            .filter_map(|r| {
+                let chunk = index.get(r.document.id)?;
+                let fields = ChunkSearchFields::from_chunk(chunk);
+                if !chunk_matches_query(chunk, &fields, &parsed_query) {
+                    return None;
+                }
+                if !matches_positive_terms(&fields, &parsed_query) {
+                    return None;
+                }
+                let w = r.score as f64 * 10.0;
+                if w > 0.0 {
+                    Some((r.document.id, w))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    };
 
     let mut score_map: HashMap<usize, f64> = scored.into_iter().map(|(s, i)| (i, s)).collect();
     for (idx, bm25_weight) in &bm25_scores {
@@ -188,31 +308,202 @@ pub fn merge_search_results(
     merged
 }
 
-fn score_chunk(chunk: &IndexChunk, query_lower: &str, query_words: &[&str]) -> f64 {
+fn tokenize_query(query: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+
+    for ch in query.chars() {
+        match ch {
+            '"' => in_quotes = !in_quotes,
+            c if c.is_whitespace() && !in_quotes => {
+                if !current.is_empty() {
+                    tokens.push(std::mem::take(&mut current));
+                }
+            }
+            _ => current.push(ch),
+        }
+    }
+
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+
+    tokens
+}
+
+fn normalize_kind_filter(value: &str) -> Option<String> {
+    let normalized = value.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "" => None,
+        "function" | "struct" | "class" | "interface" | "enum" | "impl" | "trait"
+        | "module" | "const" | "static" | "type" => Some(normalized),
+        "typealias" => Some("type".to_string()),
+        _ => Some(normalized),
+    }
+}
+
+fn normalize_lang_filter(value: &str) -> Option<String> {
+    let normalized = value.trim().to_ascii_lowercase();
+    let canonical = match normalized.as_str() {
+        "" => return None,
+        "rs" | "rust" => "rust",
+        "py" | "python" => "python",
+        "ts" | "tsx" | "typescript" => "typescript",
+        "js" | "jsx" | "mjs" | "cjs" | "javascript" => "javascript",
+        _ => normalized.as_str(),
+    };
+    Some(canonical.to_string())
+}
+
+fn detect_chunk_language(path: &str) -> Option<&'static str> {
+    let ext = Path::new(path).extension()?.to_str()?.to_ascii_lowercase();
+    match ext.as_str() {
+        "rs" => Some("rust"),
+        "py" => Some("python"),
+        "ts" | "tsx" => Some("typescript"),
+        "js" | "jsx" | "mjs" | "cjs" => Some("javascript"),
+        _ => None,
+    }
+}
+
+fn chunk_matches_query(
+    _chunk: &IndexChunk,
+    fields: &ChunkSearchFields,
+    parsed_query: &ParsedQuery,
+) -> bool {
+    if !parsed_query.path_filters.is_empty()
+        && !parsed_query
+            .path_filters
+            .iter()
+            .any(|path_filter| fields.path_lower.contains(path_filter))
+    {
+        return false;
+    }
+
+    if !parsed_query.kind_filters.is_empty()
+        && !parsed_query
+            .kind_filters
+            .iter()
+            .any(|kind_filter| kind_filter == &fields.kind_lower)
+    {
+        return false;
+    }
+
+    if !parsed_query.lang_filters.is_empty()
+        && !parsed_query
+            .lang_filters
+            .iter()
+            .any(|lang_filter| fields.lang_lower.is_some_and(|lang| lang == lang_filter))
+    {
+        return false;
+    }
+
+    if parsed_query
+        .excluded_terms
+        .iter()
+        .any(|excluded| fields.matches_term(excluded))
+    {
+        return false;
+    }
+
+    if parsed_query
+        .required_terms
+        .iter()
+        .any(|required| !fields.matches_term(required))
+    {
+        return false;
+    }
+
+    true
+}
+
+fn matches_positive_terms(fields: &ChunkSearchFields, parsed_query: &ParsedQuery) -> bool {
+    if !parsed_query.required_terms.is_empty()
+        && parsed_query
+            .required_terms
+            .iter()
+            .any(|required| !fields.matches_term(required))
+    {
+        return false;
+    }
+
+    if parsed_query.terms.is_empty() {
+        return true;
+    }
+
+    parsed_query.terms.iter().any(|term| fields.matches_term(term))
+}
+
+fn score_term(fields: &ChunkSearchFields, term: &str, required: bool) -> f64 {
     let mut score = 0.0;
-    let name_lower = chunk.name.to_ascii_lowercase();
+    let source_match_weight = if term.contains(' ') { 8.0 } else { 5.0 };
+    let exact_name_weight = if required { 60.0 } else { 45.0 };
+    let substring_name_weight = if required { 25.0 } else { 15.0 };
 
-    if name_lower == *query_lower {
-        score += 100.0;
-    } else if name_lower.contains(query_lower) {
-        score += 50.0;
-    } else if query_lower.contains(&name_lower) && name_lower.len() > 2 {
-        score += 30.0;
+    if fields.name_lower == term {
+        score += exact_name_weight;
+    } else if fields.name_lower.contains(term) {
+        score += substring_name_weight;
     }
 
-    if let Some(ref scope) = chunk.parent_scope {
-        let scope_lower = scope.to_ascii_lowercase();
-        if scope_lower.contains(query_lower) || query_lower.contains(&scope_lower) {
-            score += 20.0;
+    if fields.path_lower.contains(term) {
+        score += 10.0;
+    }
+
+    if fields.kind_lower == term {
+        score += 10.0;
+    }
+
+    if let Some(scope_lower) = fields.scope_lower.as_deref() {
+        if scope_lower.contains(term) {
+            score += 12.0;
         }
     }
 
-    let source_lower = chunk.source.to_ascii_lowercase();
-    for word in query_words {
-        if word.len() >= 3 {
-            let count = source_lower.matches(word).count();
-            score += count as f64 * 5.0;
+    let count = fields.source_lower.matches(term).count();
+    if count > 0 {
+        score += count as f64 * source_match_weight;
+    }
+
+    score
+}
+
+fn score_chunk(chunk: &IndexChunk, parsed_query: &ParsedQuery, positive_query: &str) -> f64 {
+    let fields = ChunkSearchFields::from_chunk(chunk);
+    if !chunk_matches_query(chunk, &fields, parsed_query) {
+        return 0.0;
+    }
+
+    let mut score = 0.0;
+    let query_lower = positive_query.to_ascii_lowercase();
+
+    if !query_lower.is_empty() {
+        if fields.name_lower == query_lower {
+            score += 100.0;
+        } else if fields.name_lower.contains(&query_lower) {
+            score += 50.0;
+        } else if query_lower.contains(&fields.name_lower) && fields.name_lower.len() > 2 {
+            score += 30.0;
         }
+
+        if let Some(scope_lower) = fields.scope_lower.as_deref() {
+            if scope_lower.contains(&query_lower) || query_lower.contains(scope_lower) {
+                score += 20.0;
+            }
+        }
+    }
+
+    for term in &parsed_query.terms {
+        score += score_term(&fields, term, false);
+    }
+
+    for term in &parsed_query.required_terms {
+        score += score_term(&fields, term, true);
+    }
+
+    if score <= 0.0 && !parsed_query.has_positive_terms() {
+        return 1.0;
     }
 
     score
@@ -334,6 +625,18 @@ mod tests {
         }
     }
 
+    fn make_chunk_at(path: &str, name: &str, kind: ItemKind, source: &str) -> IndexChunk {
+        IndexChunk {
+            path: path.to_string(),
+            start_line: 1,
+            end_line: 5,
+            kind,
+            name: name.to_string(),
+            parent_scope: None,
+            source: source.to_string(),
+        }
+    }
+
     #[test]
     fn test_exact_name_match_ranks_highest() {
         let index = vec![
@@ -381,6 +684,123 @@ mod tests {
         let results = codebase_search("process_request", &index, Some(10));
         assert!(!results.is_empty());
         assert_eq!(results[0].name, "handler");
+    }
+
+    #[test]
+    fn test_filter_only_query_returns_matching_chunks() {
+        let index = vec![
+            make_chunk_at(
+                "src/auth.rs",
+                "login_handler",
+                ItemKind::Function,
+                "fn login_handler() {}",
+            ),
+            make_chunk_at(
+                "src/model.rs",
+                "LoginState",
+                ItemKind::Struct,
+                "struct LoginState;",
+            ),
+        ];
+
+        let results = codebase_search("path:src/auth.rs kind:function", &index, Some(10));
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "login_handler");
+    }
+
+    #[test]
+    fn test_path_and_kind_filters_limit_results() {
+        let index = vec![
+            make_chunk_at(
+                "src/auth.rs",
+                "login_handler",
+                ItemKind::Function,
+                "fn login_handler() { authenticate(); }",
+            ),
+            make_chunk_at(
+                "src/ui.rs",
+                "login_handler",
+                ItemKind::Function,
+                "fn login_handler() { render(); }",
+            ),
+            make_chunk_at(
+                "src/auth.rs",
+                "LoginHandler",
+                ItemKind::Struct,
+                "struct LoginHandler;",
+            ),
+        ];
+
+        let results = codebase_search("login path:src/auth kind:function", &index, Some(10));
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].path, "src/auth.rs");
+        assert_eq!(results[0].kind_label, "function");
+    }
+
+    #[test]
+    fn test_lang_filter_uses_file_extension() {
+        let index = vec![
+            make_chunk_at(
+                "src/engine.rs",
+                "parse_config",
+                ItemKind::Function,
+                "fn parse_config() -> Result<()> { Ok(()) }",
+            ),
+            make_chunk_at(
+                "src/engine.py",
+                "parse_config",
+                ItemKind::Function,
+                "def parse_config():\n    return True",
+            ),
+        ];
+
+        let results = codebase_search("parse_config lang:python", &index, Some(10));
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].path, "src/engine.py");
+    }
+
+    #[test]
+    fn test_required_and_excluded_terms_are_enforced() {
+        let index = vec![
+            make_chunk_at(
+                "src/config.rs",
+                "reload_config",
+                ItemKind::Function,
+                "fn reload_config() { apply_reload(); }",
+            ),
+            make_chunk_at(
+                "src/legacy.rs",
+                "reload_config_legacy",
+                ItemKind::Function,
+                "fn reload_config_legacy() { legacy_reload(); }",
+            ),
+        ];
+
+        let results = codebase_search("+reload -legacy", &index, Some(10));
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "reload_config");
+    }
+
+    #[test]
+    fn test_quoted_phrase_matches_adjacent_terms() {
+        let index = vec![
+            make_chunk_at(
+                "src/auth.rs",
+                "login_handler",
+                ItemKind::Function,
+                "fn login_handler() { /* process request */ }",
+            ),
+            make_chunk_at(
+                "src/other.rs",
+                "reverse_handler",
+                ItemKind::Function,
+                "fn reverse_handler() { /* request process */ }",
+            ),
+        ];
+
+        let results = codebase_search("\"process request\"", &index, Some(10));
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "login_handler");
     }
 
     #[test]

--- a/src/tools/search.rs
+++ b/src/tools/search.rs
@@ -108,7 +108,10 @@ impl ChunkSearchFields {
     fn from_chunk(chunk: &IndexChunk) -> Self {
         Self {
             name_lower: chunk.name.to_ascii_lowercase(),
-            scope_lower: chunk.parent_scope.as_ref().map(|scope| scope.to_ascii_lowercase()),
+            scope_lower: chunk
+                .parent_scope
+                .as_ref()
+                .map(|scope| scope.to_ascii_lowercase()),
             source_lower: chunk.source.to_ascii_lowercase(),
             path_lower: chunk.path.to_ascii_lowercase(),
             kind_lower: chunk.kind.label().to_ascii_lowercase(),
@@ -336,8 +339,8 @@ fn normalize_kind_filter(value: &str) -> Option<String> {
     let normalized = value.trim().to_ascii_lowercase();
     match normalized.as_str() {
         "" => None,
-        "function" | "struct" | "class" | "interface" | "enum" | "impl" | "trait"
-        | "module" | "const" | "static" | "type" => Some(normalized),
+        "function" | "struct" | "class" | "interface" | "enum" | "impl" | "trait" | "module"
+        | "const" | "static" | "type" => Some(normalized),
         "typealias" => Some("type".to_string()),
         _ => Some(normalized),
     }
@@ -432,7 +435,10 @@ fn matches_positive_terms(fields: &ChunkSearchFields, parsed_query: &ParsedQuery
         return true;
     }
 
-    parsed_query.terms.iter().any(|term| fields.matches_term(term))
+    parsed_query
+        .terms
+        .iter()
+        .any(|term| fields.matches_term(term))
 }
 
 fn score_term(fields: &ChunkSearchFields, term: &str, required: bool) -> f64 {
@@ -455,10 +461,10 @@ fn score_term(fields: &ChunkSearchFields, term: &str, required: bool) -> f64 {
         score += 10.0;
     }
 
-    if let Some(scope_lower) = fields.scope_lower.as_deref() {
-        if scope_lower.contains(term) {
-            score += 12.0;
-        }
+    if let Some(scope_lower) = fields.scope_lower.as_deref()
+        && scope_lower.contains(term)
+    {
+        score += 12.0;
     }
 
     let count = fields.source_lower.matches(term).count();
@@ -487,10 +493,10 @@ fn score_chunk(chunk: &IndexChunk, parsed_query: &ParsedQuery, positive_query: &
             score += 30.0;
         }
 
-        if let Some(scope_lower) = fields.scope_lower.as_deref() {
-            if scope_lower.contains(&query_lower) || query_lower.contains(scope_lower) {
-                score += 20.0;
-            }
+        if let Some(scope_lower) = fields.scope_lower.as_deref()
+            && (scope_lower.contains(&query_lower) || query_lower.contains(scope_lower))
+        {
+            score += 20.0;
         }
     }
 

--- a/src/tools/search.rs
+++ b/src/tools/search.rs
@@ -92,6 +92,15 @@ impl ParsedQuery {
     fn has_positive_terms(&self) -> bool {
         !self.terms.is_empty() || !self.required_terms.is_empty()
     }
+
+    fn is_effectively_empty(&self) -> bool {
+        self.terms.is_empty()
+            && self.required_terms.is_empty()
+            && self.excluded_terms.is_empty()
+            && self.path_filters.is_empty()
+            && self.kind_filters.is_empty()
+            && self.lang_filters.is_empty()
+    }
 }
 
 #[derive(Debug)]
@@ -154,11 +163,14 @@ pub fn codebase_search(
     max_results: Option<usize>,
 ) -> Vec<SearchResult> {
     let cap = max_results.unwrap_or_else(max_results_default);
-    if query.is_empty() || index.is_empty() {
+    if query.trim().is_empty() || index.is_empty() {
         return Vec::new();
     }
 
     let parsed_query = ParsedQuery::parse(query);
+    if parsed_query.is_effectively_empty() {
+        return Vec::new();
+    }
     let positive_query = parsed_query.positive_query_text();
 
     let scored: Vec<(f64, usize)> = index
@@ -660,6 +672,22 @@ mod tests {
         let index = vec![make_chunk("foo", ItemKind::Function, "fn foo() {}")];
         let results = codebase_search("", &index, Some(10));
         assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_whitespace_or_quote_only_query_returns_empty() {
+        let index = vec![
+            make_chunk("foo", ItemKind::Function, "fn foo() {}"),
+            make_chunk("bar", ItemKind::Function, "fn bar() {}"),
+        ];
+        for query in ["   ", "\t\n", "\"\"", "\"   \"", "+", "-"] {
+            let results = codebase_search(query, &index, Some(10));
+            assert!(
+                results.is_empty(),
+                "query {query:?} should return no results, got {} results",
+                results.len()
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
This change teaches `codebase_search` to accept quoted phrases plus `+required`, `-excluded`, `path:`, `kind:`, and `lang:` filters, and updates the built-in tool descriptions and command docs so the syntax is discoverable.

## Motivation
The retrieval roadmap for vexcoder starts by extending the existing local `codebase_search` surface instead of introducing a second RAG subsystem. This first slice makes the current agent tool loop more precise while keeping the implementation deterministic and local.

## Approach
- parse `codebase_search` queries into positive terms, required terms, excluded terms, and path/kind/lang filters
- apply those filters before structural scoring and semantic merging
- tighten BM25 eligibility so quoted phrases do not receive false-positive boosts from reordered word matches
- add focused unit coverage for filter-only queries, path/kind/lang filters, required and excluded terms, and quoted phrases
- document the new query syntax in the tool schema, system prompt guidance, slash-command hint text, and operator docs

## Validation
- `cargo test --lib tools::search --no-fail-fast`
- `cargo test --lib scope_detail_prefers_builtin_tool_description --no-fail-fast`
- `git diff --check`

## Notes
- PR #433 was merged first so this branch is based on the updated `main`.
- The repo had no outstanding bot review findings on open PRs at the time this follow-up branch was cut.
