### PR TITLE
Adopt more text and paragraph helpers in task renderer

### DIFF
--- a/TASKS/PR-400-ratatui-api-surface-map.md
+++ b/TASKS/PR-400-ratatui-api-surface-map.md
@@ -23,8 +23,8 @@ Consumed by: PR-400 Batch G checklist (see
 
 | # | API | Status | Source file(s) | Notes |
 | :--- | :--- | :--- | :--- | :--- |
-| 1 | `Text::raw(str)` | Active | `src/ui/render/mod.rs:287` | Used for status-line text before applying a top-level `Text` style. |
-| 2 | `Text::styled(str, style)` | Gap | - | Top-level styled constructor. Not used. |
+| 1 | `Text::raw(str)` | Gap | - | No remaining call sites after the status-line path moved to `Text::styled`. |
+| 2 | `Text::styled(str, style)` | Active | `src/ui/render/mod.rs` | Used for the status-line text with a top-level dark-gray style. |
 | 3 | `Text::from(Vec<Line>)` | Gap | - | ratatui 0.30 still exposes this conversion, but the repository deliberately leaves it unused at HEAD in favor of `Text::from_iter` and incremental `Text::push_line` assembly on the active render paths. |
 | 4 | `Text::from_iter(iter)` | Active | `src/ui/render/mod.rs`, `src/tui_handle.rs` | Iterator-based construction used for task-output rows, modal body text, and inline insert rows. |
 | 5 | `text.style(style)` | Active | `src/ui/render/mod.rs`, `src/tui_handle.rs` | Fluent top-level style setter used for status-line and inline insert text. |
@@ -33,8 +33,8 @@ Consumed by: PR-400 Batch G checklist (see
 | 8 | `text.left_aligned()` / `.centered()` / `.right_aligned()` | Gap | - | Shorthand alignment setters (0.26+). Not used. |
 | 9 | `text.push_line(line)` | Active | `src/ui/render/mod.rs` | In-place append used for composer visual rows and fallback message rows. |
 | 10 | `text.push_span(span)` | Gap | - | Append span to last line. Not used. |
-| 11 | `text.extend(iter<Line>)` | Gap | - | Implements Extend<Line>. Useful for merging transcript chunks. Not used. |
-| 12 | `text.width()` | Gap | - | Max unicode width across lines. Not used. |
+| 11 | `text.extend(iter<Line>)` | Active | `src/ui/render/mod.rs` | Used to append wrapped history-row segments without manual push loops. |
+| 12 | `text.width()` | Active | `src/ui/render/mod.rs` | Used for unicode-width-aware picker overlay sizing. |
 | 13 | `text.height()` | Active | `src/ui/render/mod.rs:148` | Used for fallback message scroll extent after `Text::push_line` assembly. |
 | 14 | `text.iter()` / `iter_mut()` | Gap | - | Line iterators. Not used. |
 
@@ -45,7 +45,7 @@ Consumed by: PR-400 Batch G checklist (see
 | 15 | `Line::raw(str)` | Gap | - | Unstyled single-line constructor. Not used. |
 | 16 | `Line::styled(str, style)` | Partial | `src/ui/render/mod.rs`, `src/ui/render/transcript.rs`, `src/ui/render/markdown.rs` | Used for focused rows, transcript diagnostics, and markdown rows. Not the dominant pattern. |
 | 17 | `Line::from(Vec<Span>)` | Active | `src/ui/render/mod.rs`, `src/ui/render/transcript.rs`, `src/ui/render/markdown.rs` | Dominant multi-style line pattern. Used extensively. |
-| 18 | `Line::from_iter(iter<Span>)` | Gap | - | Iterator-based construction. Not used. |
+| 18 | `Line::from_iter(iter<Span>)` | Active | `src/ui/render/mod.rs` | Used for history-row segments and the task fork-action chip. |
 | 19 | `line.style(style)` | Gap | - | Fluent setter on an existing line. Not used. |
 | 20 | `line.patch_style(style)` | Gap | - | Additive style on line. Not used. |
 | 21 | `line.left_aligned()` / `.centered()` / `.right_aligned()` | Gap | - | Per-line alignment overrides. Not used. |
@@ -106,12 +106,12 @@ Consumed by: PR-400 Batch G checklist (see
 | # | API | Status | Source file(s) | Notes |
 | :--- | :--- | :--- | :--- | :--- |
 | 49 | `Paragraph::new(text)` | Active | `src/ui/render/mod.rs`, `src/tui_handle.rs` | Primary render widget. Used throughout frame rendering and inline insert rendering. |
-| 50 | `paragraph.block(Block)` | Gap | - | Not used. Overlays render `Block` separately and then render paragraph content into the block inner area. |
+| 50 | `paragraph.block(Block)` | Active | `src/ui/render/mod.rs` | Used for modal body rendering so the body paragraph owns the bordered block directly. |
 | 51 | `paragraph.wrap(Wrap { trim })` | Active | `src/ui/render/mod.rs` | `trim: false` used in composer and modal body renders. |
 | 52 | `paragraph.scroll((row, col))` | Active | `src/ui/render/mod.rs` | Manual vertical scroll is used in fallback `render_messages`; primary task output uses row windowing before `Paragraph::new`. |
-| 53 | `paragraph.alignment(Alignment)` / `.centered()` | Active | `src/ui/render/mod.rs` | `Alignment::Left` and `Alignment::Center` used. |
+| 53 | `paragraph.alignment(Alignment)` / `.centered()` | Active | `src/ui/render/mod.rs` | `paragraph.left_aligned()` and `.centered()` are both used on active render paths. |
 | 54 | `paragraph.style(style)` | Active | `src/ui/render/mod.rs`, `src/tui_handle.rs` | Applied to full widget including status line, picker, and inline insert rendering. |
-| 55 | `paragraph.line_count(width)` [unstable] | Declared-only feature | - | Feature `unstable-rendered-line-info` enabled in Cargo.toml. `line_count()` is not called; it remains a candidate for rendered-line extent calculation. |
+| 55 | `paragraph.line_count(width)` [unstable] | Active | `src/ui/render/mod.rs` | Used for history visual-row counting with `Wrap { trim: false }` under the `unstable-rendered-line-info` feature. |
 
 ### 2.2 Block
 
@@ -230,10 +230,10 @@ Consumed by: PR-400 Batch G checklist (see
 
 | Status | Count |
 | :--- | :--- |
-| Active | 29 |
+| Active | 34 |
 | Partial | 2 |
-| Declared-only feature | 4 |
-| Gap | 66 |
+| Declared-only feature | 3 |
+| Gap | 62 |
 | **Total** | **101** |
 
 ### Declared-only API gaps (feature already declared, adoption decision pending)
@@ -243,7 +243,6 @@ Consumed by: PR-400 Batch G checklist (see
 | `unstable-widget-ref` | `WidgetRef` | Reference widget trait for reusable widgets |
 | `unstable-widget-ref` | `render_widget_ref` | Reference-based rendering; avoids clone on every frame for transcript widgets |
 | `unstable-widget-ref` | `StatefulWidgetRef` | Reference stateful rendering |
-| `unstable-rendered-line-info` | `paragraph.line_count(width)` | Correct scroll-max calculation without manual line-count math |
 | `unstable-backend-writer` | Direct backend writer access | Custom ANSI passthrough if needed |
 
 ### Implemented migration targets in this batch
@@ -255,3 +254,6 @@ Consumed by: PR-400 Batch G checklist (see
 | `Layout::default()...split(area)` | `Layout::vertical([...]).areas(area)` | `src/ui/layout.rs`, `src/ui/render/mod.rs` |
 | `Vec<Line>` + `Text::from()` at render boundary | `Text::from_iter(...)` | `src/ui/render/mod.rs`, `src/tui_handle.rs` |
 | `Vec<Line>` fallback message assembly | `Text::default()` + `text.push_line(...)` + `text.height()` | `src/ui/render/mod.rs` |
+| Manual wrapped-row line counting | `Paragraph::line_count(width)` | `src/ui/render/mod.rs` |
+| Manual `push_line(...)` loop for wrapped history rows | `text.extend(iter<Line>)` | `src/ui/render/mod.rs` |
+| Manual block render plus inner paragraph body render | `Paragraph::new(...).block(body_block)` | `src/ui/render/mod.rs` |

--- a/src/ui/render/mod.rs
+++ b/src/ui/render/mod.rs
@@ -1,10 +1,10 @@
 use crate::ui::input_metrics::{
-    cursor_row_col, display_width, visual_row_count, visual_window_start, wrap_input_lines,
+    cursor_row_col, visual_row_count, visual_window_start, wrap_input_lines,
 };
 use crate::ui::layout::{preferred_four_region_input_rows_for_content, split_compact_task_layout};
 use crate::ui::tui::{
     Frame,
-    layout::{Alignment, Constraint, Layout, Rect},
+    layout::{Constraint, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span, Text},
     widgets::{Block, Clear, Paragraph, Wrap},
@@ -71,7 +71,7 @@ fn render_input_with_actions(
             _ => Paragraph::new(visible_actions.to_vec()),
         }
         .style(Style::new().bg(Color::Rgb(24, 24, 24)))
-        .alignment(Alignment::Left);
+        .left_aligned();
         frame.render_widget(paragraph, action_area);
     }
 
@@ -134,15 +134,20 @@ pub fn render_messages(frame: &mut Frame<'_>, area: Rect, messages: &[String]) {
     for (index, row) in logical_rows.iter().enumerate() {
         let row_style = history_row_style(row);
         let wrapped_segments = wrap_input_lines(row, content_width);
-        for (segment_index, segment) in wrapped_segments.iter().enumerate() {
-            body.push_line(format_history_row_segment(
-                index + 1,
-                line_number_width,
-                segment,
-                row_style,
-                segment_index == 0,
-            ));
-        }
+        body.extend(
+            wrapped_segments
+                .iter()
+                .enumerate()
+                .map(|(segment_index, segment)| {
+                    format_history_row_segment(
+                        index + 1,
+                        line_number_width,
+                        segment,
+                        row_style,
+                        segment_index == 0,
+                    )
+                }),
+        );
     }
 
     let total_lines = body.height();
@@ -156,10 +161,19 @@ pub fn history_visual_line_count(messages: &[String], content_width: usize) -> u
         return 0;
     }
 
-    let content_width = content_width.max(1);
+    let content_width = content_width.max(1).min(u16::MAX as usize) as u16;
     expand_history_rows(messages)
         .iter()
-        .map(|row| wrap_input_lines(row, content_width).len().max(1))
+        .map(|row| {
+            if row.is_empty() {
+                1
+            } else {
+                Paragraph::new(row.as_str())
+                    .wrap(Wrap { trim: false })
+                    .line_count(content_width)
+                    .max(1)
+            }
+        })
         .sum()
 }
 
@@ -203,7 +217,7 @@ fn format_history_row_segment(
     } else {
         format!("{:>line_number_width$} | ", "")
     };
-    Line::from(vec![
+    Line::from_iter([
         Span::styled(
             line_prefix,
             Style::new().fg(Color::DarkGray).add_modifier(Modifier::DIM),
@@ -284,13 +298,15 @@ pub fn render_status_line(frame: &mut Frame<'_>, area: Rect, status: &str) {
         return;
     }
 
-    let text = Text::raw(truncate_line(status, area.width as usize))
-        .style(Style::new().fg(Color::DarkGray));
+    let text = Text::styled(
+        truncate_line(status, area.width as usize),
+        Style::new().fg(Color::DarkGray),
+    );
     frame.render_widget(Paragraph::new(text), area);
 }
 
 fn task_fork_action_line() -> Line<'static> {
-    Line::from(vec![
+    Line::from_iter([
         Span::styled(
             " Fork ",
             Style::new()
@@ -380,13 +396,14 @@ fn render_picker_overlay(
 
     let max_visible_rows = available_height.saturating_sub(2).max(1) as usize;
     let visible_rows = lines.len().min(max_visible_rows);
-    let content_width = lines
-        .iter()
-        .take(visible_rows)
-        .map(|line| display_width(&line.text))
-        .max()
-        .unwrap_or(0)
-        .max(1);
+    let content_width = Text::from_iter(
+        lines
+            .iter()
+            .take(visible_rows)
+            .map(|line| Line::from(line.text.as_str())),
+    )
+    .width()
+    .max(1);
     let width = (content_width as u16)
         .saturating_add(2)
         .min(composer_area.width.max(4));
@@ -455,19 +472,18 @@ pub fn render_overlay_modal_in_area(frame: &mut Frame<'_>, anchor: Rect, modal: 
     let [body_area, shortcuts_area] =
         Layout::vertical([Constraint::Min(3), Constraint::Length(1)]).areas(inner);
     let body_block = Block::bordered().title("Body");
-    let body_inner = body_block.inner(body_area);
-    frame.render_widget(body_block, body_area);
 
     frame.render_widget(
         Paragraph::new(Text::from_iter(body))
-            .alignment(Alignment::Left)
+            .block(body_block)
+            .left_aligned()
             .wrap(Wrap { trim: false }),
-        body_inner,
+        body_area,
     );
 
     frame.render_widget(
         Paragraph::new(shortcuts)
-            .alignment(Alignment::Center)
+            .centered()
             .style(Style::new().fg(Color::DarkGray)),
         shortcuts_area,
     );

--- a/src/ui/render/tests.rs
+++ b/src/ui/render/tests.rs
@@ -68,9 +68,38 @@ fn task_layout_renders_fork_action_chip() {
         .expect("render");
 
     let rendered = buffer_text(tui.backend().buffer());
+    assert!(rendered.contains("ready"));
     assert!(rendered.contains("Fork"));
     assert!(rendered.contains("Alt+F"));
     assert!(rendered.contains("new task-id"));
+}
+
+#[test]
+fn task_layout_renders_picker_overlay_lines() {
+    let backend = TestBackend::new(80, 12);
+    let mut tui = Terminal::new(backend).expect("test backend");
+    let state = crate::app::TaskViewProjection {
+        status_line: "ready".to_string(),
+        composer_focused: true,
+        picker_overlay: vec![
+            crate::app::PickerOverlayLine {
+                text: "/tmp/very/long/path.rs".to_string(),
+                selected: true,
+            },
+            crate::app::PickerOverlayLine {
+                text: "[file] 2 shown".to_string(),
+                selected: false,
+            },
+        ],
+        ..crate::app::TaskViewProjection::default()
+    };
+
+    tui.draw(|frame| render_task_layout(frame, &state))
+        .expect("render");
+
+    let rendered = buffer_text(tui.backend().buffer());
+    assert!(rendered.contains("/tmp/very/long/path.rs"));
+    assert!(rendered.contains("[file] 2 shown"));
 }
 
 fn buffer_text(buffer: &Buffer) -> String {


### PR DESCRIPTION
## Summary
This change migrates more task-surface render paths to the newer text and paragraph helper APIs and updates the PR-400 inventory so the documented status matches the live code.

## Motivation
The task renderer still carried several manual text-assembly and rendered-line-count paths after the earlier terminal UI migration work. Keeping those custom paths in place left the inventory stale and made the render code less consistent than the surrounding modules.

## Approach
- Replace the manual history visual-row counting path with the widget-provided rendered line count helper and move the modal body paragraph onto the bordered block directly.
- Switch nearby render paths to direct text helpers for status text, picker overlay width, wrapped history extension, and span-line assembly, then add picker overlay regression coverage.
- Refresh TASKS/PR-400-ratatui-api-surface-map.md so the active, gap, and declared-only counts reflect the current renderer state.

## Validation
- cargo test ui::render::tests --lib
- make gate-fast
- cargo build --bin vex
- ./target/debug/vex --help >/dev/null

## Risks
- Duplication or missed shared-code opportunity: low. The patch stays inside the existing renderer helpers and inventory file instead of adding a parallel render path.
- Unused code: low. The inventory update explicitly records that the status-line path no longer uses Text::raw.
- Bugs or regression risk: low to moderate. History row counting and picker width now rely on framework helpers, so layout drift would show up in render output; the focused render tests and full gate both passed.
- ADR inconsistency: none identified. The change stays inside renderer and task documentation surfaces and does not alter runtime or routing boundaries.
- Test coverage gaps: limited. The branch adds picker-overlay coverage, but there is still no full visual assertion matrix for every modal size combination.
- Follow-up work deferred: the remaining PR-400 inventory gaps outside this render slice, including reference-widget and scrollbar adoption, remain for later batches.
