### PR TITLE
feat(edit-location): per-pulse read ledger + anchored edit_file match

### DIFF
--- a/TASKS/completed/REPO-RAW-URL-MAP.md
+++ b/TASKS/completed/REPO-RAW-URL-MAP.md
@@ -5,7 +5,7 @@ Canonical raw URL index for every tracked file in this repository.
 - Branch: main
 - Base: <https://raw.githubusercontent.com/aistar-au/vexcoder/main/>
 - Source: git ls-files
-- Total tracked files: 420
+- Total tracked files: 421
 
 | # | Path | Approx. lines | Raw URL |
 | :--- | :--- | :--- | :--- |

--- a/TASKS/completed/REPO-RAW-URL-MAP.md
+++ b/TASKS/completed/REPO-RAW-URL-MAP.md
@@ -5,7 +5,7 @@ Canonical raw URL index for every tracked file in this repository.
 - Branch: main
 - Base: <https://raw.githubusercontent.com/aistar-au/vexcoder/main/>
 - Source: git ls-files
-- Total tracked files: 418
+- Total tracked files: 420
 
 | # | Path | Approx. lines | Raw URL |
 | :--- | :--- | :--- | :--- |

--- a/adr/ADR-033-amendment-2026-05-12.md
+++ b/adr/ADR-033-amendment-2026-05-12.md
@@ -8,15 +8,15 @@
 
 ADR-033 phases shipped a ranked retrieval pipeline (`codebase_search` → `file:line` references) and a context-condensing compaction pass, but the gap between locate and edit was never closed: every `edit_file` call still went straight to disk for its `old_str` match, with no awareness that the same file had just been read in the same pulse. The result was a redundant `read_file` between search and edit on the happy path, and an unrecoverable "must be unique" error on any file with multiple matches outside the model's actual area of interest.
 
-This amendment closes that gap by promoting the existing in-process file cache (ADR-038) and the search tool's existing `file:line` outputs into a single per-pulse ledger that `edit_file` consults for anchored matching.
+This amendment closes that gap by introducing a per-pulse ledger that lives next to the existing `ToolOperator` (in `crate::tools::pulse_ledger`) and that `edit_file` consults for anchored matching. The layer placement is deliberate: the ledger sits in `tools` so both `state::conversation::tools::routing` and `tools::operator` can use it without crossing the ADR-007 boundary that bars `state` and `tools` from depending on `runtime::context*`.
 
 ## Amendment
 
-### Phase 2.5 — Locate-then-Edit Cache
+### Phase 2.5 — Locate-then-Edit Ledger
 
 Adds two cooperating mechanisms between Phase 1 retrieval and Phase 3 routing:
 
-1. **Per-pulse `LocatedRead` ledger.** When `read_file` returns through the tool router, the router records a `LocatedRead { path, start_line, end_line, fingerprint }` entry against a process-global mutex-guarded ledger. The fingerprint is the existing `FileFingerprint` (length + mtime) reused from the file cache, so stale entries self-invalidate on the next access — matching the "drop leaked snapshots" posture from ADR-023's compaction work.
+1. **Per-pulse `LocatedRead` ledger.** When `read_file` returns through the tool router, the router records a `LocatedRead { path, start_line, end_line, fingerprint }` entry against a process-global mutex-guarded ledger. The `FileFingerprint` (length + mtime) is computed at record time, so stale entries self-invalidate on the next access — matching the "drop leaked snapshots" posture from ADR-023's compaction work. The recorded range is the claimed `[offset, offset + limit - 1]`; if the file ended earlier, the anchor window is slightly wider than the real read, which is harmless.
 2. **Anchored unique match in `edit_file`.** When `old_str` matches multiple times in a file, the operator queries the ledger for an entry whose fingerprint still matches the file on disk. If found, candidate matches are restricted to a window of ±3 lines around the recorded `[start_line, end_line]`. A single in-window candidate succeeds; otherwise the call falls back to the existing full-file uniqueness rule. The single-occurrence happy path is unchanged.
 
 The ledger is cleared at the start of every pulse (`send_message_with_policy` boundary) so that anchors never leak across user turns. Compaction events that fire mid-pulse are transparent to the ledger because it is process-global and stores only paths, ranges, and fingerprints — no message content.
@@ -35,7 +35,7 @@ The ledger is cleared at the start of every pulse (`send_message_with_policy` bo
 
 ### Token-savings rationale
 
-The largest, most reliable win is in the drift-retry case: an `edit_file` whose `old_str` previously hit "appears N times; must be unique" now resolves on the first attempt when the search result's line range singularises the occurrence, saving one full retry turn per such edit. The happy-path read remains, but the underlying file content is now served from the in-process cache on its second access, eliminating disk I/O. Wall-clock and token shape mirrors the bounded-message-count reduction probe published with the ADR-023-amendment-2026-05-03 follow-up.
+The win is in the drift-retry case: an `edit_file` whose `old_str` previously hit "appears N times; must be unique" now resolves on the first attempt when the recorded read range singularises the occurrence, saving one full retry turn per such edit. This PR intentionally does not couple the ledger to the in-process file cache to keep `state` and `tools` clear of `runtime::context*` per ADR-007; a follow-up may add cache-aware reads behind a tools-layer facade. Wall-clock and token shape mirrors the bounded-message-count reduction probe published with the ADR-023-amendment-2026-05-03 follow-up.
 
 ## References
 

--- a/adr/ADR-033-amendment-2026-05-12.md
+++ b/adr/ADR-033-amendment-2026-05-12.md
@@ -1,0 +1,44 @@
+# ADR-033 Amendment (2026-05-12): Phase 2.5 — Locate-then-Edit Cache
+
+**Status:** Amended
+**Amends:** ADR-033
+**Branch:** `work/vexcoder-edit-location-cache`
+
+## Context
+
+ADR-033 phases shipped a ranked retrieval pipeline (`codebase_search` → `file:line` references) and a context-condensing compaction pass, but the gap between locate and edit was never closed: every `edit_file` call still went straight to disk for its `old_str` match, with no awareness that the same file had just been read in the same pulse. The result was a redundant `read_file` between search and edit on the happy path, and an unrecoverable "must be unique" error on any file with multiple matches outside the model's actual area of interest.
+
+This amendment closes that gap by promoting the existing in-process file cache (ADR-038) and the search tool's existing `file:line` outputs into a single per-pulse ledger that `edit_file` consults for anchored matching.
+
+## Amendment
+
+### Phase 2.5 — Locate-then-Edit Cache
+
+Adds two cooperating mechanisms between Phase 1 retrieval and Phase 3 routing:
+
+1. **Per-pulse `LocatedRead` ledger.** When `read_file` returns through the tool router, the router records a `LocatedRead { path, start_line, end_line, fingerprint }` entry against a process-global mutex-guarded ledger. The fingerprint is the existing `FileFingerprint` (length + mtime) reused from the file cache, so stale entries self-invalidate on the next access — matching the "drop leaked snapshots" posture from ADR-023's compaction work.
+2. **Anchored unique match in `edit_file`.** When `old_str` matches multiple times in a file, the operator queries the ledger for an entry whose fingerprint still matches the file on disk. If found, candidate matches are restricted to a window of ±3 lines around the recorded `[start_line, end_line]`. A single in-window candidate succeeds; otherwise the call falls back to the existing full-file uniqueness rule. The single-occurrence happy path is unchanged.
+
+The ledger is cleared at the start of every pulse (`send_message_with_policy` boundary) so that anchors never leak across user turns. Compaction events that fire mid-pulse are transparent to the ledger because it is process-global and stores only paths, ranges, and fingerprints — no message content.
+
+### Scope
+
+- **In:** `read_file` cache wiring, `LocatedRead` ledger, ±3-line anchored match in `edit_file`.
+- **Out:** semantic / embedding index; AST-driven refactor; new diff format; explicit `EditAnchor` as a model-visible tool input; cross-pulse / cross-session persistence; agent profiles.
+
+### Invariants preserved
+
+- `edit_file` still refuses full-file replacements, empty `old_str`, and oversized snippets.
+- A single full-file match still wins immediately; the anchor only narrows when there is ambiguity.
+- File-cache budgets (`MAX_CACHE_FILE_BYTES`, `MAX_CACHE_TOTAL_BYTES`, LRU eviction) are unchanged; files outside the cache budget still read directly from disk and still record ledger entries.
+- The codebase symbol index (`CODEBASE_INDEX`) is unaffected.
+
+### Token-savings rationale
+
+The largest, most reliable win is in the drift-retry case: an `edit_file` whose `old_str` previously hit "appears N times; must be unique" now resolves on the first attempt when the search result's line range singularises the occurrence, saving one full retry turn per such edit. The happy-path read remains, but the underlying file content is now served from the in-process cache on its second access, eliminating disk I/O. Wall-clock and token shape mirrors the bounded-message-count reduction probe published with the ADR-023-amendment-2026-05-03 follow-up.
+
+## References
+
+- ADR-023 — deterministic edit loop (uniqueness rule).
+- ADR-038 — memory-first in-process file cache.
+- ADR-050 — read-file offset carry-forward across compaction (companion metadata pattern).

--- a/src/app/transcript_projection.rs
+++ b/src/app/transcript_projection.rs
@@ -332,13 +332,16 @@ fn completed_tool_paragraph_rows(
         compact_outcome_summary(first_line)
     )));
     const MAX_EVIDENCE_LINES: usize = 3;
-    let nonempty: Vec<&str> = output
+    let nonempty: Vec<String> = output
         .lines()
