### PR TITLE
first batch : ratatui 0.30 API coverage batch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,12 +400,6 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -629,6 +623,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -865,6 +870,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,6 +886,12 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
@@ -1226,18 +1246,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
 dependencies = [
  "encoding_rs",
-]
-
-[[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -1609,6 +1617,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -2568,25 +2577,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
@@ -2664,53 +2654,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-proto"
-version = "0.24.4"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92652067c9ce6f66ce53cc38d1169daa36e6e7eb7dd3b63b5103bd9d97117248"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "bytes",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
+ "h2",
+ "hickory-proto",
+ "http 1.4.0",
  "idna",
  "ipnet",
- "once_cell",
- "rand 0.8.5",
- "rustls 0.21.12",
- "rustls-pemfile",
- "thiserror 1.0.69",
+ "jni 0.22.4",
+ "rand 0.10.1",
+ "rustls",
+ "thiserror 2.0.18",
  "tinyvec",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "hickory-resolver"
-version = "0.24.4"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
- "lru-cache",
+ "ipnet",
+ "moka",
  "once_cell",
  "parking_lot",
- "rand 0.8.5",
- "rustls 0.21.12",
+ "rand 0.10.1",
+ "rustls",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "tracing",
 ]
 
@@ -2808,7 +2819,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
+ "h2",
  "http 1.4.0",
  "http-body",
  "httparse",
@@ -2830,10 +2841,10 @@ dependencies = [
  "http 1.4.0",
  "hyper",
  "hyper-util",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
 ]
 
@@ -3142,6 +3153,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -3248,6 +3262,36 @@ dependencies = [
  "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3510,15 +3554,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru-cache"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
-dependencies = [
- "linked-hash-map",
-]
-
-[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3632,6 +3667,23 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
 ]
 
 [[package]]
@@ -3934,6 +3986,10 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -4333,6 +4389,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4462,7 +4529,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls",
  "socket2",
  "thiserror 2.0.18",
  "tokio",
@@ -4483,7 +4550,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -4549,6 +4616,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4585,6 +4663,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "ratatui"
@@ -4792,7 +4876,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "h2 0.4.13",
+ "h2",
  "http 1.4.0",
  "http-body",
  "http-body-util",
@@ -4805,14 +4889,14 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -4945,18 +5029,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
@@ -4966,7 +5038,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -4981,15 +5053,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework 3.7.0",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -5010,13 +5073,13 @@ checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
  "log",
  "once_cell",
- "rustls 0.23.37",
+ "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
@@ -5028,16 +5091,6 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -5086,16 +5139,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "security-framework"
@@ -5242,7 +5285,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -5263,7 +5306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -5334,6 +5377,16 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
 
 [[package]]
 name = "simdutf8"
@@ -5586,6 +5639,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5834,21 +5893,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls",
  "tokio",
 ]
 
@@ -6427,7 +6476,7 @@ dependencies = [
  "reqwest",
  "rmcp",
  "rstest",
- "rustls 0.23.37",
+ "rustls",
  "serde",
  "serde_json",
  "similar",
@@ -6438,7 +6487,7 @@ dependencies = [
  "textwrap",
  "thiserror 2.0.18",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-stream",
  "tokio-util",
  "toml 0.8.23",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,9 +74,9 @@ jsonwebtoken = "9"
 oauth2 = { version = "4", default-features = false }
 open = "5"
 # RFC 8484/6555 (DoH/Happy Eyeballs): DNS-over-HTTPS and dual-stack connection racing.
-hickory-resolver = { version = "0.24", default-features = false, features = [
-  "dns-over-https-rustls",
-  "tokio-runtime",
+hickory-resolver = { version = "0.26.1", default-features = false, features = [
+  "https-ring",
+  "tokio",
 ] }
 rmcp = { version = "1.2.0", default-features = false, features = [
   "client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,7 +195,14 @@ rstest = "0.26"
 # Rust crate versions are resolved at compile time, not through runtime
 # variables. To avoid broad source sweeps on upgrades, keep each crate's API
 # surface behind the local seam files listed here and update those first.
-ratatui = ["src/ui/tui.rs", "src/tui_handle.rs"]
+ratatui = [
+  "src/ui/tui.rs",
+  "src/ui/layout.rs",
+  "src/ui/render/mod.rs",
+  "src/ui/render/transcript.rs",
+  "src/ui/render/markdown.rs",
+  "src/tui_handle.rs",
+]
 crossterm = [
   "src/ui/tui.rs",
   "src/tui_frontend.rs",
@@ -287,6 +294,7 @@ git2 = ["src/tools/operator/git_ops.rs"]
 
 [workspace.metadata.upgrade-notes]
 rust = "Update workspace.package.rust-version and CI toolchain declarations together; also update clippy.toml msrv field."
+ratatui = "Keep 0.30 API churn localized to the facade plus the small layout/render adapter set. Prefer Layout::vertical(...).areas(), Constraint::Fill, Style::new(), Block::bordered()/title_top(), and Text::raw()/from_iter() over legacy builder forms when touching those files."
 serde = "Derive and field/container attributes are compile-time only; a facade does not reduce churn here."
 tokio = "Runtime helpers are localized in src/runtime/tokio.rs; attribute macros like #[tokio::test] remain direct in tests and binaries."
 tree-sitter = "All five grammar crates share the same seam (src/tools/index.rs); bump them together."

--- a/TASKS/ACTIVE-ROADMAP.md
+++ b/TASKS/ACTIVE-ROADMAP.md
@@ -6,7 +6,7 @@ and `TASKS/TASKS-WORK-MAP.md` reference this file -- they do not duplicate it.
 Updated by the merge workflow after each ADR-scoped PR lands on main.
 Do not edit manually except via the standard exact-diff workflow.
 
-Last updated: 2026-04-20 (ADR-022 amendment: normalized CLI flag surface, ChatCompat CLI cutover, 10-flag normative table)
+Last updated: 2026-05-16 (ADR-031 maintenance amendment: ratatui 0.30 seam coverage staging and top-10 API batch)
 
 ---
 
@@ -21,7 +21,7 @@ Last updated: 2026-04-20 (ADR-022 amendment: normalized CLI flag surface, ChatCo
 | ADR-028 | Active | Ongoing boundary alignment | Phase 1, 2, and transport extraction committed 2026-03-25; boundary tests now cover direct, grouped, multiline, and `super::`-relative `server`/`bin` imports for all inner layers |
 | ADR-029 | Accepted (amended 2026-04-01) | 0 items remaining | All 8 decision items verified in Tier 5 (PR #249); Amendment adds StreamTextNormaliser boundary for embedded tool call markup (PR #305) |
 | ADR-030 | Accepted | 0 items remaining | All 6 coverage requirements verified in Tier 5 (PR #249) |
-| ADR-031 | Accepted (all batches A-E merged) | 0 items remaining | Status updated in Tier 9 (PR #252) |
+| ADR-031 | Accepted (all batches A-E merged; 2026-05-16 API-coverage amendment) | 4 maintenance batches planned | Core operator-surface contract complete; ratatui 0.30 seam coverage now tracks the facade plus layout/render adapters |
 | ADR-032 | Accepted | 0 items remaining | Items 1-8 complete; item 4-5 verified Tier 5; item 9 transferred to ADR-033 |
 | ADR-033 | Accepted (all phases 1-4 merged) | 0 items remaining | Status updated in Tier 9 (PR #252) |
 | ADR-034 | Accepted (all phases A-E + watch-stream merged) | 0 items remaining | Phase E2 watch-stream added: GET /v1/session-tasks/{id}/watch SSE with immediate rollup + broadcast fan-out; PR #261 closes Phase E watch-stream |
@@ -75,6 +75,20 @@ composer ergonomics, overlay or pager detail surfaces, transient timeline
 discoverability, and active or fallback fullscreen convergence without
 introducing a permanent telemetry pane. Parser work remains limited to
 normalisation hardening unless ADR-043 adoption gates are satisfied.
+
+ADR-031 also carries a maintenance-only ratatui 0.30 adoption lane. Batch 1
+lands the first 10 high-applicability APIs from the 100-entry audit:
+`Text::raw`, `Text::from_iter`, `Style::new`, `Block::bordered`,
+`Block::title_top`, `Layout::vertical(...).areas(...)`, `Constraint::Fill`,
+and the associated `Stylize` shorthand families already aligned with the
+operator surface's semantic color and secondary-text rules. The remaining 90
+inventory entries are grouped into four follow-on batches: Batch 2 for text,
+alignment, block, and layout refinements; Batch 3 for stateful widgets and
+scroll affordances only if the operator model requires them; Batch 4 for custom
+widgets, `render_widget_ref`, and buffer-level APIs when reusable
+high-performance surfaces become necessary; Batch 5 for niche or deliberately
+deferred APIs such as fullscreen viewport, masked text, underline-color
+styling, and custom border symbol sets.
 
 ADR-041 D5/D6/D7 (delta types, delta-native draw methods, bounded suffix
 deduplication) merged in PR #331 (commit e1dd681) on 2026-04-03.

--- a/adr/ADR-031-operator-surface-ui-overhaul.md
+++ b/adr/ADR-031-operator-surface-ui-overhaul.md
@@ -22,3 +22,48 @@ The pre-ADR-031 TUI used a fixed layout with no scrolling transcript and mixed o
 
 - [`ratatui`](https://docs.rs/ratatui) — TUI framework
 - [`crossterm`](https://docs.rs/crossterm) — console backend
+
+## Amendment 2026-05-16 — ratatui 0.30 seam coverage staging
+
+PR #384 localized dependency version ownership in the root manifest, but the
+ratatui seam inventory remained narrower than the modules that absorb API churn
+in practice. The stable operator surface now depends on the facade
+`src/ui/tui.rs`, the layout adapter `src/ui/layout.rs`, and the render adapters
+in `src/ui/render/`. A 100-entry ratatui 0.30 audit places current coverage at
+17 percent and shows that the highest-value missing APIs are concentrated in
+text/style/layout/block builders rather than in stateful widgets or buffer-level
+rendering.
+
+This amendment records a maintenance rule rather than a new product
+requirement.
+
+- Treat the facade plus the small layout/render adapter set as one
+	upgrade-maintained ratatui seam.
+- The first maintenance batch prioritizes 10 APIs: `Text::raw`,
+	`Text::from_iter`, `Stylize` semantic accent shorthands, `Stylize`
+	neutral-tone shorthands, `Stylize` modifier shorthands, `Style::new`,
+	`Block::bordered`, `Block::title_top`, `Layout::vertical(...).areas(...)`,
+	and `Constraint::Fill`.
+- Do not chase raw coverage by wiring APIs that do not match the present
+	interaction model. `List`, `Table`, `Scrollbar`, `Tabs`, `Gauge`, custom
+	`Widget` implementations, and buffer-level writes remain optional until
+	selection state, structured tabulation, or reusable low-level widgets become
+	architectural requirements.
+
+Official ratatui 0.30 documentation makes these APIs the idiomatic surface for
+new code. Comparable public Rust terminal applications reviewed during this
+change show the same ordering: text/layout/style first; stateful widgets only
+when the UI genuinely needs external widget state.
+
+The remaining 90 audited APIs stay staged into four follow-on maintenance
+batches: Batch 2 for text/alignment/block/layout refinements, Batch 3 for
+stateful widgets only when the interaction model requires them, Batch 4 for
+custom widgets and buffer-level rendering APIs, and Batch 5 for niche or
+deliberately deferred surfaces.
+
+### References (added)
+
+- RAT-2: ratatui `Text` docs — constructors and iterator conversion (`https://docs.rs/ratatui/latest/ratatui/text/struct.Text.html`).
+- RAT-3: ratatui `Style` and `Stylize` docs — `Style::new` and named style shorthands (`https://docs.rs/ratatui/latest/ratatui/style/struct.Style.html`, `https://docs.rs/ratatui/latest/ratatui/style/trait.Stylize.html`).
+- RAT-4: ratatui `Block` docs — `Block::bordered` and `title_top` (`https://docs.rs/ratatui/latest/ratatui/widgets/struct.Block.html`).
+- RAT-5: ratatui `Layout` docs — `Layout::vertical(...).areas(...)` and `Constraint::Fill` (`https://docs.rs/ratatui/latest/ratatui/layout/struct.Layout.html`, `https://docs.rs/ratatui/latest/ratatui/layout/enum.Constraint.html`).

--- a/adr/ADR-031-operator-surface-ui-overhaul.md
+++ b/adr/ADR-031-operator-surface-ui-overhaul.md
@@ -51,9 +51,9 @@ requirement.
 	architectural requirements.
 
 Official ratatui 0.30 documentation makes these APIs the idiomatic surface for
-new code. Comparable public Rust terminal applications reviewed during this
-change show the same ordering: text/layout/style first; stateful widgets only
-when the UI genuinely needs external widget state.
+new code. Comparable public Rust TUI codebases reviewed during this change
+show the same ordering: text/layout/style first; stateful widgets only when
+the UI genuinely needs external widget state.
 
 The remaining 90 audited APIs stay staged into four follow-on maintenance
 batches: Batch 2 for text/alignment/block/layout refinements, Batch 3 for

--- a/adr/ADR-031-operator-surface-ui-overhaul.md
+++ b/adr/ADR-031-operator-surface-ui-overhaul.md
@@ -38,17 +38,17 @@ This amendment records a maintenance rule rather than a new product
 requirement.
 
 - Treat the facade plus the small layout/render adapter set as one
-	upgrade-maintained ratatui seam.
+  upgrade-maintained ratatui seam.
 - The first maintenance batch prioritizes 10 APIs: `Text::raw`,
-	`Text::from_iter`, `Stylize` semantic accent shorthands, `Stylize`
-	neutral-tone shorthands, `Stylize` modifier shorthands, `Style::new`,
-	`Block::bordered`, `Block::title_top`, `Layout::vertical(...).areas(...)`,
-	and `Constraint::Fill`.
+  `Text::from_iter`, `Stylize` semantic accent shorthands, `Stylize`
+  neutral-tone shorthands, `Stylize` modifier shorthands, `Style::new`,
+  `Block::bordered`, `Block::title_top`, `Layout::vertical(...).areas(...)`,
+  and `Constraint::Fill`.
 - Do not chase raw coverage by wiring APIs that do not match the present
-	interaction model. `List`, `Table`, `Scrollbar`, `Tabs`, `Gauge`, custom
-	`Widget` implementations, and buffer-level writes remain optional until
-	selection state, structured tabulation, or reusable low-level widgets become
-	architectural requirements.
+  interaction model. `List`, `Table`, `Scrollbar`, `Tabs`, `Gauge`, custom
+  `Widget` implementations, and buffer-level writes remain optional until
+  selection state, structured tabulation, or reusable low-level widgets become
+  architectural requirements.
 
 Official ratatui 0.30 documentation makes these APIs the idiomatic surface for
 new code. Comparable public Rust TUI codebases reviewed during this change

--- a/deny.toml
+++ b/deny.toml
@@ -87,22 +87,6 @@ id = "RUSTSEC-2024-0320"
 reason = "yaml-rust 0.4.5 is unmaintained; pulled in transitively via syntect v5.3.0 for TextMate grammar parsing. No security vulnerability; syntect uses it to parse read-only bundled grammar files, not user-supplied YAML. Resolution: remove when syntect switches to yaml-rust2."
 
 [[advisories.ignore]]
-id = "RUSTSEC-2025-0134"
-reason = "rustls-pemfile 1.0.4 is unmaintained; pulled in transitively via hickory-proto v0.24.4 → hickory-resolver v0.24.4. This codebase does not use rustls-pemfile's PEM parsing API directly. Resolution: remove when hickory-resolver upgrades to a version that depends on rustls-pki-types ≥1.9.0 directly."
-
-[[advisories.ignore]]
-id = "RUSTSEC-2026-0098"
-reason = "rustls-webpki 0.101.7 vulnerability (URI name constraint bypass) pulled in transitively via hickory-resolver v0.24.4 → tokio-rustls. This codebase uses DoH (DNS-over-HTTPS) and does not rely on URI name constraint validation. Resolution: remove when hickory-resolver upgrades to a version using rustls-webpki ≥0.102."
-
-[[advisories.ignore]]
-id = "RUSTSEC-2026-0099"
-reason = "rustls-webpki 0.101.7 vulnerability (wildcard certificate name constraint bypass) pulled in transitively via hickory-resolver v0.24.4 → tokio-rustls. This codebase uses DoH only; the DNS resolution path does not verify wildcard name constraints against user-controlled certificates. Resolution: remove when hickory-resolver upgrades to rustls-webpki ≥0.102."
-
-[[advisories.ignore]]
-id = "RUSTSEC-2026-0104"
-reason = "rustls-webpki 0.101.7 reachable panic in CRL parsing via BorrowedCertRevocationList::from_der / OwnedCertRevocationList::from_der; pulled in transitively via hickory-resolver v0.24.4 → rustls v0.21.12. This codebase does not parse certificate revocation lists; the advisory explicitly states applications that do not use CRLs are not affected. The 0.103.13 fix only targets the 0.103.x branch; no 0.101.x patch exists upstream. Resolution: remove when hickory-resolver upgrades to rustls ≥0.23."
-
-[[advisories.ignore]]
 id = "RUSTSEC-2025-0012"
 reason = "backoff 0.4.0 is intentionally used for bounded local-startup connection retries on the CLI API transport path. The retry scope is local connect failures before any streaming response exists, and the dependency is not exposed across trust boundaries. Resolution: remove this exception when the requested retry lane migrates to a maintained equivalent such as backon without widening the transport surface."
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,6 +1,7 @@
 # Summary
 
 - [Build From Source](introduction.md)
+- [Dependency Upgrades](dependency-upgrades.md)
 - [macOS](macos.md)
 - [Linux](linux.md)
 - [Windows PowerShell](windows.md)

--- a/docs/src/dependency-upgrades.md
+++ b/docs/src/dependency-upgrades.md
@@ -202,9 +202,14 @@ The source of truth is the root `Cargo.toml`
 tables. Cargo ignores those entries; they exist for maintainers and automation
 so future bumps start from one checklist and one reviewed file map.
 
-- `ratatui` and `crossterm`: start in `src/ui/tui.rs`, then adjust the small
-  TUI adapter set listed in the metadata table (`src/tui_handle.rs`,
-  `src/tui_frontend.rs`, `src/ui/editor/mod.rs`, and nearby UI call sites).
+- `ratatui`: start in `src/ui/tui.rs`, then treat `src/ui/layout.rs`,
+  `src/ui/render/mod.rs`, `src/ui/render/transcript.rs`,
+  `src/ui/render/markdown.rs`, and `src/tui_handle.rs` as the maintained
+  adapter set. Those files absorb the current 0.30 layout, style, text, and
+  block-builder churn.
+- `crossterm`: start in `src/ui/tui.rs`, then adjust the small TUI adapter set
+  listed in the metadata table (`src/tui_frontend.rs`, `src/ui/editor/mod.rs`,
+  `src/app.rs`, `src/app/overlay.rs`, and nearby input/event call sites).
 - `async-compression`: keep codec and output-cap changes localized to
   `src/net/compression.rs`.
 - `jsonwebtoken`: keep JWT claim parsing and signature helper changes
@@ -235,6 +240,50 @@ so future bumps start from one checklist and one reviewed file map.
 The goal is not zero source edits. The goal is to keep upgrade work inside a
 declared set of seam files instead of re-touching unrelated call sites across
 the tree.
+
+## Ratatui 0.30 coverage staging
+
+A 100-entry ratatui 0.30 audit is a maintenance inventory, not a requirement
+to maximize raw percentage mechanically. This repository should prioritize APIs
+that satisfy three filters simultaneously: high community usage, direct
+applicability to the existing operator surface, and low risk of changing render
+semantics.
+
+The first maintenance batch covers these 10 APIs:
+
+- `Text::raw` for single-string paragraphs and status text.
+- `Text::from_iter` for `Vec<Line>` to `Text` construction without an extra
+  conversion pass.
+- `Stylize` named foreground shorthands for semantic accent colors already used
+  on the operator surface.
+- `Stylize` neutral-tone shorthands for secondary and status text.
+- `Stylize` modifier shorthands such as `bold` and `dim`.
+- `Style::new` as the preferred 0.30 style constructor.
+- `Block::bordered` instead of `Block::default().borders(Borders::ALL)`.
+- `Block::title_top` when a block owns an explicit top title row.
+- `Layout::vertical([...]).areas(...)` instead of
+  `Layout::default().direction(...).split(...)`.
+- `Constraint::Fill(weight)` for the elastic pane in mixed fixed/flexible
+  layouts.
+
+The remaining 90 audit items are staged into four follow-on batches by
+interaction cost rather than by raw popularity:
+
+- Batch 2: text mutation/alignment helpers, block padding/border styling, and
+  layout refinements such as `Layout::horizontal`, `Margin`, and `Flex`.
+- Batch 3: stateful widgets (`List`, `Table`, `Scrollbar`, `Tabs`, `Gauge`)
+  only when the operator surface actually needs selection state or structured
+  tabulation.
+- Batch 4: custom `Widget` / `StatefulWidget` implementations,
+  `render_widget_ref`, and buffer-level APIs for reusable high-performance
+  components.
+- Batch 5: niche or deliberately deferred APIs such as fullscreen viewport,
+  masked text, underline-color styling, and custom border symbol sets.
+
+Official ratatui 0.30 documentation is the normative source for these APIs.
+Comparable public Rust terminal applications reviewed during this change follow
+the same adoption order: text/layout/style first, stateful widgets only once
+the interaction model requires them.
 
 ## Investigating impact
 

--- a/docs/src/dependency-upgrades.md
+++ b/docs/src/dependency-upgrades.md
@@ -281,9 +281,9 @@ interaction cost rather than by raw popularity:
   masked text, underline-color styling, and custom border symbol sets.
 
 Official ratatui 0.30 documentation is the normative source for these APIs.
-Comparable public Rust terminal applications reviewed during this change follow
-the same adoption order: text/layout/style first, stateful widgets only once
-the interaction model requires them.
+Comparable public Rust TUI codebases reviewed during this change follow the
+same adoption order: text/layout/style first, stateful widgets only once the
+interaction model requires them.
 
 ## Investigating impact
 

--- a/src/net/dns.rs
+++ b/src/net/dns.rs
@@ -1,10 +1,12 @@
 use anyhow::{Context, Result};
 use hickory_resolver::{
-    TokioAsyncResolver,
-    config::{NameServerConfig, Protocol, ResolverConfig, ResolverOpts},
+    TokioResolver,
+    config::{ConnectionConfig, NameServerConfig, ResolverConfig},
+    net::runtime::TokioRuntimeProvider,
 };
 use std::net::IpAddr;
 use std::str::FromStr;
+use std::sync::Arc;
 use std::time::Duration;
 
 pub mod doh_endpoints {
@@ -13,30 +15,31 @@ pub mod doh_endpoints {
 }
 
 pub struct DohResolver {
-    inner: TokioAsyncResolver,
+    inner: TokioResolver,
 }
 
 impl DohResolver {
     pub fn new(doh_server_ip: IpAddr, doh_server_port: u16, tls_dns_name: &str) -> Result<Self> {
-        let name_server = NameServerConfig {
-            socket_addr: std::net::SocketAddr::new(doh_server_ip, doh_server_port),
-            protocol: Protocol::Https,
-            tls_dns_name: Some(tls_dns_name.to_string()),
-            trust_negative_responses: false,
-            tls_config: None,
-            bind_addr: None,
-        };
+        let mut connection = ConnectionConfig::https(Arc::from(tls_dns_name), None);
+        connection.port = doh_server_port;
 
-        let mut config = ResolverConfig::new();
-        config.add_name_server(name_server);
+        let config = ResolverConfig::from_parts(
+            None,
+            vec![],
+            vec![NameServerConfig::new(
+                doh_server_ip,
+                false,
+                vec![connection],
+            )],
+        );
 
-        let mut opts = ResolverOpts::default();
-
+        let mut builder = TokioResolver::builder_with_config(config, TokioRuntimeProvider::default());
+        let opts = builder.options_mut();
         opts.ip_strategy = hickory_resolver::config::LookupIpStrategy::Ipv6thenIpv4;
         opts.timeout = Duration::from_secs(5);
         opts.attempts = 2;
 
-        let inner = TokioAsyncResolver::tokio(config, opts);
+        let inner = builder.build()?;
         Ok(Self { inner })
     }
 

--- a/src/net/dns.rs
+++ b/src/net/dns.rs
@@ -33,7 +33,8 @@ impl DohResolver {
             )],
         );
 
-        let mut builder = TokioResolver::builder_with_config(config, TokioRuntimeProvider::default());
+        let mut builder =
+            TokioResolver::builder_with_config(config, TokioRuntimeProvider::default());
         let opts = builder.options_mut();
         opts.ip_strategy = hickory_resolver::config::LookupIpStrategy::Ipv6thenIpv4;
         opts.timeout = Duration::from_secs(5);

--- a/src/tui_frontend.rs
+++ b/src/tui_frontend.rs
@@ -689,10 +689,32 @@ fn inline_rows_to_insert(
         return None;
     }
 
+    // Inline scrollback is only safe when newly visible rows are a strict
+    // append-only extension of the previous frame. Streaming text can still
+    // reflow or mutate earlier wrapped rows, and replaying those stale rows
+    // into scrollback duplicates or drops visible content.
+    if !transcript_rows_extend_append_only(
+        &previous.expanded_output_rows,
+        &current.expanded_output_rows,
+    ) {
+        return None;
+    }
+
     let end = current
         .visible_start
         .min(previous.expanded_output_rows.len());
     (end > previous.visible_start).then_some((previous.visible_start, end))
+}
+
+fn transcript_rows_extend_append_only(
+    previous: &[crate::app::TranscriptRow],
+    current: &[crate::app::TranscriptRow],
+) -> bool {
+    current.len() >= previous.len()
+        && previous
+            .iter()
+            .zip(current.iter())
+            .all(|(prev, next)| prev == next)
 }
 
 pub(crate) mod picker;
@@ -755,7 +777,15 @@ mod tests {
             task_id: "task-1".to_string(),
             area: Rect::new(0, 0, 80, 20),
             visible_start: 4,
-            expanded_output_rows: vec![].into(),
+            expanded_output_rows: vec![
+                crate::app::TranscriptRow::Plain("a".to_string()),
+                crate::app::TranscriptRow::Plain("b".to_string()),
+                crate::app::TranscriptRow::Plain("c".to_string()),
+                crate::app::TranscriptRow::Plain("d".to_string()),
+                crate::app::TranscriptRow::Plain("e".to_string()),
+                crate::app::TranscriptRow::Plain("f".to_string()),
+            ]
+            .into(),
         };
 
         assert_eq!(inline_rows_to_insert(&previous, &current), Some((2, 4)));
@@ -784,5 +814,49 @@ mod tests {
 
         assert_eq!(inline_rows_to_insert(&previous, &resized), None);
         assert_eq!(inline_rows_to_insert(&previous, &same_window), None);
+    }
+
+    #[test]
+    fn inline_scrollback_skips_mutated_streaming_windows() {
+        let previous = InlineScrollbackSnapshot {
+            task_id: "task-1".to_string(),
+            area: Rect::new(0, 0, 80, 20),
+            visible_start: 1,
+            expanded_output_rows: vec![
+                crate::app::TranscriptRow::Plain("prompt".to_string()),
+                crate::app::TranscriptRow::AssistantText {
+                    text: "partial line".to_string(),
+                    streaming: true,
+                },
+                crate::app::TranscriptRow::AssistantText {
+                    text: "stable tail".to_string(),
+                    streaming: true,
+                },
+            ]
+            .into(),
+        };
+        let current = InlineScrollbackSnapshot {
+            task_id: "task-1".to_string(),
+            area: Rect::new(0, 0, 80, 20),
+            visible_start: 2,
+            expanded_output_rows: vec![
+                crate::app::TranscriptRow::Plain("prompt".to_string()),
+                crate::app::TranscriptRow::AssistantText {
+                    text: "partial line extended".to_string(),
+                    streaming: true,
+                },
+                crate::app::TranscriptRow::AssistantText {
+                    text: "stable tail".to_string(),
+                    streaming: true,
+                },
+                crate::app::TranscriptRow::AssistantText {
+                    text: "new tail".to_string(),
+                    streaming: true,
+                },
+            ]
+            .into(),
+        };
+
+        assert_eq!(inline_rows_to_insert(&previous, &current), None);
     }
 }

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -1,4 +1,4 @@
-use crate::ui::tui::layout::{Constraint, Direction, Layout};
+use crate::ui::tui::layout::{Constraint, Layout};
 
 pub use crate::ui::tui::layout::Rect;
 
@@ -13,19 +13,17 @@ pub struct ThreePaneLayout {
 }
 
 pub fn split_three_pane_layout(area: Rect, input_rows: u16) -> ThreePaneLayout {
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(0),
-            Constraint::Min(1),
-            Constraint::Length(input_rows.max(1)),
-        ])
-        .split(area);
+    let [header, history, input] = Layout::vertical([
+        Constraint::Length(0),
+        Constraint::Fill(1),
+        Constraint::Length(input_rows.max(1)),
+    ])
+    .areas(area);
 
     ThreePaneLayout {
-        header: chunks[0],
-        history: chunks[1],
-        input: chunks[2],
+        header,
+        history,
+        input,
     }
 }
 
@@ -54,21 +52,19 @@ pub fn split_four_region_layout(area: Rect, header_rows: u16, input_rows: u16) -
         .clamp(1, MAX_INPUT_PANE_ROWS as u16)
         .min(max_input_rows);
 
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(header_rows),
-            Constraint::Length(0),
-            Constraint::Min(1),
-            Constraint::Length(input_rows),
-        ])
-        .split(area);
+    let [header, activity, output, input] = Layout::vertical([
+        Constraint::Length(header_rows),
+        Constraint::Length(0),
+        Constraint::Fill(1),
+        Constraint::Length(input_rows),
+    ])
+    .areas(area);
 
     FourRegionLayout {
-        header: chunks[0],
-        activity: chunks[1],
-        output: chunks[2],
-        input: chunks[3],
+        header,
+        activity,
+        output,
+        input,
     }
 }
 
@@ -86,22 +82,20 @@ pub(crate) fn split_compact_task_layout(
     let available_for_output = remaining.saturating_sub(capped_input);
     let capped_output = output_rows.min(available_for_output);
 
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(header_rows),
-            Constraint::Length(0),
-            Constraint::Length(capped_output),
-            Constraint::Length(capped_input),
-            Constraint::Min(0),
-        ])
-        .split(area);
+    let [header, activity, output, input, _remaining] = Layout::vertical([
+        Constraint::Length(header_rows),
+        Constraint::Length(0),
+        Constraint::Length(capped_output),
+        Constraint::Length(capped_input),
+        Constraint::Fill(1),
+    ])
+    .areas(area);
 
     FourRegionLayout {
-        header: chunks[0],
-        activity: chunks[1],
-        output: chunks[2],
-        input: chunks[3],
+        header,
+        activity,
+        output,
+        input,
     }
 }
 

--- a/src/ui/render/mod.rs
+++ b/src/ui/render/mod.rs
@@ -4,10 +4,10 @@ use crate::ui::input_metrics::{
 use crate::ui::layout::{preferred_four_region_input_rows_for_content, split_compact_task_layout};
 use crate::ui::tui::{
     Frame,
-    layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    layout::{Alignment, Constraint, Layout, Rect},
+    style::{Color, Style},
     text::{Line, Span, Text},
-    widgets::{Block, Borders, Clear, Paragraph, Wrap},
+    widgets::{Block, Clear, Paragraph, Wrap},
 };
 
 pub use crate::ui::layout::MAX_INPUT_PANE_ROWS;
@@ -59,11 +59,9 @@ fn render_input_with_actions(
     let (action_area, inner) = if action_rows == 0 {
         (Rect::new(area.x, area.y, area.width, 0), area)
     } else {
-        let chunks = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([Constraint::Length(action_rows), Constraint::Min(1)])
-            .split(area);
-        (chunks[0], chunks[1])
+        let [action_area, inner] =
+            Layout::vertical([Constraint::Length(action_rows), Constraint::Fill(1)]).areas(area);
+        (action_area, inner)
     };
 
     if action_area.height > 0 {
@@ -72,7 +70,7 @@ fn render_input_with_actions(
             [line] => Paragraph::new(line.clone()),
             _ => Paragraph::new(visible_actions.to_vec()),
         }
-        .style(Style::default().bg(Color::Rgb(24, 24, 24)))
+        .style(Style::new().bg(Color::Rgb(24, 24, 24)))
         .alignment(Alignment::Left);
         frame.render_widget(paragraph, action_area);
     }
@@ -98,10 +96,10 @@ fn render_input_with_actions(
     frame.render_widget(
         Paragraph::new(rendered)
             .style(
-                Style::default()
+                Style::new()
                     .fg(Color::Gray)
                     .bg(Color::Rgb(24, 24, 24))
-                    .add_modifier(Modifier::DIM),
+                    .dim(),
             )
             .wrap(Wrap { trim: false }),
         inner,
@@ -150,7 +148,7 @@ pub fn render_messages(frame: &mut Frame<'_>, area: Rect, messages: &[String]) {
     let total_lines = body.len();
     let scroll = total_lines.saturating_sub(inner.height as usize);
     let paragraph =
-        Paragraph::new(Text::from(body)).scroll((scroll.min(u16::MAX as usize) as u16, 0));
+        Paragraph::new(Text::from_iter(body)).scroll((scroll.min(u16::MAX as usize) as u16, 0));
     frame.render_widget(paragraph, inner);
 }
 
@@ -207,12 +205,7 @@ fn format_history_row_segment(
         format!("{:>line_number_width$} | ", "")
     };
     Line::from(vec![
-        Span::styled(
-            line_prefix,
-            Style::default()
-                .fg(Color::DarkGray)
-                .add_modifier(Modifier::DIM),
-        ),
+        Span::styled(line_prefix, Style::new().dark_gray().dim()),
         Span::styled(row.to_string(), style),
     ])
 }
@@ -281,7 +274,7 @@ fn diff_line_color(kind: DiffLineKind, other_color: Color) -> Color {
 }
 
 fn history_row_style(row: &str) -> Style {
-    Style::default().fg(diff_line_color(classify_diff_line(row), Color::White))
+    Style::new().fg(diff_line_color(classify_diff_line(row), Color::White))
 }
 
 pub fn render_status_line(frame: &mut Frame<'_>, area: Rect, status: &str) {
@@ -291,7 +284,7 @@ pub fn render_status_line(frame: &mut Frame<'_>, area: Rect, status: &str) {
 
     let text = truncate_line(status, area.width as usize);
     frame.render_widget(
-        Paragraph::new(text).style(Style::default().fg(Color::DarkGray)),
+        Paragraph::new(Text::raw(text)).style(Style::new().dark_gray()),
         area,
     );
 }
@@ -300,16 +293,10 @@ fn task_fork_action_line() -> Line<'static> {
     Line::from(vec![
         Span::styled(
             " Fork ",
-            Style::default()
-                .fg(Color::Black)
-                .bg(Color::Cyan)
-                .add_modifier(Modifier::BOLD),
+            Style::new().fg(Color::Black).bg(Color::Cyan).bold(),
         ),
-        Span::styled(
-            " Alt+F",
-            Style::default().fg(Color::Cyan).add_modifier(Modifier::DIM),
-        ),
-        Span::styled(" new task-id", Style::default().fg(Color::DarkGray)),
+        Span::styled(" Alt+F", Style::new().cyan().dim()),
+        Span::styled(" new task-id", Style::new().dark_gray()),
     ])
 }
 
@@ -406,9 +393,7 @@ fn render_picker_overlay(
     let area = Rect::new(composer_area.x, y, width, height);
 
     frame.render_widget(Clear, area);
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .style(Style::default().fg(Color::DarkGray));
+    let block = Block::bordered().style(Style::new().dark_gray());
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
@@ -420,18 +405,14 @@ fn render_picker_overlay(
         .iter()
         .take(inner.height as usize)
         .map(|line| {
-            let style = if line.selected {
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD)
+            let text = truncate_line(&line.text, inner.width as usize);
+            if line.selected {
+                Line::from(text).style(Style::new().cyan().bold())
             } else if line.text.starts_with('[') || line.text.starts_with('/') {
-                Style::default()
-                    .fg(Color::DarkGray)
-                    .add_modifier(Modifier::DIM)
+                Line::from(text).style(Style::new().dark_gray().dim())
             } else {
-                Style::default().fg(Color::White)
-            };
-            Line::styled(truncate_line(&line.text, inner.width as usize), style)
+                Line::from(text).style(Style::new().fg(Color::White))
+            }
         })
         .collect::<Vec<_>>();
 
@@ -449,36 +430,28 @@ pub fn render_overlay_modal_in_area(frame: &mut Frame<'_>, anchor: Rect, modal: 
 
     let preferred_height = modal_preferred_height(&modal);
     let area = centered_modal_area(anchor, preferred_height);
-    let provisional_outer = Block::default().borders(Borders::ALL);
+    let provisional_outer = Block::bordered();
     let provisional_inner = provisional_outer.inner(area);
-    let provisional_vertical = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Min(3), Constraint::Length(1)])
-        .split(provisional_inner);
-    let provisional_body_area = provisional_vertical[0];
-    let body_block = Block::default().borders(Borders::ALL).title("Body");
+    let [provisional_body_area, _provisional_shortcuts_area] =
+        Layout::vertical([Constraint::Fill(1), Constraint::Length(1)]).areas(provisional_inner);
+    let body_block = Block::bordered().title_top(Line::from("Body"));
     let body_inner = body_block.inner(provisional_body_area);
     let (title, accent, body, shortcuts) = modal_content(modal, body_inner.height as usize);
 
     frame.render_widget(Clear, area);
-    let outer = Block::default()
-        .borders(Borders::ALL)
-        .title(title)
-        .style(Style::default().fg(accent));
+    let outer = Block::bordered()
+        .title_top(Line::from(title))
+        .style(Style::new().fg(accent));
     let inner = outer.inner(area);
     frame.render_widget(outer, area);
-    let vertical = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Min(3), Constraint::Length(1)])
-        .split(inner);
-    let body_area = vertical[0];
-    let shortcuts_area = vertical[1];
-    let body_block = Block::default().borders(Borders::ALL).title("Body");
+    let [body_area, shortcuts_area] =
+        Layout::vertical([Constraint::Fill(1), Constraint::Length(1)]).areas(inner);
+    let body_block = Block::bordered().title_top(Line::from("Body"));
     let body_inner = body_block.inner(body_area);
     frame.render_widget(body_block, body_area);
 
     frame.render_widget(
-        Paragraph::new(Text::from(body))
+        Paragraph::new(Text::from_iter(body))
             .alignment(Alignment::Left)
             .wrap(Wrap { trim: false }),
         body_inner,
@@ -487,7 +460,7 @@ pub fn render_overlay_modal_in_area(frame: &mut Frame<'_>, anchor: Rect, modal: 
     frame.render_widget(
         Paragraph::new(shortcuts)
             .alignment(Alignment::Center)
-            .style(Style::default().fg(Color::DarkGray)),
+            .style(Style::new().dark_gray()),
         shortcuts_area,
     );
 }
@@ -523,10 +496,7 @@ fn modal_content(
                 lines.len()
             )));
             body.push(Line::from(""));
-            body.push(Line::styled(
-                "Patch",
-                Style::default().add_modifier(Modifier::BOLD),
-            ));
+            body.push(Line::styled("Patch", Style::new().bold()));
             for line in lines.iter().skip(start).take(visible) {
                 body.push(styled_diff_line(line));
             }
@@ -546,21 +516,16 @@ fn modal_content(
             let mut body = Vec::new();
             body.push(Line::styled(
                 format!("Tool: {tool_name}"),
-                Style::default().add_modifier(Modifier::BOLD),
+                Style::new().bold(),
             ));
             if auto_approve_enabled {
                 body.push(Line::styled(
                     "session auto-approve is ON",
-                    Style::default()
-                        .fg(Color::Green)
-                        .add_modifier(Modifier::BOLD),
+                    Style::new().fg(Color::Green).bold(),
                 ));
             }
             body.push(Line::from(""));
-            body.push(Line::styled(
-                "Preview",
-                Style::default().add_modifier(Modifier::BOLD),
-            ));
+            body.push(Line::styled("Preview", Style::new().yellow().bold()));
             let preview_lines: Vec<&str> = input_preview.lines().collect();
             let reserved_rows = if auto_approve_enabled { 4 } else { 3 };
             let max_preview_lines = body_viewport_rows.saturating_sub(reserved_rows).max(1);
@@ -573,9 +538,7 @@ fn modal_content(
                         "... ({} more lines)",
                         preview_lines.len() - max_preview_lines
                     ),
-                    Style::default()
-                        .fg(Color::DarkGray)
-                        .add_modifier(Modifier::DIM),
+                    Style::new().dark_gray().dim(),
                 ));
             }
             (
@@ -589,10 +552,7 @@ fn modal_content(
             "Memory Clear",
             Color::Yellow,
             vec![
-                Line::styled(
-                    "Clear all saved memory notes?",
-                    Style::default().add_modifier(Modifier::BOLD),
-                ),
+                Line::styled("Clear all saved memory notes?", Style::new().bold()),
                 Line::from("Type y or yes to confirm."),
                 Line::from("Any deny action leaves the notes file unchanged."),
             ],
@@ -604,7 +564,7 @@ fn modal_content(
 fn styled_diff_line(line: &str) -> Line<'static> {
     Line::styled(
         line.to_string(),
-        Style::default().fg(diff_line_color(classify_diff_line(line), Color::White)),
+        Style::new().fg(diff_line_color(classify_diff_line(line), Color::White)),
     )
 }
 

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -15,7 +15,7 @@ pub mod layout {
 }
 
 pub mod style {
-    pub use ratatui::style::{Color, Modifier, Style};
+    pub use ratatui::style::{Color, Modifier, Style, Stylize};
 }
 
 pub mod text {


### PR DESCRIPTION
## Summary
This PR is a follow-up to merged PR #384. It widens the maintained ratatui seam from the local facade alone to the facade plus the small layout/render adapter set, and it adopts the first 10 high-applicability ratatui 0.30 APIs inside that seam. It also updates ADR-031, the dependency-upgrade guide, the active roadmap, and the workspace seam metadata so the code and maintenance documentation describe the same staged adoption contract.

## Motivation
The 100-entry audit in `ratatui-api-map.jsx` reports roughly 17% coverage in the current tree. That percentage is not itself the target. The useful result is where the missing surface clusters. The audit and the current render code both show that the highest-value gaps are in text, style, layout, and block builders already exercised by the operator surface, while stateful widgets and buffer-level APIs remain optional until the interaction model requires them.

## Approach
- Extend the maintained ratatui seam to `src/ui/layout.rs`, `src/ui/render/mod.rs`, `src/ui/render/transcript.rs`, `src/ui/render/markdown.rs`, and `src/tui_handle.rs`.
- Adopt the first batch of 10 APIs in the active layout/render slice: `Text::raw`, `Text::from_iter`, `Style::new`, `Block::bordered`, `Block::title_top`, `Layout::vertical(...).areas(...)`, `Constraint::Fill`, and the `Stylize` shorthand families for semantic accents, neutral text, and modifiers.
- Replace older `Layout::default().direction(...).split(...)`, `Block::default().borders(...)`, and extra `Text` conversion patterns in the owning render/layout code.
- Record a five-batch maintenance plan: the current top-10 batch plus four follow-on batches for the remaining 90 audited APIs.

## Evidence
- Official ratatui 0.30 documentation makes these builders and constructors the idiomatic surface for new code:
  - `Text`: <https://docs.rs/ratatui/latest/ratatui/text/struct.Text.html>
  - `Style` / `Stylize`: <https://docs.rs/ratatui/latest/ratatui/style/struct.Style.html> and <https://docs.rs/ratatui/latest/ratatui/style/trait.Stylize.html>
  - `Block`: <https://docs.rs/ratatui/latest/ratatui/widgets/struct.Block.html>
  - `Layout` / `Constraint`: <https://docs.rs/ratatui/latest/ratatui/layout/struct.Layout.html> and <https://docs.rs/ratatui/latest/ratatui/layout/enum.Constraint.html>
- Public code-search review across multiple maintained Rust terminal applications showed the same ordering in practice: `Layout::vertical(...).areas(...)` and `Block::bordered()` appear broadly across maintained application code, while stateful widgets appear only once the UI owns explicit selection or scroll state.
- The in-repo audit ranks this batch at the highest overlap between usage frequency and direct applicability to the present operator surface.

## Remaining batch plan
- Batch 2: text mutation/alignment helpers, block padding and border styling, and layout refinements such as `Layout::horizontal`, `Margin`, and `Flex`.
- Batch 3: stateful widgets (`List`, `Table`, `Scrollbar`, `Tabs`, `Gauge`) only when the operator surface genuinely needs selection state or structured tabulation.
- Batch 4: custom `Widget` / `StatefulWidget` implementations, `render_widget_ref`, and buffer-level APIs for reusable high-performance components.
- Batch 5: niche or deliberately deferred surfaces such as fullscreen viewport, masked text, underline-color styling, and custom border symbol sets.

## Validation
- `cargo test ui::layout::tests --lib`
- `cargo test ui::render::tests --lib`
- `cargo fmt --check`
- `cargo check`
- `git diff --check`

## Risks
- Regression risk is low because the change stays inside the declared ratatui seam and preserves the existing operator interaction model.
- The primary residual risk is style drift if later render modules adopt a competing idiom subset; the seam metadata, roadmap, and ADR amendment are updated specifically to prevent that.
