### PR TITLE
fix: restore local runtime memory refresh and compaction

### DIFF
--- a/src/api/client/mod.rs
+++ b/src/api/client/mod.rs
@@ -297,7 +297,7 @@ pub struct ApiClient {
     reasoning_budget: u32,
 
     project_instructions: Option<String>,
-    notes_content: Option<String>,
+    notes_content: Arc<RwLock<Option<String>>>,
     extra_tool_definitions: Vec<Value>,
     server_info: Arc<RwLock<Option<ServerInfo>>>,
     tls_verification_disabled: bool,
@@ -342,7 +342,7 @@ impl ApiClient {
             stop_sequences: config.model_profile.stop_sequences.clone(),
             reasoning_budget: config.model_profile.reasoning_budget,
             project_instructions: None,
-            notes_content: None,
+            notes_content: Arc::new(RwLock::new(None)),
             extra_tool_definitions: Vec::new(),
             server_info: Arc::new(RwLock::new(None)),
             tls_verification_disabled: config.model_url_skip_tls_check,
@@ -374,7 +374,7 @@ impl ApiClient {
             stop_sequences: Vec::new(),
             reasoning_budget: 0,
             project_instructions: None,
-            notes_content: None,
+            notes_content: Arc::new(RwLock::new(None)),
             extra_tool_definitions: Vec::new(),
             server_info: Arc::new(RwLock::new(None)),
             tls_verification_disabled: false,
@@ -383,9 +383,18 @@ impl ApiClient {
         }
     }
 
-    pub fn with_notes_content(mut self, content: Option<String>) -> Self {
-        self.notes_content = content;
+    pub fn with_notes_content(self, content: Option<String>) -> Self {
+        self.set_notes_content(content);
         self
+    }
+
+    pub fn set_notes_content(&self, content: Option<String>) {
+        *self
+            .notes_content
+            .write()
+            .expect("api client notes lock poisoned") = content
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
     }
 
     pub fn with_extra_tool_definitions(mut self, extra_tools: Vec<Value>) -> Self {
@@ -568,12 +577,12 @@ impl ApiClient {
             prompt.push_str("\n[project instructions: end]\n---");
         }
 
-        if let Some(notes) = self
+        let notes_content = self
             .notes_content
-            .as_deref()
-            .map(str::trim)
-            .filter(|notes| !notes.is_empty())
-        {
+            .read()
+            .expect("api client notes lock poisoned")
+            .clone();
+        if let Some(notes) = notes_content.as_deref() {
             prompt.push_str("\n\n<memory>\n");
             prompt.push_str(notes);
             prompt.push_str("\n</memory>");

--- a/src/api/client/tests/protocol.rs
+++ b/src/api/client/tests/protocol.rs
@@ -111,7 +111,7 @@ fn native_protocol_overrides_configured_for_bare_base_url() {
         stop_sequences: Vec::new(),
         reasoning_budget: 0,
         project_instructions: None,
-        notes_content: None,
+        notes_content: Arc::new(RwLock::new(None)),
         extra_tool_definitions: Vec::new(),
         server_info: Arc::new(RwLock::new(Some(ServerInfo {
             n_ctx: 65536,

--- a/src/app/facade.rs
+++ b/src/app/facade.rs
@@ -79,6 +79,7 @@ pub fn build_facade_runtime<M: RuntimeMode>(
     .with_sandbox(sandbox)
     .with_mcp_registry(mcp_registry)
     .with_compaction_config(config.compaction.clone())
+    .with_memory_notes_config(config.notes_path.clone(), config.max_memory_tokens)
     .with_undo_enabled(config.undo.enabled)
     .with_max_undo_checkpoints(config.undo.max_checkpoints);
     let (update_tx, update_rx) = mpsc::unbounded_channel::<UiUpdate>();
@@ -97,6 +98,7 @@ where
     F: FrontendAdapter<M>,
 {
     let (mut runtime, mut ctx, bootstrap) = build_facade_runtime(config, mode)?;
+    ctx.populate_local_server_info().await;
     runtime.run(frontend, &mut ctx).await;
     ctx.shutdown_resources().await;
     Ok(bootstrap)

--- a/src/app/tests/session/runtime.rs
+++ b/src/app/tests/session/runtime.rs
@@ -18,15 +18,15 @@ type RouteLog = Arc<Mutex<Vec<String>>>;
 struct HeadlessFrontend {
     inputs: VecDeque<String>,
     render_count: usize,
-    quit_after_renders: usize,
+    ready_to_quit: bool,
 }
 
 impl HeadlessFrontend {
-    fn new(inputs: Vec<&str>, quit_after_renders: usize) -> Self {
+    fn new(inputs: Vec<&str>) -> Self {
         Self {
             inputs: inputs.into_iter().map(|value| value.to_string()).collect(),
             render_count: 0,
-            quit_after_renders,
+            ready_to_quit: false,
         }
     }
 }
@@ -38,10 +38,11 @@ impl FrontendAdapter<TuiMode> for HeadlessFrontend {
 
     fn render(&mut self, _mode: &TuiMode) {
         self.render_count += 1;
+        self.ready_to_quit = self.inputs.is_empty() && !_mode.is_pulse_in_progress();
     }
 
     fn should_quit(&self) -> bool {
-        self.render_count >= self.quit_after_renders
+        self.ready_to_quit
     }
 }
 
@@ -180,7 +181,7 @@ async fn run_tui_session_populates_local_server_info_before_first_pulse() {
     config.model_url = format!("http://{addr}/v1");
     config.model_protocol = crate::runtime::ModelProtocol::MessagesV1;
 
-    let mut frontend = HeadlessFrontend::new(vec!["hello"], 6);
+    let mut frontend = HeadlessFrontend::new(vec!["hello"]);
     run_tui_session(config, None, &mut frontend).await.unwrap();
     server.abort();
 

--- a/src/app/tests/session/runtime.rs
+++ b/src/app/tests/session/runtime.rs
@@ -106,7 +106,7 @@ fn build_runtime_with_resume_restores_task_and_grants() {
 }
 
 #[tokio::test]
-async fn run_tui_session_populates_local_server_info_before_first_pulse() {
+async fn run_tui_session_populates_local_server_info_before_first_pulse() -> anyhow::Result<()> {
     async fn messages_get(State(log): State<RouteLog>) -> impl IntoResponse {
         log.lock().unwrap().push("GET /v1/messages".to_string());
         StatusCode::NOT_FOUND
@@ -167,7 +167,7 @@ async fn run_tui_session_populates_local_server_info_before_first_pulse() {
         }))
     }
 
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempfile::tempdir()?;
     let route_log: RouteLog = Arc::new(Mutex::new(Vec::new()));
     let (server, addr) = spawn_axum_server(
         Router::new()
@@ -180,9 +180,10 @@ async fn run_tui_session_populates_local_server_info_before_first_pulse() {
     let mut config = make_config(temp.path());
     config.model_url = format!("http://{addr}/v1");
     config.model_protocol = crate::runtime::ModelProtocol::MessagesV1;
+    config.notes_path = Some(temp.path().join("memory.md"));
 
     let mut frontend = HeadlessFrontend::new(vec!["hello"]);
-    run_tui_session(config, None, &mut frontend).await.unwrap();
+    run_tui_session(config, None, &mut frontend).await?;
     server.abort();
 
     let events = route_log.lock().unwrap().clone();
@@ -204,6 +205,7 @@ async fn run_tui_session_populates_local_server_info_before_first_pulse() {
             .any(|event| event.starts_with("POST /v1/messages")),
         "messages-v1 endpoint should not be used after preload; events: {events:?}"
     );
+    Ok(())
 }
 
 #[test]

--- a/src/app/tests/session/runtime.rs
+++ b/src/app/tests/session/runtime.rs
@@ -1,6 +1,49 @@
 use super::*;
 use crate::config::CompactionConfig;
 use crate::config::UndoConfig;
+use crate::runtime::frontend::{FrontendAdapter, InputOccurrence};
+use crate::test_support::spawn_axum_server;
+use axum::Json;
+use axum::Router;
+use axum::extract::State;
+use axum::http::{StatusCode, header};
+use axum::response::IntoResponse;
+use axum::routing::get;
+use serde_json::{Value, json};
+use std::collections::VecDeque;
+use std::sync::Mutex;
+
+type RouteLog = Arc<Mutex<Vec<String>>>;
+
+struct HeadlessFrontend {
+    inputs: VecDeque<String>,
+    render_count: usize,
+    quit_after_renders: usize,
+}
+
+impl HeadlessFrontend {
+    fn new(inputs: Vec<&str>, quit_after_renders: usize) -> Self {
+        Self {
+            inputs: inputs.into_iter().map(|value| value.to_string()).collect(),
+            render_count: 0,
+            quit_after_renders,
+        }
+    }
+}
+
+impl FrontendAdapter<TuiMode> for HeadlessFrontend {
+    fn poll_user_input(&mut self, _mode: &TuiMode) -> Option<InputOccurrence> {
+        self.inputs.pop_front().map(InputOccurrence::Text)
+    }
+
+    fn render(&mut self, _mode: &TuiMode) {
+        self.render_count += 1;
+    }
+
+    fn should_quit(&self) -> bool {
+        self.render_count >= self.quit_after_renders
+    }
+}
 
 fn make_config(temp: &std::path::Path) -> Config {
     Config {
@@ -58,6 +101,107 @@ fn build_runtime_with_resume_restores_task_and_grants() {
             .active_grants
             .get(&Capability::Network),
         Some(&ApprovalScope::Session)
+    );
+}
+
+#[tokio::test]
+async fn run_tui_session_populates_local_server_info_before_first_pulse() {
+    async fn messages_get(State(log): State<RouteLog>) -> impl IntoResponse {
+        log.lock().unwrap().push("GET /v1/messages".to_string());
+        StatusCode::NOT_FOUND
+    }
+
+    async fn messages_post(
+        State(log): State<RouteLog>,
+        Json(payload): Json<Value>,
+    ) -> impl IntoResponse {
+        let stream = payload
+            .get("stream")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        log.lock()
+            .unwrap()
+            .push(format!("POST /v1/messages stream={stream}"));
+        (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "messages endpoint should not be used" })),
+        )
+    }
+
+    async fn chat_get(State(log): State<RouteLog>) -> impl IntoResponse {
+        log.lock()
+            .unwrap()
+            .push("GET /v1/chat/completions".to_string());
+        ([(header::CONTENT_TYPE, "text/event-stream")], "")
+    }
+
+    async fn chat_post(
+        State(log): State<RouteLog>,
+        Json(payload): Json<Value>,
+    ) -> impl IntoResponse {
+        let stream = payload
+            .get("stream")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        log.lock()
+            .unwrap()
+            .push(format!("POST /v1/chat/completions stream={stream}"));
+        Json(json!({
+            "id": "chatcmpl-runtime",
+            "object": "chat.completion",
+            "created": 1,
+            "model": "local/test-model",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": { "role": "assistant", "content": "OK" },
+                    "finish_reason": "stop"
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 12,
+                "completion_tokens": 1,
+                "total_tokens": 13
+            }
+        }))
+    }
+
+    let temp = tempfile::tempdir().unwrap();
+    let route_log: RouteLog = Arc::new(Mutex::new(Vec::new()));
+    let (server, addr) = spawn_axum_server(
+        Router::new()
+            .route("/v1/messages", get(messages_get).post(messages_post))
+            .route("/v1/chat/completions", get(chat_get).post(chat_post))
+            .with_state(route_log.clone()),
+    )
+    .await;
+
+    let mut config = make_config(temp.path());
+    config.model_url = format!("http://{addr}/v1");
+    config.model_protocol = crate::runtime::ModelProtocol::MessagesV1;
+
+    let mut frontend = HeadlessFrontend::new(vec!["hello"], 6);
+    run_tui_session(config, None, &mut frontend).await.unwrap();
+    server.abort();
+
+    let events = route_log.lock().unwrap().clone();
+    assert!(
+        events
+            .iter()
+            .any(|event| event == "GET /v1/chat/completions"),
+        "local runtime discovery must probe chat-compat endpoint; events: {events:?}"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| event.starts_with("POST /v1/chat/completions")),
+        "first pulse must route through discovered chat-compat endpoint; events: {events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| event.starts_with("POST /v1/messages")),
+        "messages-v1 endpoint should not be used after preload; events: {events:?}"
     );
 }
 

--- a/src/session_notes.rs
+++ b/src/session_notes.rs
@@ -5,9 +5,31 @@ use std::path::{Path, PathBuf};
 
 pub fn build_api_client_with_notes(config: &Config) -> Result<(ApiClient, Option<String>)> {
     let (notes_content, notes_warning) =
-        resolve_notes_for_injection(config.notes_path.as_deref(), config.max_memory_tokens);
+        resolve_notes_load(config.notes_path.as_deref(), config.max_memory_tokens).into_parts();
     let client = ApiClient::new(config)?.with_notes_content(notes_content);
     Ok((client, notes_warning))
+}
+
+pub enum NotesLoadResult {
+    Missing,
+    Loaded {
+        content: Option<String>,
+        warning: Option<String>,
+    },
+    ReadError {
+        path: PathBuf,
+        error: std::io::Error,
+    },
+}
+
+impl NotesLoadResult {
+    pub fn into_parts(self) -> (Option<String>, Option<String>) {
+        match self {
+            Self::Missing => (None, None),
+            Self::Loaded { content, warning } => (content, warning),
+            Self::ReadError { .. } => (None, None),
+        }
+    }
 }
 
 pub fn resolve_notes_path_for_read(explicit_path: Option<&Path>) -> Option<PathBuf> {
@@ -69,28 +91,44 @@ pub fn resolve_notes_for_injection(
     explicit_path: Option<&Path>,
     token_budget: usize,
 ) -> (Option<String>, Option<String>) {
+    resolve_notes_load(explicit_path, token_budget).into_parts()
+}
+
+pub fn resolve_notes_load(explicit_path: Option<&Path>, token_budget: usize) -> NotesLoadResult {
     let Some(path) = resolve_notes_path_for_read(explicit_path) else {
-        return (None, None);
+        return NotesLoadResult::Missing;
     };
-    let Ok(content) = std::fs::read_to_string(path) else {
-        return (None, None);
+    let content = match std::fs::read_to_string(&path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return NotesLoadResult::Missing;
+        }
+        Err(error) => {
+            return NotesLoadResult::ReadError { path, error };
+        }
     };
     let trimmed = content.trim();
     if trimmed.is_empty() {
-        return (None, None);
+        return NotesLoadResult::Loaded {
+            content: None,
+            warning: None,
+        };
     }
 
     let estimated_tokens = trimmed.len().saturating_add(3) / 4;
     if estimated_tokens > token_budget {
-        return (
-            None,
-            Some(format!(
+        return NotesLoadResult::Loaded {
+            content: None,
+            warning: Some(format!(
                 "[memory] notes exceed token budget ({estimated_tokens} > {token_budget}), skipped"
             )),
-        );
+        };
     }
 
-    (Some(trimmed.to_string()), None)
+    NotesLoadResult::Loaded {
+        content: Some(trimmed.to_string()),
+        warning: None,
+    }
 }
 
 #[cfg(test)]

--- a/src/state/conversation/send_message.rs
+++ b/src/state/conversation/send_message.rs
@@ -29,6 +29,7 @@ impl ConversationManager {
         let original_user_input = content.clone();
         self.ensure_task_doc();
         self.begin_turn_doc(content.clone(), turn_tool_policy);
+        self.refresh_notes_content();
         let cache_hint = self.shared_prefix_cache_hint(shared_prefix_context.as_deref());
         self.push_user_message(content, cache_hint);
         if let Some(response) = builtin_supported_git_tools_response(&original_user_input) {

--- a/src/state/conversation/state.rs
+++ b/src/state/conversation/state.rs
@@ -102,6 +102,8 @@ pub struct ConversationManager {
     pub(super) max_undo_checkpoints: usize,
     pub(super) undo_enabled: bool,
     pub(super) compaction_config: CompactionConfig,
+    pub(super) notes_path: Option<PathBuf>,
+    pub(super) max_memory_tokens: usize,
     #[cfg(test)]
     pub(super) mock_tool_operator_responses: Option<Arc<Mutex<HashMap<String, String>>>>,
 }
@@ -145,6 +147,8 @@ impl ConversationManager {
             max_undo_checkpoints: 20,
             undo_enabled: true,
             compaction_config: CompactionConfig::default(),
+            notes_path: None,
+            max_memory_tokens: 0,
             #[cfg(test)]
             mock_tool_operator_responses: None,
         }
@@ -202,6 +206,16 @@ impl ConversationManager {
         self
     }
 
+    pub fn with_memory_notes_config(
+        mut self,
+        notes_path: Option<PathBuf>,
+        max_memory_tokens: usize,
+    ) -> Self {
+        self.notes_path = notes_path;
+        self.max_memory_tokens = max_memory_tokens;
+        self
+    }
+
     pub async fn shutdown_resources(&mut self) {
         if let Some(mcp_registry) = self.mcp_registry.take() {
             mcp_registry.shutdown().await;
@@ -230,8 +244,21 @@ impl ConversationManager {
             max_undo_checkpoints: 20,
             undo_enabled: true,
             compaction_config: CompactionConfig::default(),
+            notes_path: None,
+            max_memory_tokens: 0,
             mock_tool_operator_responses: Some(Arc::new(Mutex::new(tool_operator_responses))),
         }
+    }
+
+    pub(super) fn refresh_notes_content(&self) {
+        if self.max_memory_tokens == 0 {
+            return;
+        }
+        let (notes_content, _) = crate::session_notes::resolve_notes_for_injection(
+            self.notes_path.as_deref(),
+            self.max_memory_tokens,
+        );
+        self.client.set_notes_content(notes_content);
     }
 
     pub fn push_user_message(&mut self, input: String, cache_hint: Option<String>) {

--- a/src/state/conversation/state.rs
+++ b/src/state/conversation/state.rs
@@ -211,6 +211,14 @@ impl ConversationManager {
         notes_path: Option<PathBuf>,
         max_memory_tokens: usize,
     ) -> Self {
+        if max_memory_tokens == 0
+            && let Some(path) = notes_path.as_deref()
+        {
+            tracing::warn!(
+                path = %path.display(),
+                "memory notes path configured with zero token budget; note injection is disabled"
+            );
+        }
         self.notes_path = notes_path;
         self.max_memory_tokens = max_memory_tokens;
         self
@@ -223,6 +231,8 @@ impl ConversationManager {
     }
 
     #[cfg(test)]
+    /// Test helper. Call `with_memory_notes_config(...)` on the returned
+    /// manager when the test needs to exercise memory-note injection refresh.
     pub fn new_mock(client: ApiClient, tool_operator_responses: HashMap<String, String>) -> Self {
         Self {
             client: Arc::new(client),
@@ -251,13 +261,13 @@ impl ConversationManager {
     }
 
     pub(super) fn refresh_notes_content(&self) {
-        if self.max_memory_tokens == 0 {
-            return;
-        }
-        let (notes_content, _) = crate::session_notes::resolve_notes_for_injection(
+        let (notes_content, notes_warning) = crate::session_notes::resolve_notes_for_injection(
             self.notes_path.as_deref(),
             self.max_memory_tokens,
         );
+        if let Some(warning) = notes_warning {
+            tracing::debug!(warning = %warning, "memory notes refresh skipped");
+        }
         self.client.set_notes_content(notes_content);
     }
 

--- a/src/state/conversation/state.rs
+++ b/src/state/conversation/state.rs
@@ -15,6 +15,7 @@ use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::SystemTime;
 #[cfg(test)]
 use std::sync::Mutex;
 use tokio::sync::oneshot;
@@ -104,8 +105,17 @@ pub struct ConversationManager {
     pub(super) compaction_config: CompactionConfig,
     pub(super) notes_path: Option<PathBuf>,
     pub(super) max_memory_tokens: usize,
+    notes_source_path: Option<PathBuf>,
+    notes_source_fingerprint: Option<NotesFileFingerprint>,
+    notes_source_budget: usize,
     #[cfg(test)]
     pub(super) mock_tool_operator_responses: Option<Arc<Mutex<HashMap<String, String>>>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct NotesFileFingerprint {
+    len: u64,
+    modified: SystemTime,
 }
 
 impl ConversationManager {
@@ -149,6 +159,9 @@ impl ConversationManager {
             compaction_config: CompactionConfig::default(),
             notes_path: None,
             max_memory_tokens: 0,
+            notes_source_path: None,
+            notes_source_fingerprint: None,
+            notes_source_budget: 0,
             #[cfg(test)]
             mock_tool_operator_responses: None,
         }
@@ -256,19 +269,108 @@ impl ConversationManager {
             compaction_config: CompactionConfig::default(),
             notes_path: None,
             max_memory_tokens: 0,
+            notes_source_path: None,
+            notes_source_fingerprint: None,
+            notes_source_budget: 0,
             mock_tool_operator_responses: Some(Arc::new(Mutex::new(tool_operator_responses))),
         }
     }
 
-    pub(super) fn refresh_notes_content(&self) {
-        let (notes_content, notes_warning) = crate::session_notes::resolve_notes_for_injection(
-            self.notes_path.as_deref(),
-            self.max_memory_tokens,
-        );
-        if let Some(warning) = notes_warning {
-            tracing::debug!(warning = %warning, "memory notes refresh skipped");
+    pub(super) fn refresh_notes_content(&mut self) {
+        if self.max_memory_tokens == 0 {
+            self.notes_source_budget = 0;
+            self.client.set_notes_content(None);
+            return;
         }
-        self.client.set_notes_content(notes_content);
+
+        let Some(path) = crate::session_notes::resolve_notes_path_for_read(self.notes_path.as_deref())
+        else {
+            self.notes_source_path = None;
+            self.notes_source_fingerprint = None;
+            self.notes_source_budget = self.max_memory_tokens;
+            self.client.set_notes_content(None);
+            return;
+        };
+
+        let fingerprint = match notes_file_fingerprint(&path) {
+            Ok(fingerprint) => fingerprint,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                self.notes_source_path = None;
+                self.notes_source_fingerprint = None;
+                self.notes_source_budget = self.max_memory_tokens;
+                self.client.set_notes_content(None);
+                return;
+            }
+            Err(error) => {
+                if !is_transient_notes_read_error(&error) {
+                    tracing::debug!(
+                        path = %path.display(),
+                        error = %error,
+                        "memory notes fingerprint cleared cached notes"
+                    );
+                    self.notes_source_path = Some(path);
+                    self.notes_source_fingerprint = None;
+                    self.notes_source_budget = self.max_memory_tokens;
+                    self.client.set_notes_content(None);
+                    return;
+                }
+                tracing::debug!(
+                    path = %path.display(),
+                    error = %error,
+                    "memory notes refresh skipped"
+                );
+                return;
+            }
+        };
+
+        let notes_changed = self.notes_source_path.as_deref() != Some(path.as_path())
+            || self.notes_source_fingerprint != Some(fingerprint)
+            || self.notes_source_budget != self.max_memory_tokens;
+        if !notes_changed {
+            return;
+        }
+
+        match crate::session_notes::resolve_notes_load(Some(path.as_path()), self.max_memory_tokens)
+        {
+            crate::session_notes::NotesLoadResult::Missing => {
+                self.notes_source_path = None;
+                self.notes_source_fingerprint = None;
+                self.notes_source_budget = self.max_memory_tokens;
+                self.client.set_notes_content(None);
+            }
+            crate::session_notes::NotesLoadResult::Loaded {
+                content,
+                warning,
+            } => {
+                if let Some(warning) = warning {
+                    tracing::debug!(warning = %warning, "memory notes refresh skipped");
+                }
+                self.notes_source_path = Some(path);
+                self.notes_source_fingerprint = Some(fingerprint);
+                self.notes_source_budget = self.max_memory_tokens;
+                self.client.set_notes_content(content);
+            }
+            crate::session_notes::NotesLoadResult::ReadError { path, error } => {
+                if is_transient_notes_read_error(&error) {
+                    tracing::debug!(
+                        path = %path.display(),
+                        error = %error,
+                        "memory notes refresh skipped"
+                    );
+                    return;
+                }
+
+                tracing::debug!(
+                    path = %path.display(),
+                    error = %error,
+                    "memory notes refresh cleared cached notes"
+                );
+                self.notes_source_path = Some(path);
+                self.notes_source_fingerprint = None;
+                self.notes_source_budget = self.max_memory_tokens;
+                self.client.set_notes_content(None);
+            }
+        }
     }
 
     pub fn push_user_message(&mut self, input: String, cache_hint: Option<String>) {
@@ -476,6 +578,23 @@ impl ConversationManager {
             previous_content: previous,
         })
     }
+}
+
+fn notes_file_fingerprint(path: &std::path::Path) -> std::io::Result<NotesFileFingerprint> {
+    let metadata = std::fs::metadata(path)?;
+    Ok(NotesFileFingerprint {
+        len: metadata.len(),
+        modified: metadata.modified()?,
+    })
+}
+
+fn is_transient_notes_read_error(error: &std::io::Error) -> bool {
+    matches!(
+        error.kind(),
+        std::io::ErrorKind::Interrupted
+            | std::io::ErrorKind::WouldBlock
+            | std::io::ErrorKind::TimedOut
+    )
 }
 
 fn is_turn_mutation_tool(name: &str) -> bool {

--- a/src/state/conversation/tests/history.rs
+++ b/src/state/conversation/tests/history.rs
@@ -894,7 +894,7 @@ async fn send_message_applies_shared_prefix_cache_hint_to_user_turn() {
 
 #[tokio::test]
 async fn send_message_refreshes_memory_notes_before_each_pulse() -> Result<()> {
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempfile::tempdir()?;
     let notes_path = temp.path().join("memory.md");
     std::fs::write(&notes_path, "first retained note\n")?;
     let client = ApiClient::new_mock(Arc::new(crate::api::mock_client::MockApiClient::new(vec![
@@ -931,7 +931,7 @@ async fn send_message_refreshes_memory_notes_before_each_pulse() -> Result<()> {
 
 #[tokio::test]
 async fn send_message_clears_memory_notes_when_budget_drops_to_zero() -> Result<()> {
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempfile::tempdir()?;
     let notes_path = temp.path().join("memory.md");
     std::fs::write(&notes_path, "retained note\n")?;
     let client = ApiClient::new_mock(Arc::new(crate::api::mock_client::MockApiClient::new(vec![

--- a/src/state/conversation/tests/history.rs
+++ b/src/state/conversation/tests/history.rs
@@ -892,6 +892,43 @@ async fn send_message_applies_shared_prefix_cache_hint_to_user_turn() {
     );
 }
 
+#[tokio::test]
+async fn send_message_refreshes_memory_notes_before_each_pulse() -> Result<()> {
+    let temp = tempfile::tempdir().unwrap();
+    let notes_path = temp.path().join("memory.md");
+    std::fs::write(&notes_path, "first retained note\n")?;
+    let client = ApiClient::new_mock(Arc::new(crate::api::mock_client::MockApiClient::new(vec![
+        vec![
+            r#"data: {"choices":[{"delta":{"content":"first"},"finish_reason":"stop"}]}"#
+                .to_string(),
+        ],
+        vec![
+            r#"data: {"choices":[{"delta":{"content":"second"},"finish_reason":"stop"}]}"#
+                .to_string(),
+        ],
+    ])));
+    let mut manager = ConversationManager::new_mock(client, HashMap::new())
+        .with_memory_notes_config(Some(notes_path.clone()), 2048);
+
+    manager.send_message("first turn".to_string(), None).await?;
+    assert!(
+        manager
+            .client()
+            .test_system_prompt()
+            .contains("first retained note")
+    );
+
+    std::fs::write(&notes_path, "second retained note\n")?;
+    manager
+        .send_message("second turn".to_string(), None)
+        .await?;
+    let prompt = manager.client().test_system_prompt();
+
+    assert!(prompt.contains("second retained note"));
+    assert!(!prompt.contains("first retained note"));
+    Ok(())
+}
+
 #[test]
 fn truncate_for_history_preserves_head_and_suffix_context() {
     let long = "head-aaaa-bbbb-cccc-dddd-eeee-ffff-gggg-suffix";

--- a/src/state/conversation/tests/history.rs
+++ b/src/state/conversation/tests/history.rs
@@ -929,6 +929,43 @@ async fn send_message_refreshes_memory_notes_before_each_pulse() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn send_message_clears_memory_notes_when_budget_drops_to_zero() -> Result<()> {
+    let temp = tempfile::tempdir().unwrap();
+    let notes_path = temp.path().join("memory.md");
+    std::fs::write(&notes_path, "retained note\n")?;
+    let client = ApiClient::new_mock(Arc::new(crate::api::mock_client::MockApiClient::new(vec![
+        vec![
+            r#"data: {"choices":[{"delta":{"content":"first"},"finish_reason":"stop"}]}"#
+                .to_string(),
+        ],
+        vec![
+            r#"data: {"choices":[{"delta":{"content":"second"},"finish_reason":"stop"}]}"#
+                .to_string(),
+        ],
+    ])));
+    let mut manager = ConversationManager::new_mock(client, HashMap::new())
+        .with_memory_notes_config(Some(notes_path.clone()), 2048);
+
+    manager.send_message("first turn".to_string(), None).await?;
+    assert!(
+        manager
+            .client()
+            .test_system_prompt()
+            .contains("retained note")
+    );
+
+    manager.max_memory_tokens = 0;
+    manager
+        .send_message("second turn".to_string(), None)
+        .await?;
+    let prompt = manager.client().test_system_prompt();
+
+    assert!(!prompt.contains("retained note"));
+    assert!(!prompt.contains("<memory>"));
+    Ok(())
+}
+
 #[test]
 fn truncate_for_history_preserves_head_and_suffix_context() {
     let long = "head-aaaa-bbbb-cccc-dddd-eeee-ffff-gggg-suffix";

--- a/src/state/conversation/tests/history.rs
+++ b/src/state/conversation/tests/history.rs
@@ -966,6 +966,45 @@ async fn send_message_clears_memory_notes_when_budget_drops_to_zero() -> Result<
     Ok(())
 }
 
+#[tokio::test]
+async fn send_message_clears_cached_memory_notes_on_non_transient_refresh_error() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let notes_path = temp.path().join("memory.md");
+    std::fs::write(&notes_path, "retained note\n")?;
+    let client = ApiClient::new_mock(Arc::new(crate::api::mock_client::MockApiClient::new(vec![
+        vec![
+            r#"data: {"choices":[{"delta":{"content":"first"},"finish_reason":"stop"}]}"#
+                .to_string(),
+        ],
+        vec![
+            r#"data: {"choices":[{"delta":{"content":"second"},"finish_reason":"stop"}]}"#
+                .to_string(),
+        ],
+    ])));
+    let mut manager = ConversationManager::new_mock(client, HashMap::new())
+        .with_memory_notes_config(Some(notes_path.clone()), 2048);
+
+    manager.send_message("first turn".to_string(), None).await?;
+    assert!(
+        manager
+            .client()
+            .test_system_prompt()
+            .contains("retained note")
+    );
+
+    std::fs::remove_file(&notes_path)?;
+    std::fs::create_dir(&notes_path)?;
+
+    manager
+        .send_message("second turn".to_string(), None)
+        .await?;
+    let prompt = manager.client().test_system_prompt();
+
+    assert!(!prompt.contains("retained note"));
+    assert!(!prompt.contains("<memory>"));
+    Ok(())
+}
+
 #[test]
 fn truncate_for_history_preserves_head_and_suffix_context() {
     let long = "head-aaaa-bbbb-cccc-dddd-eeee-ffff-gggg-suffix";


### PR DESCRIPTION
## Summary
- restore local-runtime server-info preload in the facade entrypoints so the first pulse sees the server context window and native protocol
- share memory notes across cloned ApiClient handles and refresh notes before each pulse so notes stay injected in the system prompt instead of bloating conversation history
- add regression tests for per-pulse note refresh and the TUI first-pulse preload path

## Motivation
Recent local-runtime wiring changes regressed two coupled behaviors: memory notes stopped refreshing across pulses, and first-pulse local sessions no longer preloaded server metadata, so the runtime fell back to the default context window and compaction behavior. That pushed note content back toward conversation-history growth instead of keeping it in the injected memory block.

## Approach
- thread notes_path and max_memory_tokens into ConversationManager and refresh the resolved notes content before each send
- store ApiClient notes content behind shared interior mutability so cloned clients observe note updates
- preload local server info in execute_facade_runtime and run_tui_session before the first pulse
- add regression coverage for memory refresh between pulses and for TUI local-runtime protocol discovery on the first request

## Validation
- cargo fmt --check
- cargo test --all-targets
- cargo clippy --all-targets -- -D warnings
- cargo nextest run -j 2
- bash scripts/check_forbidden_names.sh
- git diff --check

## Risks
- Low: changes are scoped to local-runtime request setup and memory-note injection; remote endpoint behavior is unchanged except for shared ApiClient note storage semantics.