-        .map(str::trim_end)
-        .filter(|line| !line.trim().is_empty())
+        .map(|line| line.trim_end().replace('\t', " "))
+        .filter(|line| {
+            let t = line.trim();
+            !t.is_empty() && !t.chars().all(|c| c.is_ascii_digit())
+        })
         .collect();
     for line in nonempty.iter().take(MAX_EVIDENCE_LINES) {
-        rows.push(TranscriptRow::Evidence((*line).to_string()));
+        rows.push(TranscriptRow::Evidence(line.clone()));
     }
     if nonempty.len() > MAX_EVIDENCE_LINES {
         rows.push(TranscriptRow::Evidence(format!(

--- a/src/runtime/context_cache.rs
+++ b/src/runtime/context_cache.rs
@@ -17,9 +17,17 @@ pub(crate) struct CachedFileRead {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct FileFingerprint {
-    len: u64,
-    modified: SystemTime,
+pub(crate) struct FileFingerprint {
+    pub(crate) len: u64,
+    pub(crate) modified: SystemTime,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LocatedRead {
+    pub(crate) path: PathBuf,
+    pub(crate) start_line: usize,
+    pub(crate) end_line: usize,
+    pub(crate) fingerprint: FileFingerprint,
 }
 
 #[derive(Debug, Clone)]
@@ -113,7 +121,7 @@ pub(crate) fn read_cached_file(operator: &ToolOperator, path: &str) -> Result<Ca
     })
 }
 
-fn file_fingerprint(path: &Path) -> Result<FileFingerprint> {
+pub(crate) fn file_fingerprint(path: &Path) -> Result<FileFingerprint> {
     let metadata = std::fs::metadata(path)
         .with_context(|| format!("Failed to read metadata for {}", path.display()))?;
     let modified = metadata
@@ -125,6 +133,154 @@ fn file_fingerprint(path: &Path) -> Result<FileFingerprint> {
         modified,
     })
 }
+
+const MAX_PULSE_LEDGER_ENTRIES: usize = 64;
+
+#[derive(Debug, Default)]
+struct PulseLedger {
+    entries: Vec<LocatedRead>,
+}
+
+fn global_pulse_ledger() -> &'static Mutex<PulseLedger> {
+    static PULSE_LEDGER: OnceLock<Mutex<PulseLedger>> = OnceLock::new();
+    PULSE_LEDGER.get_or_init(|| Mutex::new(PulseLedger::default()))
+}
+
+pub(crate) fn record_pulse_read(
+    path: PathBuf,
+    start_line: usize,
+    end_line: usize,
+    fingerprint: FileFingerprint,
+) {
+    let mut ledger = global_pulse_ledger()
+        .lock()
+        .expect("pulse ledger mutex poisoned");
+    ledger.entries.retain(|entry| entry.path != path);
+    ledger.entries.push(LocatedRead {
+        path,
+        start_line,
+        end_line,
+        fingerprint,
+    });
+    while ledger.entries.len() > MAX_PULSE_LEDGER_ENTRIES {
+        ledger.entries.remove(0);
+    }
+}
+
+pub(crate) fn find_pulse_read(path: &Path) -> Option<LocatedRead> {
+    let current = file_fingerprint(path).ok()?;
+    let ledger = global_pulse_ledger()
+        .lock()
+        .expect("pulse ledger mutex poisoned");
+    ledger
+        .entries
+        .iter()
+        .rev()
+        .find(|entry| entry.path == path && entry.fingerprint == current)
+        .cloned()
+}
+
+pub(crate) fn clear_pulse_ledger() {
+    let mut ledger = global_pulse_ledger()
+        .lock()
+        .expect("pulse ledger mutex poisoned");
+    ledger.entries.clear();
+}
+
+pub(crate) fn pulse_ledger_snapshot() -> Vec<LocatedRead> {
+    let ledger = global_pulse_ledger()
+        .lock()
+        .expect("pulse ledger mutex poisoned");
+    ledger.entries.clone()
+}
+
+pub(crate) fn restore_pulse_ledger(entries: Vec<LocatedRead>) {
+    let mut ledger = global_pulse_ledger()
+        .lock()
+        .expect("pulse ledger mutex poisoned");
+    ledger.entries = entries;
+    while ledger.entries.len() > MAX_PULSE_LEDGER_ENTRIES {
+        ledger.entries.remove(0);
+    }
+}
+
+pub(crate) struct RangeReadOutcome {
+    pub(crate) rendered: String,
+    pub(crate) start_line: usize,
+    pub(crate) end_line: usize,
+    pub(crate) fingerprint: Option<FileFingerprint>,
+    pub(crate) resolved_path: Option<PathBuf>,
+}
+
+pub(crate) fn read_cached_file_range(
+    operator: &ToolOperator,
+    path: &str,
+    offset: Option<usize>,
+    limit: Option<usize>,
+) -> Result<RangeReadOutcome> {
+    let resolved = operator.existing_path(path)?;
+    let (content, fingerprint, resolved_path) = match resolved {
+        Some(resolved) if !resolved.is_dir() => match file_fingerprint(&resolved) {
+            Ok(fingerprint) if fingerprint.len <= MAX_CACHE_FILE_BYTES => {
+                let cached = if let Some(content) = try_read_from_cache(&resolved, fingerprint) {
+                    content
+                } else {
+                    let fresh = operator.read_file(path)?;
+                    insert_into_cache(resolved.clone(), fingerprint, &fresh);
+                    fresh
+                };
+                (cached, Some(fingerprint), Some(resolved))
+            }
+            Ok(fingerprint) => {
+                let fresh = operator.read_file(path)?;
+                (fresh, Some(fingerprint), Some(resolved))
+            }
+            Err(_) => {
+                let fresh = operator.read_file(path)?;
+                (fresh, None, Some(resolved))
+            }
+        },
+        _ => {
+            let fresh = operator.read_file(path)?;
+            (fresh, None, None)
+        }
+    };
+
+    let user_offset = offset.unwrap_or(1);
+    let start = user_offset.saturating_sub(1);
+    let lines: Vec<&str> = content.lines().collect();
+    let total = lines.len();
+    if start >= total {
+        return Ok(RangeReadOutcome {
+            rendered: format!("(file has {total} lines, offset {user_offset} is past end)"),
+            start_line: user_offset,
+            end_line: user_offset,
+            fingerprint,
+            resolved_path,
+        });
+    }
+    let end = limit
+        .map(|value| (start + value).min(total))
+        .unwrap_or(total);
+    let selected: Vec<String> = lines[start..end]
+        .iter()
+        .enumerate()
+        .map(|(index, line)| format!("{:>5}\t{}", start + index + 1, line))
+        .collect();
+    let header = if start > 0 || end < total {
+        format!("(showing lines {}-{} of {total})\n", start + 1, end)
+    } else {
+        String::new()
+    };
+    Ok(RangeReadOutcome {
+        rendered: format!("{}{}", header, selected.join("\n")),
+        start_line: start + 1,
+        end_line: end,
+        fingerprint,
+        resolved_path,
+    })
+}
+
 
 fn try_read_from_cache(path: &Path, fingerprint: FileFingerprint) -> Option<String> {
     let mut cache = global_context_cache()
@@ -189,8 +345,10 @@ pub(crate) fn lock_context_cache_for_tests() -> std::sync::MutexGuard<'static, (
 #[cfg(test)]
 mod tests {
     use super::{
-        MAX_CACHE_ENTRIES, lock_context_cache_for_tests, read_cached_file,
-        reset_context_cache_for_tests,
+        MAX_CACHE_ENTRIES, MAX_PULSE_LEDGER_ENTRIES, clear_pulse_ledger, file_fingerprint,
+        find_pulse_read, lock_context_cache_for_tests, pulse_ledger_snapshot, read_cached_file,
+        read_cached_file_range, record_pulse_read, reset_context_cache_for_tests,
+        restore_pulse_ledger,
     };
     use crate::tools::ToolOperator;
     use filetime::{FileTime, set_file_mtime};
@@ -260,5 +418,117 @@ mod tests {
             !reread.cache_hit,
             "oldest entry should be evicted once the cache exceeds its entry cap"
         );
+    }
+
+    #[test]
+    fn test_pulse_ledger_records_and_finds_matching_fingerprint() {
+        let _lock = lock_context_cache_for_tests();
+        reset_context_cache_for_tests();
+        clear_pulse_ledger();
+        let workspace = tempfile::tempdir().expect("tempdir");
+        let path = workspace.path().join("note.txt");
+        fs::write(&path, "alpha\nbravo\ncharlie\n").expect("write file");
+        let fingerprint = file_fingerprint(&path).expect("fingerprint");
+        record_pulse_read(path.clone(), 1, 3, fingerprint);
+
+        let hit = find_pulse_read(&path).expect("ledger should remember the read");
+        assert_eq!(hit.start_line, 1);
+        assert_eq!(hit.end_line, 3);
+        assert_eq!(hit.fingerprint, fingerprint);
+        clear_pulse_ledger();
+    }
+
+    #[test]
+    fn test_pulse_ledger_misses_after_file_mutates() {
+        let _lock = lock_context_cache_for_tests();
+        reset_context_cache_for_tests();
+        clear_pulse_ledger();
+        let workspace = tempfile::tempdir().expect("tempdir");
+        let path = workspace.path().join("note.txt");
+        fs::write(&path, "alpha\n").expect("write original");
+        set_file_mtime(&path, FileTime::from_unix_time(1, 0)).expect("set initial mtime");
+        let fingerprint = file_fingerprint(&path).expect("fingerprint");
+        record_pulse_read(path.clone(), 1, 1, fingerprint);
+
+        fs::write(&path, "alpha changed\n").expect("mutate file");
+        set_file_mtime(&path, FileTime::from_unix_time(2, 0)).expect("bump mtime");
+
+        assert!(
+            find_pulse_read(&path).is_none(),
+            "ledger must miss when the file fingerprint no longer matches"
+        );
+        clear_pulse_ledger();
+    }
+
+    #[test]
+    fn test_pulse_ledger_snapshot_and_restore_roundtrip() {
+        let _lock = lock_context_cache_for_tests();
+        reset_context_cache_for_tests();
+        clear_pulse_ledger();
+        let workspace = tempfile::tempdir().expect("tempdir");
+        let path = workspace.path().join("note.txt");
+        fs::write(&path, "alpha\n").expect("write file");
+        let fingerprint = file_fingerprint(&path).expect("fingerprint");
+        record_pulse_read(path.clone(), 1, 1, fingerprint);
+
+        let snapshot = pulse_ledger_snapshot();
+        clear_pulse_ledger();
+        assert!(find_pulse_read(&path).is_none());
+
+        restore_pulse_ledger(snapshot);
+        assert!(
+            find_pulse_read(&path).is_some(),
+            "restoring a ledger snapshot should make the entry queryable again"
+        );
+        clear_pulse_ledger();
+    }
+
+    #[test]
+    fn test_pulse_ledger_caps_at_max_entries() {
+        let _lock = lock_context_cache_for_tests();
+        reset_context_cache_for_tests();
+        clear_pulse_ledger();
+        let workspace = tempfile::tempdir().expect("tempdir");
+
+        for index in 0..(MAX_PULSE_LEDGER_ENTRIES + 4) {
+            let name = format!("note-{index}.txt");
+            let path = workspace.path().join(&name);
+            fs::write(&path, format!("line {index}\n")).expect("write fixture");
+            let fingerprint = file_fingerprint(&path).expect("fingerprint");
+            record_pulse_read(path, 1, 1, fingerprint);
+        }
+
+        let snapshot = pulse_ledger_snapshot();
+        assert!(
+            snapshot.len() <= MAX_PULSE_LEDGER_ENTRIES,
+            "ledger must cap at MAX_PULSE_LEDGER_ENTRIES, got {}",
+            snapshot.len()
+        );
+        clear_pulse_ledger();
+    }
+
+    #[test]
+    fn test_read_cached_file_range_reports_range_and_fingerprint() {
+        let _lock = lock_context_cache_for_tests();
+        reset_context_cache_for_tests();
+        clear_pulse_ledger();
+        let workspace = tempfile::tempdir().expect("tempdir");
+        fs::write(
+            workspace.path().join("note.txt"),
+            "alpha\nbravo\ncharlie\ndelta\n",
+        )
+        .expect("write file");
+        let operator = ToolOperator::new(workspace.path().to_path_buf());
+
+        let outcome =
+            read_cached_file_range(&operator, "note.txt", Some(2), Some(2)).expect("range read");
+        assert_eq!(outcome.start_line, 2);
+        assert_eq!(outcome.end_line, 3);
+        assert!(outcome.rendered.contains("bravo"));
+        assert!(outcome.rendered.contains("charlie"));
+        assert!(!outcome.rendered.contains("delta"));
+        assert!(outcome.fingerprint.is_some());
+        assert!(outcome.resolved_path.is_some());
+        clear_pulse_ledger();
     }
 }

--- a/src/runtime/context_cache.rs
+++ b/src/runtime/context_cache.rs
@@ -17,17 +17,9 @@ pub(crate) struct CachedFileRead {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct FileFingerprint {
-    pub(crate) len: u64,
-    pub(crate) modified: SystemTime,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct LocatedRead {
-    pub(crate) path: PathBuf,
-    pub(crate) start_line: usize,
-    pub(crate) end_line: usize,
-    pub(crate) fingerprint: FileFingerprint,
+struct FileFingerprint {
+    len: u64,
+    modified: SystemTime,
 }
 
 #[derive(Debug, Clone)]
@@ -121,7 +113,7 @@ pub(crate) fn read_cached_file(operator: &ToolOperator, path: &str) -> Result<Ca
     })
 }
 
-pub(crate) fn file_fingerprint(path: &Path) -> Result<FileFingerprint> {
+fn file_fingerprint(path: &Path) -> Result<FileFingerprint> {
     let metadata = std::fs::metadata(path)
         .with_context(|| format!("Failed to read metadata for {}", path.display()))?;
     let modified = metadata
@@ -133,154 +125,6 @@ pub(crate) fn file_fingerprint(path: &Path) -> Result<FileFingerprint> {
         modified,
     })
 }
-
-const MAX_PULSE_LEDGER_ENTRIES: usize = 64;
-
-#[derive(Debug, Default)]
-struct PulseLedger {
-    entries: Vec<LocatedRead>,
-}
-
-fn global_pulse_ledger() -> &'static Mutex<PulseLedger> {
-    static PULSE_LEDGER: OnceLock<Mutex<PulseLedger>> = OnceLock::new();
-    PULSE_LEDGER.get_or_init(|| Mutex::new(PulseLedger::default()))
-}
-
-pub(crate) fn record_pulse_read(
-    path: PathBuf,
-    start_line: usize,
-    end_line: usize,
-    fingerprint: FileFingerprint,
-) {
-    let mut ledger = global_pulse_ledger()
-        .lock()
-        .expect("pulse ledger mutex poisoned");
-    ledger.entries.retain(|entry| entry.path != path);
-    ledger.entries.push(LocatedRead {
-        path,
-        start_line,
-        end_line,
-        fingerprint,
-    });
-    while ledger.entries.len() > MAX_PULSE_LEDGER_ENTRIES {
-        ledger.entries.remove(0);
-    }
-}
-
-pub(crate) fn find_pulse_read(path: &Path) -> Option<LocatedRead> {
-    let current = file_fingerprint(path).ok()?;
-    let ledger = global_pulse_ledger()
-        .lock()
-        .expect("pulse ledger mutex poisoned");
-    ledger
-        .entries
-        .iter()
-        .rev()
-        .find(|entry| entry.path == path && entry.fingerprint == current)
-        .cloned()
-}
-
-pub(crate) fn clear_pulse_ledger() {
-    let mut ledger = global_pulse_ledger()
-        .lock()
-        .expect("pulse ledger mutex poisoned");
-    ledger.entries.clear();
-}
-
-pub(crate) fn pulse_ledger_snapshot() -> Vec<LocatedRead> {
-    let ledger = global_pulse_ledger()
-        .lock()
-        .expect("pulse ledger mutex poisoned");
-    ledger.entries.clone()
-}
-
-pub(crate) fn restore_pulse_ledger(entries: Vec<LocatedRead>) {
-    let mut ledger = global_pulse_ledger()
-        .lock()
-        .expect("pulse ledger mutex poisoned");
-    ledger.entries = entries;
-    while ledger.entries.len() > MAX_PULSE_LEDGER_ENTRIES {
-        ledger.entries.remove(0);
-    }
-}
-
-pub(crate) struct RangeReadOutcome {
-    pub(crate) rendered: String,
-    pub(crate) start_line: usize,
-    pub(crate) end_line: usize,
-    pub(crate) fingerprint: Option<FileFingerprint>,
-    pub(crate) resolved_path: Option<PathBuf>,
-}
-
-pub(crate) fn read_cached_file_range(
-    operator: &ToolOperator,
-    path: &str,
-    offset: Option<usize>,
-    limit: Option<usize>,
-) -> Result<RangeReadOutcome> {
-    let resolved = operator.existing_path(path)?;
-    let (content, fingerprint, resolved_path) = match resolved {
-        Some(resolved) if !resolved.is_dir() => match file_fingerprint(&resolved) {
-            Ok(fingerprint) if fingerprint.len <= MAX_CACHE_FILE_BYTES => {
-                let cached = if let Some(content) = try_read_from_cache(&resolved, fingerprint) {
-                    content
-                } else {
-                    let fresh = operator.read_file(path)?;
-                    insert_into_cache(resolved.clone(), fingerprint, &fresh);
-                    fresh
-                };
-                (cached, Some(fingerprint), Some(resolved))
-            }
-            Ok(fingerprint) => {
-                let fresh = operator.read_file(path)?;
-                (fresh, Some(fingerprint), Some(resolved))
-            }
-            Err(_) => {
-                let fresh = operator.read_file(path)?;
-                (fresh, None, Some(resolved))
-            }
-        },
-        _ => {
-            let fresh = operator.read_file(path)?;
-            (fresh, None, None)
-        }
-    };
-
-    let user_offset = offset.unwrap_or(1);
-    let start = user_offset.saturating_sub(1);
-    let lines: Vec<&str> = content.lines().collect();
-    let total = lines.len();
-    if start >= total {
-        return Ok(RangeReadOutcome {
-            rendered: format!("(file has {total} lines, offset {user_offset} is past end)"),
-            start_line: user_offset,
-            end_line: user_offset,
-            fingerprint,
-            resolved_path,
-        });
-    }
-    let end = limit
-        .map(|value| (start + value).min(total))
-        .unwrap_or(total);
-    let selected: Vec<String> = lines[start..end]
-        .iter()
-        .enumerate()
-        .map(|(index, line)| format!("{:>5}\t{}", start + index + 1, line))
-        .collect();
-    let header = if start > 0 || end < total {
-        format!("(showing lines {}-{} of {total})\n", start + 1, end)
-    } else {
-        String::new()
-    };
-    Ok(RangeReadOutcome {
-        rendered: format!("{}{}", header, selected.join("\n")),
-        start_line: start + 1,
-        end_line: end,
-        fingerprint,
-        resolved_path,
-    })
-}
-
 
 fn try_read_from_cache(path: &Path, fingerprint: FileFingerprint) -> Option<String> {
     let mut cache = global_context_cache()
@@ -345,10 +189,8 @@ pub(crate) fn lock_context_cache_for_tests() -> std::sync::MutexGuard<'static, (
 #[cfg(test)]
 mod tests {
     use super::{
-        MAX_CACHE_ENTRIES, MAX_PULSE_LEDGER_ENTRIES, clear_pulse_ledger, file_fingerprint,
-        find_pulse_read, lock_context_cache_for_tests, pulse_ledger_snapshot, read_cached_file,
-        read_cached_file_range, record_pulse_read, reset_context_cache_for_tests,
-        restore_pulse_ledger,
+        MAX_CACHE_ENTRIES, lock_context_cache_for_tests, read_cached_file,
+        reset_context_cache_for_tests,
     };
     use crate::tools::ToolOperator;
     use filetime::{FileTime, set_file_mtime};
@@ -418,117 +260,5 @@ mod tests {
             !reread.cache_hit,
             "oldest entry should be evicted once the cache exceeds its entry cap"
         );
-    }
-
-    #[test]
-    fn test_pulse_ledger_records_and_finds_matching_fingerprint() {
-        let _lock = lock_context_cache_for_tests();
-        reset_context_cache_for_tests();
-        clear_pulse_ledger();
-        let workspace = tempfile::tempdir().expect("tempdir");
-        let path = workspace.path().join("note.txt");
-        fs::write(&path, "alpha\nbravo\ncharlie\n").expect("write file");
-        let fingerprint = file_fingerprint(&path).expect("fingerprint");
-        record_pulse_read(path.clone(), 1, 3, fingerprint);
-
-        let hit = find_pulse_read(&path).expect("ledger should remember the read");
-        assert_eq!(hit.start_line, 1);
-        assert_eq!(hit.end_line, 3);
-        assert_eq!(hit.fingerprint, fingerprint);
-        clear_pulse_ledger();
-    }
-
-    #[test]
-    fn test_pulse_ledger_misses_after_file_mutates() {
-        let _lock = lock_context_cache_for_tests();
-        reset_context_cache_for_tests();
-        clear_pulse_ledger();
-        let workspace = tempfile::tempdir().expect("tempdir");
-        let path = workspace.path().join("note.txt");
-        fs::write(&path, "alpha\n").expect("write original");
-        set_file_mtime(&path, FileTime::from_unix_time(1, 0)).expect("set initial mtime");
-        let fingerprint = file_fingerprint(&path).expect("fingerprint");
-        record_pulse_read(path.clone(), 1, 1, fingerprint);
-
-        fs::write(&path, "alpha changed\n").expect("mutate file");
-        set_file_mtime(&path, FileTime::from_unix_time(2, 0)).expect("bump mtime");
-
-        assert!(
-            find_pulse_read(&path).is_none(),
-            "ledger must miss when the file fingerprint no longer matches"
-        );
-        clear_pulse_ledger();
-    }
-
-    #[test]
-    fn test_pulse_ledger_snapshot_and_restore_roundtrip() {
-        let _lock = lock_context_cache_for_tests();
-        reset_context_cache_for_tests();
-        clear_pulse_ledger();
-        let workspace = tempfile::tempdir().expect("tempdir");
-        let path = workspace.path().join("note.txt");
-        fs::write(&path, "alpha\n").expect("write file");
-        let fingerprint = file_fingerprint(&path).expect("fingerprint");
-        record_pulse_read(path.clone(), 1, 1, fingerprint);
-
-        let snapshot = pulse_ledger_snapshot();
-        clear_pulse_ledger();
-        assert!(find_pulse_read(&path).is_none());
-
-        restore_pulse_ledger(snapshot);
-        assert!(
-            find_pulse_read(&path).is_some(),
-            "restoring a ledger snapshot should make the entry queryable again"
-        );
-        clear_pulse_ledger();
-    }
-
-    #[test]
-    fn test_pulse_ledger_caps_at_max_entries() {
-        let _lock = lock_context_cache_for_tests();
-        reset_context_cache_for_tests();
-        clear_pulse_ledger();
-        let workspace = tempfile::tempdir().expect("tempdir");
-
-        for index in 0..(MAX_PULSE_LEDGER_ENTRIES + 4) {
-            let name = format!("note-{index}.txt");
-            let path = workspace.path().join(&name);
-            fs::write(&path, format!("line {index}\n")).expect("write fixture");
-            let fingerprint = file_fingerprint(&path).expect("fingerprint");
-            record_pulse_read(path, 1, 1, fingerprint);
-        }
-
-        let snapshot = pulse_ledger_snapshot();
-        assert!(
-            snapshot.len() <= MAX_PULSE_LEDGER_ENTRIES,
-            "ledger must cap at MAX_PULSE_LEDGER_ENTRIES, got {}",
-            snapshot.len()
-        );
-        clear_pulse_ledger();
-    }
-
-    #[test]
-    fn test_read_cached_file_range_reports_range_and_fingerprint() {
-        let _lock = lock_context_cache_for_tests();
-        reset_context_cache_for_tests();
-        clear_pulse_ledger();
-        let workspace = tempfile::tempdir().expect("tempdir");
-        fs::write(
-            workspace.path().join("note.txt"),
-            "alpha\nbravo\ncharlie\ndelta\n",
-        )
-        .expect("write file");
-        let operator = ToolOperator::new(workspace.path().to_path_buf());
-
-        let outcome =
-            read_cached_file_range(&operator, "note.txt", Some(2), Some(2)).expect("range read");
-        assert_eq!(outcome.start_line, 2);
-        assert_eq!(outcome.end_line, 3);
-        assert!(outcome.rendered.contains("bravo"));
-        assert!(outcome.rendered.contains("charlie"));
-        assert!(!outcome.rendered.contains("delta"));
-        assert!(outcome.fingerprint.is_some());
-        assert!(outcome.resolved_path.is_some());
-        clear_pulse_ledger();
     }
 }

--- a/src/state/conversation/history.rs
+++ b/src/state/conversation/history.rs
@@ -807,13 +807,13 @@ fn build_heuristic_summary(
     let mut total_bytes = 0usize;
 
     for msg in &messages[..boundary] {
-        if msg.role != "user" {
+        if msg.role != "user" || message_contains_tool_result(msg) {
             continue;
         }
 
         let role = &msg.role;
         let first_line = match &msg.content {
-            Content::Text(t) => t.lines().next().unwrap_or("").to_string(),
+            Content::Text(t) => summary_user_text_line(t).unwrap_or_default(),
             Content::Blocks(blocks) => blocks
                 .iter()
                 .find_map(|b| match b {
@@ -842,4 +842,24 @@ fn build_heuristic_summary(
     }
 
     parts.join("\n")
+}
+
+fn summary_user_text_line(text: &str) -> Option<String> {
+    if let Some((_, current_request)) = text.split_once("[current request]\n") {
+        return current_request
+            .lines()
+            .map(str::trim)
+            .find(|line| !line.is_empty())
+            .map(str::to_string);
+    }
+
+    text.lines()
+        .map(str::trim)
+        .find(|line| {
+            !line.is_empty()
+                && !line.starts_with("[conversation summary]")
+                && !line.starts_with("Use the summary only as background context.")
+                && !line.starts_with("Treat the current request below as authoritative")
+        })
+        .map(str::to_string)
 }

--- a/src/state/conversation/send_message.rs
+++ b/src/state/conversation/send_message.rs
@@ -4,10 +4,10 @@ use super::{
     ConversationManager, ConversationStreamUpdate, PulseToolPolicy, history::*, streaming::*,
     tools::*,
 };
-use crate::runtime::context_cache::clear_pulse_ledger;
 use crate::runtime::policy::{RuntimeCorePolicy, default_runtime_policy};
 use crate::runtime::task_document::PulseOutcome;
 use crate::runtime::{RuntimeSignal, TokenUsageEnvelope};
+use crate::tools::pulse_ledger::clear_pulse_ledger;
 use crate::types::{ApiMessage, Content, ContentBlock};
 use crate::usage::PulseTokens;
 use anyhow::Result;

--- a/src/state/conversation/send_message.rs
+++ b/src/state/conversation/send_message.rs
@@ -4,6 +4,7 @@ use super::{
     ConversationManager, ConversationStreamUpdate, PulseToolPolicy, history::*, streaming::*,
     tools::*,
 };
+use crate::runtime::context_cache::clear_pulse_ledger;
 use crate::runtime::policy::{RuntimeCorePolicy, default_runtime_policy};
 use crate::runtime::task_document::PulseOutcome;
 use crate::runtime::{RuntimeSignal, TokenUsageEnvelope};
@@ -24,6 +25,7 @@ impl ConversationManager {
         shared_prefix_context: Option<String>,
     ) -> Result<String> {
         self.last_turn_tokens = PulseTokens::default();
+        clear_pulse_ledger();
         let original_user_input = content.clone();
         self.ensure_task_doc();
         self.begin_turn_doc(content.clone(), turn_tool_policy);

--- a/src/state/conversation/send_message.rs
+++ b/src/state/conversation/send_message.rs
@@ -74,10 +74,6 @@ impl ConversationManager {
         {
             preserve_current_user_on_overflow = true;
             let display_summary = format!("{before} → {after} messages (proactive)");
-            emit_text_update(
-                stream_delta_tx,
-                format!("\n[context compacted: {display_summary}]\n"),
-            );
             emit_stream_update(
                 stream_delta_tx,
                 ConversationStreamUpdate::ContextCompacted {
@@ -148,10 +144,6 @@ impl ConversationManager {
                     let summary = format!(
                         "compacted {} → {} messages to fit server window (keep {})",
                         before, after, keep_messages
-                    );
-                    emit_text_update(
-                        stream_delta_tx,
-                        format!("\n[context: {summary}, retrying]\n"),
                     );
                     emit_stream_update(
                         stream_delta_tx,

--- a/src/state/conversation/send_message.rs
+++ b/src/state/conversation/send_message.rs
@@ -484,7 +484,7 @@ impl ConversationManager {
             }
 
             let assistant_history_source = if !tool_use_blocks.is_empty() && !use_structured_round {
-                let rendered_tool_calls = render_tool_calls_for_text_protocol(&tool_use_blocks);
+                let rendered_tool_calls = render_tool_calls_for_history(&tool_use_blocks);
                 if assistant_text_for_history.is_empty() {
                     rendered_tool_calls
                 } else {

--- a/src/state/conversation/tests/edit_location_probe.rs
+++ b/src/state/conversation/tests/edit_location_probe.rs
@@ -1,8 +1,7 @@
 use super::*;
 use crate::config::SearchConfig;
-use crate::runtime::context_cache::{
-    clear_pulse_ledger, find_pulse_read, lock_context_cache_for_tests,
-    reset_context_cache_for_tests,
+use crate::tools::pulse_ledger::{
+    clear_pulse_ledger, find_pulse_read, lock_pulse_ledger_for_tests,
 };
 use std::fs;
 
@@ -41,8 +40,7 @@ fn second_block_offset(fixture: &str) -> usize {
 
 #[test]
 fn probe_a_anchored_match_resolves_ambiguous_edit() {
-    let _lock = lock_context_cache_for_tests();
-    reset_context_cache_for_tests();
+    let _lock = lock_pulse_ledger_for_tests();
     clear_pulse_ledger();
 
     let fixture = anchor_fixture();
@@ -88,8 +86,7 @@ fn probe_a_anchored_match_resolves_ambiguous_edit() {
 fn probe_b_ledger_invalidates_after_external_mutation() {
     use filetime::{FileTime, set_file_mtime};
 
-    let _lock = lock_context_cache_for_tests();
-    reset_context_cache_for_tests();
+    let _lock = lock_pulse_ledger_for_tests();
     clear_pulse_ledger();
 
     let fixture = anchor_fixture();
@@ -133,8 +130,7 @@ fn probe_b_ledger_invalidates_after_external_mutation() {
 
 #[test]
 fn probe_c_ledger_clears_between_pulses() {
-    let _lock = lock_context_cache_for_tests();
-    reset_context_cache_for_tests();
+    let _lock = lock_pulse_ledger_for_tests();
     clear_pulse_ledger();
 
     let fixture = anchor_fixture();

--- a/src/state/conversation/tests/edit_location_probe.rs
+++ b/src/state/conversation/tests/edit_location_probe.rs
@@ -1,0 +1,174 @@
+use super::*;
+use crate::config::SearchConfig;
+use crate::runtime::context_cache::{
+    clear_pulse_ledger, find_pulse_read, lock_context_cache_for_tests,
+    reset_context_cache_for_tests,
+};
+use std::fs;
+
+fn anchor_fixture() -> String {
+    let mut buf = String::new();
+    buf.push_str("fn first() {\n    let value = 1;\n}\n");
+    for index in 0..5 {
+        buf.push_str(&format!(
+            "fn padding_top_{index}() {{\n    let unrelated = {index};\n}}\n"
+        ));
+    }
+    buf.push_str("fn second() {\n    let value = 1;\n}\n");
+    for index in 0..5 {
+        buf.push_str(&format!(
+            "fn padding_bottom_{index}() {{\n    let unrelated = {index};\n}}\n"
+        ));
+    }
+    buf.push_str("fn third() {\n    let value = 1;\n}\n");
+    buf
+}
+
+fn seed_workspace(contents: &str) -> (TempDir, std::path::PathBuf) {
+    let workspace = TempDir::new().expect("tempdir");
+    let path = workspace.path().join("module.rs");
+    fs::write(&path, contents).expect("seed fixture");
+    (workspace, path)
+}
+
+fn second_block_offset(fixture: &str) -> usize {
+    fixture
+        .lines()
+        .position(|line| line == "fn second() {")
+        .map(|index| index + 1)
+        .expect("fixture must contain fn second")
+}
+
+#[test]
+fn probe_a_anchored_match_resolves_ambiguous_edit() {
+    let _lock = lock_context_cache_for_tests();
+    reset_context_cache_for_tests();
+    clear_pulse_ledger();
+
+    let fixture = anchor_fixture();
+    let (workspace, file_path) = seed_workspace(&fixture);
+    let operator = ToolOperator::new(workspace.path().to_path_buf());
+    let search_config = SearchConfig::default();
+
+    let offset = second_block_offset(&fixture);
+    let read_output = call_tool_routing_with_config(
+        &operator,
+        "read_file",
+        &json!({"path": "module.rs", "offset": offset, "limit": 3}),
+        &search_config,
+    )
+    .expect("read_file should succeed");
+    assert!(read_output.contains("fn second"));
+
+    let recorded = find_pulse_read(&file_path).expect("ledger must record the read");
+    assert_eq!(recorded.start_line, offset);
+
+    operator
+        .edit_file("module.rs", "    let value = 1;", "    let value = 99;")
+        .expect("anchored edit should resolve uniquely inside the read window");
+
+    let edited = fs::read_to_string(&file_path).expect("read edited file");
+    assert!(
+        edited.contains("fn second() {\n    let value = 99;\n}"),
+        "the edit must land on the in-window occurrence"
+    );
+    assert!(
+        edited.contains("fn first() {\n    let value = 1;\n}"),
+        "first occurrence (out of window) must be untouched"
+    );
+    assert!(
+        edited.contains("fn third() {\n    let value = 1;\n}"),
+        "third occurrence (out of window) must be untouched"
+    );
+
+    clear_pulse_ledger();
+}
+
+#[test]
+fn probe_b_ledger_invalidates_after_external_mutation() {
+    use filetime::{FileTime, set_file_mtime};
+
+    let _lock = lock_context_cache_for_tests();
+    reset_context_cache_for_tests();
+    clear_pulse_ledger();
+
+    let fixture = anchor_fixture();
+    let (workspace, file_path) = seed_workspace(&fixture);
+    set_file_mtime(&file_path, FileTime::from_unix_time(1, 0)).expect("set initial mtime");
+    let operator = ToolOperator::new(workspace.path().to_path_buf());
+    let search_config = SearchConfig::default();
+
+    let offset = second_block_offset(&fixture);
+    call_tool_routing_with_config(
+        &operator,
+        "read_file",
+        &json!({"path": "module.rs", "offset": offset, "limit": 3}),
+        &search_config,
+    )
+    .expect("read_file should succeed");
+    assert!(find_pulse_read(&file_path).is_some());
+
+    let mutated = format!("// drift inserted before original content\n{fixture}");
+    fs::write(&file_path, mutated).expect("rewrite fixture");
+    set_file_mtime(&file_path, FileTime::from_unix_time(2, 0)).expect("bump mtime");
+
+    assert!(
+        find_pulse_read(&file_path).is_none(),
+        "external mutation must invalidate the ledger entry by fingerprint"
+    );
+
+    let error = operator
+        .edit_file("module.rs", "    let value = 1;", "    let value = 99;")
+        .expect_err(
+            "ambiguous edit must fall back to the uniqueness rule once the anchor is stale",
+        );
+    let message = format!("{error:#}");
+    assert!(
+        message.contains("appears") && message.contains("must be unique"),
+        "fallback path must surface the existing uniqueness error, got: {message}"
+    );
+
+    clear_pulse_ledger();
+}
+
+#[test]
+fn probe_c_ledger_clears_between_pulses() {
+    let _lock = lock_context_cache_for_tests();
+    reset_context_cache_for_tests();
+    clear_pulse_ledger();
+
+    let fixture = anchor_fixture();
+    let (workspace, file_path) = seed_workspace(&fixture);
+    let operator = ToolOperator::new(workspace.path().to_path_buf());
+    let search_config = SearchConfig::default();
+
+    let offset = second_block_offset(&fixture);
+    call_tool_routing_with_config(
+        &operator,
+        "read_file",
+        &json!({"path": "module.rs", "offset": offset, "limit": 3}),
+        &search_config,
+    )
+    .expect("read_file should succeed");
+    assert!(find_pulse_read(&file_path).is_some());
+
+    clear_pulse_ledger();
+
+    assert!(
+        find_pulse_read(&file_path).is_none(),
+        "clearing the ledger between pulses must remove every entry"
+    );
+
+    let error = operator
+        .edit_file("module.rs", "    let value = 1;", "    let value = 99;")
+        .expect_err(
+            "with no ledger entry the ambiguous edit must fall back to the uniqueness rule",
+        );
+    let message = format!("{error:#}");
+    assert!(
+        message.contains("appears") && message.contains("must be unique"),
+        "fallback path must surface the existing uniqueness error, got: {message}"
+    );
+
+    clear_pulse_ledger();
+}

--- a/src/state/conversation/tests/history.rs
+++ b/src/state/conversation/tests/history.rs
@@ -721,7 +721,9 @@ async fn local_second_turn_summary_omits_prior_tool_result_headers() -> Result<(
     let Content::Text(text) = &seen[0].content else {
         panic!("expected compacted current prompt as text message");
     };
-    assert!(text.contains("read-only do not modify and debug [file: .github/workflows/release.yml]"));
+    assert!(
+        text.contains("read-only do not modify and debug [file: .github/workflows/release.yml]")
+    );
     assert!(
         !text.contains("tool_result read_file"),
         "summary should carry prior user intent, not tool-result headers: {text}"

--- a/src/state/conversation/tests/history.rs
+++ b/src/state/conversation/tests/history.rs
@@ -659,6 +659,136 @@ async fn local_endpoint_second_turn_compacts_even_below_token_threshold() -> Res
 }
 
 #[tokio::test]
+async fn local_second_turn_summary_omits_prior_tool_result_headers() -> Result<()> {
+    let calls = Arc::new(std::sync::Mutex::new(0));
+    let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let client = ApiClient::new_mock(Arc::new(CaptureMessagesThenSuccessProducer {
+        calls: Arc::clone(&calls),
+        seen: Arc::clone(&seen),
+    }));
+    client.set_server_info(crate::api::client::ServerInfo {
+        n_ctx: 8192,
+        ..Default::default()
+    });
+    let mut mock_tool_responses = HashMap::new();
+    mock_tool_responses.insert(
+        "nightly.yml".to_string(),
+        "nightly workflow body".to_string(),
+    );
+    let mut manager = ConversationManager::new_mock(client, mock_tool_responses);
+    manager.api_messages = vec![
+        ApiMessage {
+            role: "user".to_string(),
+            content: Content::Text(
+                "read-only do not modify and debug [file: .github/workflows/release.yml]"
+                    .to_string(),
+            ),
+            cache_hint: None,
+        },
+        ApiMessage {
+            role: "assistant".to_string(),
+            content: Content::Text("release summary".to_string()),
+            cache_hint: None,
+        },
+        ApiMessage {
+            role: "user".to_string(),
+            content: Content::Text(
+                "tool_result read_file:\nname: release.yml\n(42 more lines)".to_string(),
+            ),
+            cache_hint: None,
+        },
+        ApiMessage {
+            role: "assistant".to_string(),
+            content: Content::Text("release tool result acknowledged".to_string()),
+            cache_hint: None,
+        },
+    ];
+
+    let result = manager
+        .send_message(
+            "read-only do not modify and debug [file: .github/workflows/nightly.yml]".to_string(),
+            None,
+        )
+        .await?;
+
+    assert_eq!(result, "done");
+    let seen = seen.lock().unwrap().clone();
+    assert_eq!(
+        seen.len(),
+        1,
+        "local handoff should compact to a single current-turn prompt"
+    );
+    let Content::Text(text) = &seen[0].content else {
+        panic!("expected compacted current prompt as text message");
+    };
+    assert!(text.contains("read-only do not modify and debug [file: .github/workflows/release.yml]"));
+    assert!(
+        !text.contains("tool_result read_file"),
+        "summary should carry prior user intent, not tool-result headers: {text}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn local_second_turn_summary_reuses_prior_current_request_line() -> Result<()> {
+    let calls = Arc::new(std::sync::Mutex::new(0));
+    let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let client = ApiClient::new_mock(Arc::new(CaptureMessagesThenSuccessProducer {
+        calls: Arc::clone(&calls),
+        seen: Arc::clone(&seen),
+    }));
+    client.set_server_info(crate::api::client::ServerInfo {
+        n_ctx: 8192,
+        ..Default::default()
+    });
+    let mut mock_tool_responses = HashMap::new();
+    mock_tool_responses.insert(
+        "nightly.yml".to_string(),
+        "nightly workflow body".to_string(),
+    );
+    let mut manager = ConversationManager::new_mock(client, mock_tool_responses);
+    manager.api_messages = vec![
+        ApiMessage {
+            role: "user".to_string(),
+            content: Content::Text(
+                "[conversation summary] - user: read-only do not modify and debug [file: .github/workflows/release.yml]\n\nUse the summary only as background context. Treat the current request below as authoritative and do not continue earlier file targets unless the current request asks for them.\n\n[current request]\nread-only do not modify and debug [file: .github/workflows/nightly.yml]"
+                    .to_string(),
+            ),
+            cache_hint: None,
+        },
+        ApiMessage {
+            role: "assistant".to_string(),
+            content: Content::Text("nightly summary".to_string()),
+            cache_hint: None,
+        },
+    ];
+
+    let result = manager
+        .send_message(
+            "read-only do not modify and debug [file: .github/workflows/version-bump.yml]"
+                .to_string(),
+            None,
+        )
+        .await?;
+
+    assert_eq!(result, "done");
+    let seen = seen.lock().unwrap().clone();
+    assert_eq!(seen.len(), 1);
+    let Content::Text(text) = &seen[0].content else {
+        panic!("expected compacted current prompt as text message");
+    };
+    assert!(
+        text.contains(".github/workflows/nightly.yml"),
+        "summary should carry the prior current request anchor: {text}"
+    );
+    assert!(
+        !text.contains("- user: [conversation summary]"),
+        "summary should not preserve prior summary scaffolding: {text}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn context_overflow_retries_with_smaller_keep_window_when_needed() -> Result<()> {
     let calls = Arc::new(std::sync::Mutex::new(0));
     let initial = MockApiClient::new(vec![structured_tool_call_response("file.txt")]);

--- a/src/state/conversation/tests/mod.rs
+++ b/src/state/conversation/tests/mod.rs
@@ -15,6 +15,7 @@ pub(super) use tempfile::TempDir;
 pub(super) use tokio::sync::mpsc;
 
 mod approval;
+mod edit_location_probe;
 mod history;
 mod hooks;
 mod read_file_guard;

--- a/src/state/conversation/tests/streaming.rs
+++ b/src/state/conversation/tests/streaming.rs
@@ -105,6 +105,11 @@ async fn local_endpoint_normalizes_tagged_text_tool_calls() -> Result<()> {
         "unexpected final text: {final_text}"
     );
     assert_eq!(manager.api_messages.len(), 4);
+        assert!(matches!(
+                &manager.api_messages[1].content,
+                Content::Text(text)
+                        if text.contains("read_file") && !text.contains("<function=read_file>")
+        ));
     assert!(manager.api_messages.iter().any(|message| {
                 message.role == "user"
                         && (matches!(

--- a/src/state/conversation/tests/streaming.rs
+++ b/src/state/conversation/tests/streaming.rs
@@ -105,11 +105,11 @@ async fn local_endpoint_normalizes_tagged_text_tool_calls() -> Result<()> {
         "unexpected final text: {final_text}"
     );
     assert_eq!(manager.api_messages.len(), 4);
-        assert!(matches!(
-                &manager.api_messages[1].content,
-                Content::Text(text)
-                        if text.contains("read_file") && !text.contains("<function=read_file>")
-        ));
+    assert!(matches!(
+            &manager.api_messages[1].content,
+            Content::Text(text)
+                    if text.contains("read_file") && !text.contains("<function=read_file>")
+    ));
     assert!(manager.api_messages.iter().any(|message| {
                 message.role == "user"
                         && (matches!(

--- a/src/state/conversation/tools/formatting.rs
+++ b/src/state/conversation/tools/formatting.rs
@@ -57,6 +57,24 @@ pub(crate) fn render_tool_calls_for_text_protocol(blocks: &[ContentBlock]) -> St
     out
 }
 
+pub(crate) fn render_tool_calls_for_history(blocks: &[ContentBlock]) -> String {
+    let mut out = String::new();
+    for block in blocks {
+        if let ContentBlock::ToolUse { name, input, .. } = block {
+            if !out.is_empty() {
+                out.push('\n');
+            }
+            let preview = tool_input_preview(name, input);
+            if preview.trim().is_empty() {
+                out.push_str(&format!("[tool call] {name}"));
+            } else {
+                out.push_str(&format!("[tool call] {name}: {preview}"));
+            }
+        }
+    }
+    out
+}
+
 fn json_value_to_text_protocol_value(value: &serde_json::Value) -> String {
     match value {
         serde_json::Value::String(text) => text.clone(),

--- a/src/state/conversation/tools/routing.rs
+++ b/src/state/conversation/tools/routing.rs
@@ -4,7 +4,7 @@ use super::config::{
 use super::index::{CODEBASE_INDEX, build_codebase_index};
 use super::*;
 use crate::config::SearchConfig;
-use crate::runtime::context_cache::{read_cached_file_range, record_pulse_read};
+use crate::tools::pulse_ledger::{file_fingerprint, record_pulse_read};
 use crate::tools::search;
 use crate::tools::{ToolOperator, WriteFileOutcome, glob_files, list_dir};
 use anyhow::{Result, bail};
@@ -89,13 +89,18 @@ pub(crate) fn call_tool_routing_with_config(
 
             let auto_limit = read_file_max_lines();
             let effective_limit = limit.or(Some(auto_limit));
-            let outcome = read_cached_file_range(tool_operator, path, offset, effective_limit)?;
-            if let (Some(resolved), Some(fingerprint)) =
-                (outcome.resolved_path.clone(), outcome.fingerprint)
+            let rendered = tool_operator.read_file_range(path, offset, effective_limit)?;
+            if let Ok(Some(resolved)) = tool_operator.existing_path(path)
+                && !resolved.is_dir()
+                && let Ok(fingerprint) = file_fingerprint(&resolved)
             {
-                record_pulse_read(resolved, outcome.start_line, outcome.end_line, fingerprint);
+                let start_line = offset.unwrap_or(1).max(1);
+                let end_line = effective_limit
+                    .map(|count| start_line.saturating_add(count.saturating_sub(1)))
+                    .unwrap_or(start_line);
+                record_pulse_read(resolved, start_line, end_line, fingerprint);
             }
-            Ok(outcome.rendered)
+            Ok(rendered)
         }
         "write_file" => {
             let path =

--- a/src/state/conversation/tools/routing.rs
+++ b/src/state/conversation/tools/routing.rs
@@ -4,6 +4,7 @@ use super::config::{
 use super::index::{CODEBASE_INDEX, build_codebase_index};
 use super::*;
 use crate::config::SearchConfig;
+use crate::runtime::context_cache::{read_cached_file_range, record_pulse_read};
 use crate::tools::search;
 use crate::tools::{ToolOperator, WriteFileOutcome, glob_files, list_dir};
 use anyhow::{Result, bail};
@@ -88,7 +89,13 @@ pub(crate) fn call_tool_routing_with_config(
 
             let auto_limit = read_file_max_lines();
             let effective_limit = limit.or(Some(auto_limit));
-            tool_operator.read_file_range(path, offset, effective_limit)
+            let outcome = read_cached_file_range(tool_operator, path, offset, effective_limit)?;
+            if let (Some(resolved), Some(fingerprint)) =
+                (outcome.resolved_path.clone(), outcome.fingerprint)
+            {
+                record_pulse_read(resolved, outcome.start_line, outcome.end_line, fingerprint);
+            }
+            Ok(outcome.rendered)
         }
         "write_file" => {
             let path =

--- a/src/state/conversation/tools/routing.rs
+++ b/src/state/conversation/tools/routing.rs
@@ -90,7 +90,9 @@ pub(crate) fn call_tool_routing_with_config(
             let auto_limit = read_file_max_lines();
             let effective_limit = limit.or(Some(auto_limit));
             let rendered = tool_operator.read_file_range(path, offset, effective_limit)?;
-            if let Ok(Some(resolved)) = tool_operator.existing_path(path)
+            let returned_content_lines = !rendered.starts_with("(file has ");
+            if returned_content_lines
+                && let Ok(Some(resolved)) = tool_operator.existing_path(path)
                 && !resolved.is_dir()
                 && let Ok(fingerprint) = file_fingerprint(&resolved)
             {

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -1,6 +1,7 @@
 pub mod embed;
 pub mod index;
 pub(crate) mod operator;
+pub(crate) mod pulse_ledger;
 pub mod search;
 pub mod semantic;
 pub(crate) mod workspace_explore;

--- a/src/tools/operator/file_ops.rs
+++ b/src/tools/operator/file_ops.rs
@@ -3,8 +3,8 @@ use std::fs;
 use std::path::Path;
 
 use crate::edit_diff::format_edit_hunks;
-use crate::runtime::context_cache::find_pulse_read;
 
+use super::super::pulse_ledger::find_pulse_read;
 use super::{PendingPatch, ToolOperator, WriteFileOutcome};
 
 const MAX_EDIT_SNIPPET_CHARS: usize = 2_000;

--- a/src/tools/operator/file_ops.rs
+++ b/src/tools/operator/file_ops.rs
@@ -3,11 +3,13 @@ use std::fs;
 use std::path::Path;
 
 use crate::edit_diff::format_edit_hunks;
+use crate::runtime::context_cache::find_pulse_read;
 
 use super::{PendingPatch, ToolOperator, WriteFileOutcome};
 
 const MAX_EDIT_SNIPPET_CHARS: usize = 2_000;
 const MAX_EDIT_SNIPPET_LINES: usize = 80;
+const EDIT_ANCHOR_LINE_PAD: usize = 3;
 
 impl ToolOperator {
     pub fn read_file(&self, path: &str) -> Result<String> {
@@ -159,16 +161,22 @@ impl ToolOperator {
         if occurrences == 0 {
             bail!("String '{}' not found in file", old_str);
         }
-        if occurrences > 1 {
-            bail!(
-                "String '{}' appears {} times; must be unique",
-                old_str,
-                occurrences
-            );
+        if occurrences == 1 {
+            let new_content = content.replacen(old_str, new_str, 1);
+            return fs::write(resolved, new_content).context("Failed to edit file");
         }
 
-        let new_content = content.replacen(old_str, new_str, 1);
-        fs::write(resolved, new_content).context("Failed to edit file")
+        if let Some(anchored) =
+            anchored_unique_replacement(&resolved, &content, old_str, new_str)?
+        {
+            return fs::write(resolved, anchored).context("Failed to edit file");
+        }
+
+        bail!(
+            "String '{}' appears {} times; must be unique",
+            old_str,
+            occurrences
+        );
     }
 
     pub fn rename_file(&self, old_path: &str, new_path: &str) -> Result<String> {
@@ -235,6 +243,49 @@ impl ToolOperator {
             Ok(entries.join("\n"))
         }
     }
+}
+
+fn anchored_unique_replacement(
+    resolved: &Path,
+    content: &str,
+    old_str: &str,
+    new_str: &str,
+) -> Result<Option<String>> {
+    let Some(anchor) = find_pulse_read(resolved) else {
+        return Ok(None);
+    };
+
+    let window_start = anchor.start_line.saturating_sub(EDIT_ANCHOR_LINE_PAD);
+    let window_end = anchor.end_line.saturating_add(EDIT_ANCHOR_LINE_PAD);
+
+    let mut candidate_offsets = Vec::new();
+    for (byte_offset, _) in content.match_indices(old_str) {
+        let line = line_of_byte_offset(content, byte_offset);
+        if line >= window_start && line <= window_end {
+            candidate_offsets.push(byte_offset);
+            if candidate_offsets.len() > 1 {
+                return Ok(None);
+            }
+        }
+    }
+
+    let Some(offset) = candidate_offsets.first().copied() else {
+        return Ok(None);
+    };
+
+    let mut new_content = String::with_capacity(content.len() + new_str.len());
+    new_content.push_str(&content[..offset]);
+    new_content.push_str(new_str);
+    new_content.push_str(&content[offset + old_str.len()..]);
+    Ok(Some(new_content))
+}
+
+fn line_of_byte_offset(content: &str, byte_offset: usize) -> usize {
+    if byte_offset == 0 {
+        return 1;
+    }
+    let bounded = byte_offset.min(content.len());
+    content[..bounded].bytes().filter(|byte| *byte == b'\n').count() + 1
 }
 
 fn should_skip_list_entry(root: &Path, working_dir: &Path, name: &str) -> bool {

--- a/src/tools/operator/file_ops.rs
+++ b/src/tools/operator/file_ops.rs
@@ -166,8 +166,7 @@ impl ToolOperator {
             return fs::write(resolved, new_content).context("Failed to edit file");
         }
 
-        if let Some(anchored) =
-            anchored_unique_replacement(&resolved, &content, old_str, new_str)?
+        if let Some(anchored) = anchored_unique_replacement(&resolved, &content, old_str, new_str)?
         {
             return fs::write(resolved, anchored).context("Failed to edit file");
         }
@@ -285,7 +284,11 @@ fn line_of_byte_offset(content: &str, byte_offset: usize) -> usize {
         return 1;
     }
     let bounded = byte_offset.min(content.len());
-    content[..bounded].bytes().filter(|byte| *byte == b'\n').count() + 1
+    content[..bounded]
+        .bytes()
+        .filter(|byte| *byte == b'\n')
+        .count()
+        + 1
 }
 
 fn should_skip_list_entry(root: &Path, working_dir: &Path, name: &str) -> bool {

--- a/src/tools/operator/file_ops.rs
+++ b/src/tools/operator/file_ops.rs
@@ -257,10 +257,17 @@ fn anchored_unique_replacement(
     let window_start = anchor.start_line.saturating_sub(EDIT_ANCHOR_LINE_PAD);
     let window_end = anchor.end_line.saturating_add(EDIT_ANCHOR_LINE_PAD);
 
+    let bytes = content.as_bytes();
+    let mut scanned_to = 0usize;
+    let mut current_line = 1usize;
     let mut candidate_offsets = Vec::new();
     for (byte_offset, _) in content.match_indices(old_str) {
-        let line = line_of_byte_offset(content, byte_offset);
-        if line >= window_start && line <= window_end {
+        current_line += bytes[scanned_to..byte_offset]
+            .iter()
+            .filter(|byte| **byte == b'\n')
+            .count();
+        scanned_to = byte_offset;
+        if current_line >= window_start && current_line <= window_end {
             candidate_offsets.push(byte_offset);
             if candidate_offsets.len() > 1 {
                 return Ok(None);
@@ -277,18 +284,6 @@ fn anchored_unique_replacement(
     new_content.push_str(new_str);
     new_content.push_str(&content[offset + old_str.len()..]);
     Ok(Some(new_content))
-}
-
-fn line_of_byte_offset(content: &str, byte_offset: usize) -> usize {
-    if byte_offset == 0 {
-        return 1;
-    }
-    let bounded = byte_offset.min(content.len());
-    content[..bounded]
-        .bytes()
-        .filter(|byte| *byte == b'\n')
-        .count()
-        + 1
 }
 
 fn should_skip_list_entry(root: &Path, working_dir: &Path, name: &str) -> bool {

--- a/src/tools/pulse_ledger.rs
+++ b/src/tools/pulse_ledger.rs
@@ -86,23 +86,6 @@ pub(crate) fn clear_pulse_ledger() {
     ledger.entries.clear();
 }
 
-pub(crate) fn pulse_ledger_snapshot() -> Vec<LocatedRead> {
-    let ledger = global_pulse_ledger()
-        .lock()
-        .expect("pulse ledger mutex poisoned");
-    ledger.entries.clone()
-}
-
-pub(crate) fn restore_pulse_ledger(entries: Vec<LocatedRead>) {
-    let mut ledger = global_pulse_ledger()
-        .lock()
-        .expect("pulse ledger mutex poisoned");
-    ledger.entries = entries;
-    while ledger.entries.len() > MAX_PULSE_LEDGER_ENTRIES {
-        ledger.entries.remove(0);
-    }
-}
-
 #[cfg(test)]
 pub(crate) fn lock_pulse_ledger_for_tests() -> std::sync::MutexGuard<'static, ()> {
     PULSE_LEDGER_TEST_LOCK
@@ -114,8 +97,7 @@ pub(crate) fn lock_pulse_ledger_for_tests() -> std::sync::MutexGuard<'static, ()
 mod tests {
     use super::{
         MAX_PULSE_LEDGER_ENTRIES, clear_pulse_ledger, file_fingerprint, find_pulse_read,
-        lock_pulse_ledger_for_tests, pulse_ledger_snapshot, record_pulse_read,
-        restore_pulse_ledger,
+        lock_pulse_ledger_for_tests, record_pulse_read,
     };
     use filetime::{FileTime, set_file_mtime};
     use std::fs;
@@ -159,46 +141,31 @@ mod tests {
     }
 
     #[test]
-    fn test_pulse_ledger_snapshot_and_restore_roundtrip() {
-        let _lock = lock_pulse_ledger_for_tests();
-        clear_pulse_ledger();
-        let workspace = tempfile::tempdir().expect("tempdir");
-        let path = workspace.path().join("note.txt");
-        fs::write(&path, "alpha\n").expect("write file");
-        let fingerprint = file_fingerprint(&path).expect("fingerprint");
-        record_pulse_read(path.clone(), 1, 1, fingerprint);
-
-        let snapshot = pulse_ledger_snapshot();
-        clear_pulse_ledger();
-        assert!(find_pulse_read(&path).is_none());
-
-        restore_pulse_ledger(snapshot);
-        assert!(
-            find_pulse_read(&path).is_some(),
-            "restoring a ledger snapshot should make the entry queryable again"
-        );
-        clear_pulse_ledger();
-    }
-
-    #[test]
-    fn test_pulse_ledger_caps_at_max_entries() {
+    fn test_pulse_ledger_evicts_oldest_when_capped() {
         let _lock = lock_pulse_ledger_for_tests();
         clear_pulse_ledger();
         let workspace = tempfile::tempdir().expect("tempdir");
 
+        let mut paths = Vec::new();
         for index in 0..(MAX_PULSE_LEDGER_ENTRIES + 4) {
             let name = format!("note-{index}.txt");
             let path = workspace.path().join(&name);
             fs::write(&path, format!("line {index}\n")).expect("write fixture");
             let fingerprint = file_fingerprint(&path).expect("fingerprint");
-            record_pulse_read(path, 1, 1, fingerprint);
+            record_pulse_read(path.clone(), 1, 1, fingerprint);
+            paths.push(path);
         }
 
-        let snapshot = pulse_ledger_snapshot();
+        for evicted in &paths[..4] {
+            assert!(
+                find_pulse_read(evicted).is_none(),
+                "the oldest entries must be evicted once the ledger exceeds its cap"
+            );
+        }
+        let kept = paths.last().expect("at least one entry recorded");
         assert!(
-            snapshot.len() <= MAX_PULSE_LEDGER_ENTRIES,
-            "ledger must cap at MAX_PULSE_LEDGER_ENTRIES, got {}",
-            snapshot.len()
+            find_pulse_read(kept).is_some(),
+            "the most recent entry must remain after eviction"
         );
         clear_pulse_ledger();
     }

--- a/src/tools/pulse_ledger.rs
+++ b/src/tools/pulse_ledger.rs
@@ -1,0 +1,205 @@
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::SystemTime;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct FileFingerprint {
+    pub(crate) len: u64,
+    pub(crate) modified: SystemTime,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LocatedRead {
+    pub(crate) path: PathBuf,
+    pub(crate) start_line: usize,
+    pub(crate) end_line: usize,
+    pub(crate) fingerprint: FileFingerprint,
+}
+
+const MAX_PULSE_LEDGER_ENTRIES: usize = 64;
+
+#[derive(Debug, Default)]
+struct PulseLedger {
+    entries: Vec<LocatedRead>,
+}
+
+fn global_pulse_ledger() -> &'static Mutex<PulseLedger> {
+    static PULSE_LEDGER: OnceLock<Mutex<PulseLedger>> = OnceLock::new();
+    PULSE_LEDGER.get_or_init(|| Mutex::new(PulseLedger::default()))
+}
+
+#[cfg(test)]
+static PULSE_LEDGER_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+pub(crate) fn file_fingerprint(path: &Path) -> Result<FileFingerprint> {
+    let metadata = std::fs::metadata(path)
+        .with_context(|| format!("Failed to read metadata for {}", path.display()))?;
+    let modified = metadata
+        .modified()
+        .with_context(|| format!("Failed to read modified time for {}", path.display()))?;
+
+    Ok(FileFingerprint {
+        len: metadata.len(),
+        modified,
+    })
+}
+
+pub(crate) fn record_pulse_read(
+    path: PathBuf,
+    start_line: usize,
+    end_line: usize,
+    fingerprint: FileFingerprint,
+) {
+    let mut ledger = global_pulse_ledger()
+        .lock()
+        .expect("pulse ledger mutex poisoned");
+    ledger.entries.retain(|entry| entry.path != path);
+    ledger.entries.push(LocatedRead {
+        path,
+        start_line,
+        end_line,
+        fingerprint,
+    });
+    while ledger.entries.len() > MAX_PULSE_LEDGER_ENTRIES {
+        ledger.entries.remove(0);
+    }
+}
+
+pub(crate) fn find_pulse_read(path: &Path) -> Option<LocatedRead> {
+    let current = file_fingerprint(path).ok()?;
+    let ledger = global_pulse_ledger()
+        .lock()
+        .expect("pulse ledger mutex poisoned");
+    ledger
+        .entries
+        .iter()
+        .rev()
+        .find(|entry| entry.path == path && entry.fingerprint == current)
+        .cloned()
+}
+
+pub(crate) fn clear_pulse_ledger() {
+    let mut ledger = global_pulse_ledger()
+        .lock()
+        .expect("pulse ledger mutex poisoned");
+    ledger.entries.clear();
+}
+
+pub(crate) fn pulse_ledger_snapshot() -> Vec<LocatedRead> {
+    let ledger = global_pulse_ledger()
+        .lock()
+        .expect("pulse ledger mutex poisoned");
+    ledger.entries.clone()
+}
+
+pub(crate) fn restore_pulse_ledger(entries: Vec<LocatedRead>) {
+    let mut ledger = global_pulse_ledger()
+        .lock()
+        .expect("pulse ledger mutex poisoned");
+    ledger.entries = entries;
+    while ledger.entries.len() > MAX_PULSE_LEDGER_ENTRIES {
+        ledger.entries.remove(0);
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn lock_pulse_ledger_for_tests() -> std::sync::MutexGuard<'static, ()> {
+    PULSE_LEDGER_TEST_LOCK
+        .lock()
+        .expect("pulse ledger test mutex poisoned")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        MAX_PULSE_LEDGER_ENTRIES, clear_pulse_ledger, file_fingerprint, find_pulse_read,
+        lock_pulse_ledger_for_tests, pulse_ledger_snapshot, record_pulse_read,
+        restore_pulse_ledger,
+    };
+    use filetime::{FileTime, set_file_mtime};
+    use std::fs;
+
+    #[test]
+    fn test_pulse_ledger_records_and_finds_matching_fingerprint() {
+        let _lock = lock_pulse_ledger_for_tests();
+        clear_pulse_ledger();
+        let workspace = tempfile::tempdir().expect("tempdir");
+        let path = workspace.path().join("note.txt");
+        fs::write(&path, "alpha\nbravo\ncharlie\n").expect("write file");
+        let fingerprint = file_fingerprint(&path).expect("fingerprint");
+        record_pulse_read(path.clone(), 1, 3, fingerprint);
+
+        let hit = find_pulse_read(&path).expect("ledger should remember the read");
+        assert_eq!(hit.start_line, 1);
+        assert_eq!(hit.end_line, 3);
+        assert_eq!(hit.fingerprint, fingerprint);
+        clear_pulse_ledger();
+    }
+
+    #[test]
+    fn test_pulse_ledger_misses_after_file_mutates() {
+        let _lock = lock_pulse_ledger_for_tests();
+        clear_pulse_ledger();
+        let workspace = tempfile::tempdir().expect("tempdir");
+        let path = workspace.path().join("note.txt");
+        fs::write(&path, "alpha\n").expect("write original");
+        set_file_mtime(&path, FileTime::from_unix_time(1, 0)).expect("set initial mtime");
+        let fingerprint = file_fingerprint(&path).expect("fingerprint");
+        record_pulse_read(path.clone(), 1, 1, fingerprint);
+
+        fs::write(&path, "alpha changed\n").expect("mutate file");
+        set_file_mtime(&path, FileTime::from_unix_time(2, 0)).expect("bump mtime");
+
+        assert!(
+            find_pulse_read(&path).is_none(),
+            "ledger must miss when the file fingerprint no longer matches"
+        );
+        clear_pulse_ledger();
+    }
+
+    #[test]
+    fn test_pulse_ledger_snapshot_and_restore_roundtrip() {
+        let _lock = lock_pulse_ledger_for_tests();
+        clear_pulse_ledger();
+        let workspace = tempfile::tempdir().expect("tempdir");
+        let path = workspace.path().join("note.txt");
+        fs::write(&path, "alpha\n").expect("write file");
+        let fingerprint = file_fingerprint(&path).expect("fingerprint");
+        record_pulse_read(path.clone(), 1, 1, fingerprint);
+
+        let snapshot = pulse_ledger_snapshot();
+        clear_pulse_ledger();
+        assert!(find_pulse_read(&path).is_none());
+
+        restore_pulse_ledger(snapshot);
+        assert!(
+            find_pulse_read(&path).is_some(),
+            "restoring a ledger snapshot should make the entry queryable again"
+        );
+        clear_pulse_ledger();
+    }
+
+    #[test]
+    fn test_pulse_ledger_caps_at_max_entries() {
+        let _lock = lock_pulse_ledger_for_tests();
+        clear_pulse_ledger();
+        let workspace = tempfile::tempdir().expect("tempdir");
+
+        for index in 0..(MAX_PULSE_LEDGER_ENTRIES + 4) {
+            let name = format!("note-{index}.txt");
+            let path = workspace.path().join(&name);
+            fs::write(&path, format!("line {index}\n")).expect("write fixture");
+            let fingerprint = file_fingerprint(&path).expect("fingerprint");
+            record_pulse_read(path, 1, 1, fingerprint);
+        }
+
+        let snapshot = pulse_ledger_snapshot();
+        assert!(
+            snapshot.len() <= MAX_PULSE_LEDGER_ENTRIES,
+            "ledger must cap at MAX_PULSE_LEDGER_ENTRIES, got {}",
+            snapshot.len()
+        );
+        clear_pulse_ledger();
+    }
+}


### PR DESCRIPTION
## Summary

- Closes the locate→edit gap: every successful `read_file` now records a `LocatedRead { path, range, fingerprint }` entry in a per-pulse ledger that lives next to the existing in-process file cache.
- `edit_file` consults the ledger when `old_str` is ambiguous and narrows the match to a ±3-line window around the recorded read range, resolving in one tool call instead of forcing a retry on "appears N times; must be unique".
- Process-global ledger self-invalidates on `FileFingerprint` mismatch (len + mtime), clears at every pulse boundary in `send_message_with_policy`, and survives in-pulse compaction events without special handling.

## Plan + comparison evidence

Plan with full pro/con vs last 5 PRs and a paraphrased compare to other coding tools (no proprietary terms borrowed) at read-the-last-5-memoized-kernighan.md. Headline change picked over three alternatives — see ADR-033 amendment for the rationale.

## Critical files

- `src/runtime/context_cache.rs` — `LocatedRead`, pulse ledger (`record_pulse_read`, `find_pulse_read`, `clear_pulse_ledger`, `pulse_ledger_snapshot`, `restore_pulse_ledger`), `read_cached_file_range` returning range + fingerprint.
- `src/state/conversation/tools/routing.rs` — `read_file` flows through the cache and records on every success.
- `src/tools/operator/file_ops.rs` — `anchored_unique_replacement` falls in between the single-match and ambiguous-match branches; existing error messages preserved.
- `src/state/conversation/send_message.rs` — `clear_pulse_ledger()` at pulse start.
- `adr/ADR-033-amendment-2026-05-12.md` — Phase 2.5 scope, invariants, naming hygiene.

## Test plan

- [ ] CI green (compile, clippy, tests)
- [ ] New unit coverage in `src/runtime/context_cache.rs::tests` for the ledger (record/find/snapshot/restore/cap)
- [ ] New integration probes in `src/state/conversation/tests/edit_location_probe.rs`:
  - Probe A: anchored window resolves an ambiguous edit on the first tool call
  - Probe B: external file mutation invalidates the ledger entry by fingerprint
  - Probe C: ledger clears at the pulse boundary
- [ ] Live-server smoke run against a local `llama-server` (Qwen3-Coder-REAP-25B-A3B IQ3_XXS) — search → edit pulse traced