### PR TITLE
Guard inline scrollback against mutable streaming rows

### DIFF
--- a/src/tui_frontend.rs
+++ b/src/tui_frontend.rs
@@ -689,10 +689,32 @@ fn inline_rows_to_insert(
         return None;
     }
 
+    // Inline scrollback is only safe when newly visible rows are a strict
+    // append-only extension of the previous frame. Streaming text can still
+    // reflow or mutate earlier wrapped rows, and replaying those stale rows
+    // into scrollback duplicates or drops visible content.
+    if !transcript_rows_extend_append_only(
+        &previous.expanded_output_rows,
+        &current.expanded_output_rows,
+    ) {
+        return None;
+    }
+
     let end = current
         .visible_start
         .min(previous.expanded_output_rows.len());
     (end > previous.visible_start).then_some((previous.visible_start, end))
+}
+
+fn transcript_rows_extend_append_only(
+    previous: &[crate::app::TranscriptRow],
+    current: &[crate::app::TranscriptRow],
+) -> bool {
+    current.len() >= previous.len()
+        && previous
+            .iter()
+            .zip(current.iter())
+            .all(|(prev, next)| prev == next)
 }
 
 pub(crate) mod picker;
@@ -755,7 +777,15 @@ mod tests {
             task_id: "task-1".to_string(),
             area: Rect::new(0, 0, 80, 20),
             visible_start: 4,
-            expanded_output_rows: vec![].into(),
+            expanded_output_rows: vec![
+                crate::app::TranscriptRow::Plain("a".to_string()),
+                crate::app::TranscriptRow::Plain("b".to_string()),
+                crate::app::TranscriptRow::Plain("c".to_string()),
+                crate::app::TranscriptRow::Plain("d".to_string()),
+                crate::app::TranscriptRow::Plain("e".to_string()),
+                crate::app::TranscriptRow::Plain("f".to_string()),
+            ]
+            .into(),
         };
 
         assert_eq!(inline_rows_to_insert(&previous, &current), Some((2, 4)));
@@ -784,5 +814,49 @@ mod tests {
 
         assert_eq!(inline_rows_to_insert(&previous, &resized), None);
         assert_eq!(inline_rows_to_insert(&previous, &same_window), None);
+    }
+
+    #[test]
+    fn inline_scrollback_skips_mutated_streaming_windows() {
+        let previous = InlineScrollbackSnapshot {
+            task_id: "task-1".to_string(),
+            area: Rect::new(0, 0, 80, 20),
+            visible_start: 1,
+            expanded_output_rows: vec![
+                crate::app::TranscriptRow::Plain("prompt".to_string()),
+                crate::app::TranscriptRow::AssistantText {
+                    text: "partial line".to_string(),
+                    streaming: true,
+                },
+                crate::app::TranscriptRow::AssistantText {
+                    text: "stable tail".to_string(),
+                    streaming: true,
+                },
+            ]
+            .into(),
+        };
+        let current = InlineScrollbackSnapshot {
+            task_id: "task-1".to_string(),
+            area: Rect::new(0, 0, 80, 20),
+            visible_start: 2,
+            expanded_output_rows: vec![
+                crate::app::TranscriptRow::Plain("prompt".to_string()),
+                crate::app::TranscriptRow::AssistantText {
+                    text: "partial line extended".to_string(),
+                    streaming: true,
+                },
+                crate::app::TranscriptRow::AssistantText {
+                    text: "stable tail".to_string(),
+                    streaming: true,
+                },
+                crate::app::TranscriptRow::AssistantText {
+                    text: "new tail".to_string(),
+                    streaming: true,
+                },
+            ]
+            .into(),
+        };
+
+        assert_eq!(inline_rows_to_insert(&previous, &current), None);
     }
 }


### PR DESCRIPTION
## Summary
Guard the inline ratatui scrollback optimization so it only inserts rows into terminal scrollback when the expanded transcript is a strict append-only extension of the previous frame. When streamed assistant text mutates or reflows existing wrapped rows, the frontend now falls back to a normal full redraw instead of replaying stale rows into scrollback.

## Motivation
The inline viewport path uses \`Terminal::insert_before\` to push rows that just left the visible window into terminal scrollback. That is only safe when those rows are already stable. During live streaming, assistant rows can still change as new tokens arrive and wrapping shifts. Re-inserting the older version of those rows explains the duplicated fragments and missing/latest-response inconsistencies reported in the native terminal renderer.

A plain non-TTY \`| tee\` run is not the right reproduction for this bug because \`src/tui_handle.rs\` switches to \`Terminal::new(CrosstermBackend::new(stdout()))\` when stdin/stdout are not terminals. The problematic path is the inline TTY viewport created by \`try_init_with_options(... Viewport::Inline(...))\`. I therefore used a PTY capture (\`script | tee\`) for the live evidence instead of a bare pipe.

## Approach
- Add \`transcript_rows_extend_append_only\` in \`src/tui_frontend.rs\`
- Gate \`inline_rows_to_insert\` on that append-only check
- Keep the fast path for true append-only growth
- Skip \`insert_before\` when any existing expanded row changed, forcing the next \`draw()\` to repaint from the authoritative current frame buffer
- Add a regression test covering mutated streaming rows and update the existing safe-path fixture to model real append-only growth

## Supporting Evidence
- Framework contract: ratatui \`Terminal::draw\` documentation states the render callback should fully render the entire frame each time because the current buffer is diffed against the previous buffer, and incomplete/stale rendering leaves the terminal in an inconsistent state.
- Inline-scrollback contract: ratatui \`Terminal::insert_before\` documentation states it inserts content before the current inline viewport and pushes/scrolls the terminal area above the viewport. That makes it appropriate only for rows that are already stable.
- Public renderer pattern: Aider's \`aider/mdstream.py\` treats streamed output as two regions: stable lines printed above the live window, and an unstable live window whose lines "may shift around as new chunks are appended". Only the stable portion is emitted to scrollback; the unstable tail is repainted live. This matches the safety boundary enforced here.
- Local capture: a PTY capture from this branch showed that the inline viewport path is the relevant renderer path, and that a bare non-TTY pipe would exercise different initialization logic.

## Validation
- cargo test inline_scrollback --lib
- cargo test tui_frontend::tests --lib
- cargo fmt --check
- cargo check
- cargo clippy --all-targets -- -D warnings

## Risks
- Low. The change only disables the scrollback insertion optimization when previously rendered rows are no longer identical.
- In the guarded cases, rendering falls back to the existing full redraw path rather than introducing a new rendering mechanism.
- The optimization remains enabled for the safe append-only case.

## References
- ratatui Viewport docs: https://docs.rs/ratatui/latest/ratatui/enum.Viewport.html
- ratatui Terminal docs: https://docs.rs/ratatui/latest/ratatui/struct.Terminal.html
- Aider markdown streaming renderer: https://github.com/Aider-AI/aider/blob/main/aider/mdstream.py
